### PR TITLE
Add templates, codeowners, readme

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @elastic/platform-docs

--- a/.github/ISSUE_TEMPLATE/community-request.yaml
+++ b/.github/ISSUE_TEMPLATE/community-request.yaml
@@ -1,0 +1,32 @@
+name: "Community documentation request"
+description: Request a documentation change or enhancement.
+title: "[Request]: "
+labels: ["Request", "community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi 👋. Thanks for taking the time to fill out this request!
+        This form will create an issue that Elastic's docs team will triage and prioritize.
+        You can also open a PR instead.
+  - type: textarea
+    id: link
+    attributes:
+      label: What documentation page is affected
+      description: Include a link to the page where you're seeing the problem. Screenshots are also helpful.
+    validations:
+      required: true
+  - type: textarea
+    id: related
+    attributes:
+      label: What change would you like to see?
+      description: What's wrong? Why should the docs be changed? What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    id: moreinfo
+    attributes:
+      label: Additional info
+      description: Anything else we should know?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/internal-request.yaml
+++ b/.github/ISSUE_TEMPLATE/internal-request.yaml
@@ -39,9 +39,11 @@ body:
       label: Which documentation set does this change impact?
       description: Stateful, Serverless, or both?
       options:
-        - Stateful and Serverless
-        - Stateful only
-        - Serverless only
+        - Elastic On-Prem and Cloud (all)
+        - Elastic On-Prem only
+        - Elastic Cloud (Hosted and Serverless) only
+        - Elastic Cloud Hosted only
+        - Elastic Cloud Serverless only
         - Unknown
       default: 0
     validations:
@@ -50,8 +52,8 @@ body:
     id: doc-set-differences
     attributes:
       label: Feature differences
-      description: If you selected both Stateful and Serverless above, please describe how, if at all, the feature differs in each deployment method.
-      placeholder: The feature is identical in Stateful and Serverless.
+      description: If you selected multiple deployment methods above, please describe how, if at all, the feature differs in each deployment method.
+      placeholder: The feature is identical in all deployment methods.
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/internal-request.yaml
+++ b/.github/ISSUE_TEMPLATE/internal-request.yaml
@@ -1,0 +1,98 @@
+name: "Documentation request"
+description: Request a documentation change or enhancement for any supported release.
+title: "[REQUEST]: "
+labels: ["request", "Team:Docs"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this request! This form will create an issue that the Platform Docs team will triage and prioritize.
+
+        ### For best results, complete all fields.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe what needs to be documented. What details do users need to know about?
+      placeholder: |
+        What: We're introducing new feature A.
+        When: This feature will launch at the completion of project B.
+        Why: This feature will make X, Y, and Z easier for the user.
+    validations:
+      required: true
+  - type: textarea
+    id: related
+    attributes:
+      label: Resources
+      description: Where can the documentation team learn more about this feature?
+      placeholder: |
+        This feature was implemented in {link_to_PR}.
+
+        This feature was scoped and researched in {link_to_issue}.
+
+        Context for the feature is described in {link_to_internal_doc}.
+    validations:
+      required: true
+  - type: dropdown
+    id: doc-set
+    attributes:
+      label: Which documentation set does this change impact?
+      description: Stateful, Serverless, or both?
+      options:
+        - Stateful and Serverless
+        - Stateful only
+        - Serverless only
+        - Unknown
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: doc-set-differences
+    attributes:
+      label: Feature differences
+      description: If you selected both Stateful and Serverless above, please describe how, if at all, the feature differs in each deployment method.
+      placeholder: The feature is identical in Stateful and Serverless.
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: What release is this request related to?
+      description: Some requests may be tied to the Elastic Stack release schedule. Some, like Serverless requests, may not. Please select an option.
+      options:
+        - 'N/A'
+        - '8.11'
+        - '8.12'
+        - '8.13'
+        - '8.14'
+        - '8.15'
+        - '8.16'
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: collaboration
+    attributes:
+      label: Collaboration model
+      description: Which team do you expect to create the initial content?
+      options:
+        - "The documentation team"
+        - "The product team"
+        - "The engineering team"
+        - "Unknown"
+        - "Other (please describe below)"
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: contact
+    attributes:
+      label: Point of contact.
+      description: Please assign at least one point of contact using the GitHub `@` mention. Add as many stakeholders as you'd like.
+      value: "**Main contact:** @\n\n**Stakeholders:**\n"
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filling out this form. Note that this form does not guarantee that your issue will be prioritized for the selected iteration. _But_, completing this issue as early and as comprehensively as possible will help us understand and plan the work better!

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This repo contains most of our Elastic Serverless documentation, including:
 
 > Not the docs you're looking for? Try the following:
 > 
-> - For Elastic Observability, visit https://github.com/elastic/observability-docs.
-> - For Elastic Security, visit https://github.com/elastic/security-docs.
+> - For Elastic Observability, visit [elastic/observability-docs](https://github.com/elastic/observability-docs).
+> - For Elastic Security, visit [elastic/security-docs](https://github.com/elastic/security-docs).
 > - For all other documentation, click the **✏️ edit** button on any page to jump to its source in GitHub.
 
 ## Reviews

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # docs-content
+
+This repo contains most of our Elastic Serverless documentation, including: 
+
+- [Overview content](https://docs.elastic.co/serverless)
+- [Elasticsearch](https://docs.elastic.co/serverless/elasticsearch/what-is-elasticsearch-serverless)
+- [Dev tools](https://docs.elastic.co/serverless/devtools/developer-tools)
+- [Project and management settings](https://docs.elastic.co/serverless/project-and-management-settings)
+
+> Not the docs you're looking for? Try the following:
+> 
+> - For Elastic Observability, visit https://github.com/elastic/observability-docs.
+> - For Elastic Security, visit https://github.com/elastic/security-docs.
+> - For all other documentation, click the **✏️ edit** button on any page to jump to its source in GitHub.
+
+## Reviews
+
+All documentation pull requests automatically add the [@platform-docs](https://github.com/orgs/elastic/teams/platform-docs) team as a reviewer.
+
+## Contribute
+
+If you find any bugs in our documentation, or want to request an enhancement, then you can open an issue using our template. We also welcome contributions in the form of PRs. Before you submit a PR, make sure that you have signed our [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
+
+This documentation uses a custom syntax written in [MDX](https://mdxjs.com/). In many cases, you only need to know plain markdown to contribute. We'll add a public component reference and additional contribution guidelines in future. Elasticians can refer to our [internal syntax reference](https://docs.elastic.dev/docsmobile/syntax).
+
+## Preview the docs
+
+When you open a PR, a preview is automatically generated. A link to the preview is added as a comment.


### PR DESCRIPTION
This PR adds a basic readme, codeowners, and issue templates to make the repo more welcoming to external contributors.

## notes
- **README**: this is intended to be a lightweight readme, and should be extended with additional contribution guidelines and a public mdx component reference when we have one available.

- **issue templates** are based on the public templates currently in use in the observability and security repos.

- the **codeowners** file will be extended when we add actions that need to be managed by eng.

open question: I have a link to docs.elastic.dev available for internal contributors. I think this is ok because we are labeling it as internal, and it will be hard for contributors to find otherwise. open to other opinions.