### PR TITLE
[Serverless] Add link to Cases connector

### DIFF
--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -17,7 +17,13 @@ The list of available connectors varies by project type.
       {
         "title": "Amazon Bedrock",
         "description": "Send a request to Amazon Bedrock.",
-        "href": "hhttps://www.elastic.co/guide/en/kibana/8.11/bedrock-action-type.html",
+        "href": "hhttps://www.elastic.co/guide/en/kibana/current/bedrock-action-type.html",
+        "target": "_blank"
+      },
+      {
+        "title": "Cases",
+        "description": "Add alerts to cases.",
+        "href": "https://www.elastic.co/guide/en/kibana/8.14/cases-action-type.html",
         "target": "_blank"
       },
       {
@@ -59,13 +65,13 @@ The list of available connectors varies by project type.
       {
         "title": "Observability AI Assistant",
         "description": "Add AI-driven insights and custom actions to your workflow.",
-        "href": "https://www.elastic.co/guide/en/kibana/master/obs-ai-assistant-action-type.html",
+        "href": "https://www.elastic.co/guide/en/kibana/8.14/obs-ai-assistant-action-type.html",
         "target": "_blank"
       },
       {
         "title": "OpenAI",
         "description": "Send a request to OpenAI.",
-        "href": "https://www.elastic.co/guide/en/kibana/8.11/openai-action-type.html",
+        "href": "https://www.elastic.co/guide/en/kibana/current/openai-action-type.html",
         "target": "_blank"
       },
       {

--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -23,7 +23,7 @@ The list of available connectors varies by project type.
       {
         "title": "Cases",
         "description": "Add alerts to cases.",
-        "href": "https://www.elastic.co/guide/en/kibana/8.14/cases-action-type.html",
+        "href": "https://www.elastic.co/guide/en/kibana/current/cases-action-type.html",
         "target": "_blank"
       },
       {
@@ -65,7 +65,7 @@ The list of available connectors varies by project type.
       {
         "title": "Observability AI Assistant",
         "description": "Add AI-driven insights and custom actions to your workflow.",
-        "href": "https://www.elastic.co/guide/en/kibana/8.14/obs-ai-assistant-action-type.html",
+        "href": "https://www.elastic.co/guide/en/kibana/current/obs-ai-assistant-action-type.html",
         "target": "_blank"
       },
       {

--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -17,7 +17,7 @@ The list of available connectors varies by project type.
       {
         "title": "Amazon Bedrock",
         "description": "Send a request to Amazon Bedrock.",
-        "href": "hhttps://www.elastic.co/guide/en/kibana/current/bedrock-action-type.html",
+        "href": "https://www.elastic.co/guide/en/kibana/current/bedrock-action-type.html",
         "target": "_blank"
       },
       {


### PR DESCRIPTION
This PR updates the list of connectors in https://docs.elastic.co/serverless/action-connectors

It adds a link to the new Cases connector, and updates the versions in some of the existing connector links.

Relates to https://github.com/elastic/docs-content/pull/16

### Preview

https://docs-elastic-h3895kt64-elastic-dev.vercel.app/serverless/action-connectors