### PR TITLE
Add ES3 Playground stub page

### DIFF
--- a/serverless/nav/serverless-elasticsearch.docnav.json
+++ b/serverless/nav/serverless-elasticsearch.docnav.json
@@ -121,6 +121,9 @@
       ]
     },
     {
+      "pageId": "serverlessPlayground"
+    },
+    {
       "pageId": "serverlessDifferences",
       "label": "Serverless differences"
     },  

--- a/serverless/pages/search-playground.mdx
+++ b/serverless/pages/search-playground.mdx
@@ -1,0 +1,19 @@
+---
+id: serverlessPlayground
+slug: /serverless/elasticsearch/playground
+title: Playground
+description: Test and edit Elasticsearch queries and chat with your data using LLMs.
+tags: ['serverless', 'elasticsearch', 'search', 'playground', 'GenAI', 'LLMs']
+---
+
+<DocBadge template="technical preview" />
+
+Use the Search Playground to test and edit ((es)) queries visually in the UI. Then use the Chat Playground to combine your ((es)) data with large language models (LLMs) for retrieval augmented generation (RAG).
+You can also view the underlying Python code that powers the chat interface, and use it in your own application.
+
+Find Playground in the ((es)) serverless UI under **((es)) > Build > Playground**.
+
+<DocCallOut>
+    ℹ️ The Playground documentation currently lives in the [((kib)) docs](https://www.elastic.co/guide/en/kibana/master/playground.html).
+</DocCallOut>
+


### PR DESCRIPTION
Creates a presence for Playground in serverless docs, and points users to Kibana docs where content currently lives.

## [URL preview](https://docs-elastic-6l9bl8r3c-elastic-dev.vercel.app/serverless/elasticsearch/playground)