### PR TITLE
Update docs-elastic-publish.yml

### DIFF
--- a/.github/workflows/docs-elastic-publish.yml
+++ b/.github/workflows/docs-elastic-publish.yml
@@ -1,25 +1,29 @@
-# name: Docs
+name: Elastic docs
 
-# on:
-#   pull_request_target:
-#     paths:
-#       - '**.mdx'
-#       - '**.docnav.json'
-#       - '**.docapi.json'
-#       - '**.devdocs.json'
-#       - '**.jpg'
-#       - '**.jpeg'
-#       - '**.png'
-#       - '**.svg'
-#       - '**.gif'
-#     types: [opened, closed, synchronize]
+on:
+  pull_request_target:
+    # The paths property can be omitted entirely if the repo is mainly used for docs. Leaving it in can result in builds that 
+    # have branch protection checks in place lose the ability to merge because the workflow is not starting. If this property 
+    # is included, please ensure that branch protection checks are disabled for the repo. 
+    paths:
+      # Preface with your docs dir if you need further specificity (optional)
+      - '**.mdx'
+      - '**.docnav.json'
+      - '**.docapi.json'
+      - '**.devdocs.json'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.svg'
+      - '**.png'
+      - '**.gif'
+    types: [closed, opened, synchronize, labeled]
 
-# jobs:
-#   publish:
-#     name: Vercel Build Check
-#     uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
-#     secrets:
-#       VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
-#       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-#       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-#       VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}
+jobs:
+  publish:
+    if: contains(github.event.pull_request.labels.*.name, 'ci:doc-build')
+    uses: elastic/workflows/.github/workflows/docs-elastic-co-publish.yml@main
+    secrets:
+      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN_PUBLIC }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PUBLIC }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PUBLIC }}
+      VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}


### PR DESCRIPTION
Done as part of our serverless move (https://github.com/elastic/docs-projects/issues/178)

- Copies the public docs builder for a public repo (https://github.com/elastic/workflows/tree/main?tab=readme-ov-file#public-repos)
- Leaves all paths to consume from root