### PR TITLE
Add Obs AI connector to connectors list in serverless

### DIFF
--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -57,6 +57,12 @@ The list of available connectors varies by project type.
         "target": "_blank"
       },
       {
+        "title": "Observability AI Assistant",
+        "description": "Add AI-driven insights and custom actions to your workflow.",
+        "href": "https://www.elastic.co/guide/en/kibana/master/obs-ai-assistant-action-type.html",
+        "target": "_blank"
+      },
+      {
         "title": "OpenAI",
         "description": "Send a request to OpenAI.",
         "href": "https://www.elastic.co/guide/en/kibana/8.11/openai-action-type.html",


### PR DESCRIPTION
Adds link to connector docs added in https://github.com/elastic/kibana/pull/183792.