### PR TITLE
CP-7016 update serverless api spec links to point to bump.sh

### DIFF
--- a/serverless/pages/manage-your-project-rest-api.mdx
+++ b/serverless/pages/manage-your-project-rest-api.mdx
@@ -44,7 +44,7 @@ curl -H "Authorization: ApiKey essu_..." https://api.elastic-cloud.com/api/v1/se
 
 The Project Management API is documented using the [OpenAPI Specification](https://en.wikipedia.org/wiki/OpenAPI_Specification). The current supported version of the specification is `3.0`.
 
-For details, check the [API reference](https://docs.elastic.co/api-reference) or download the [OpenAPI Specification](https://docs.elastic.co/api-reference/openapi/serverless-project-api.yml).
+For details, check the [API reference](https://www.elastic.co/docs/api/doc/elastic-cloud-serverless) or download the [OpenAPI Specification](https://www.elastic.co/docs/api/doc/elastic-cloud-serverless.yaml).
 
 This specification can be used to generate client SDKs, or on tools that support it, such as the [Swagger Editor](https://editor.swagger.io).
 

--- a/serverless/pages/manage-your-project-rest-api.mdx
+++ b/serverless/pages/manage-your-project-rest-api.mdx
@@ -8,7 +8,7 @@ tags: [ 'serverless', 'project', 'manage', 'rest', 'api']
 
 <DocBadge template="technical preview" />
 
-You can manage serverless projects using [Elastic Cloud Serverless REST API](https://www.elastic.co/docs/api/doc/elastic-cloud-serverless). This API allows you to create, update, and delete projects, as well as manage project features and usage.
+You can manage serverless projects using the [Elastic Cloud Serverless REST API](https://www.elastic.co/docs/api/doc/elastic-cloud-serverless). This API allows you to create, update, and delete projects, as well as manage project features and usage.
 
 <DocCallOut color="success" title="Tip">
     More APIs let you interact with data, capabilities, and settings inside of specific projects. Refer to the [Serverless API reference page](https://docs.elastic.co/api-reference).

--- a/serverless/pages/manage-your-project-rest-api.mdx
+++ b/serverless/pages/manage-your-project-rest-api.mdx
@@ -8,7 +8,7 @@ tags: [ 'serverless', 'project', 'manage', 'rest', 'api']
 
 <DocBadge template="technical preview" />
 
-You can manage serverless projects using Elastic Cloud's [Project Management](https://docs.elastic.co/api-reference/project-management) REST API. This API allows you to create, update, and delete projects, as well as manage project features and usage.
+You can manage serverless projects using [Elastic Cloud Serverless REST API](https://www.elastic.co/docs/api/doc/elastic-cloud-serverless). This API allows you to create, update, and delete projects, as well as manage project features and usage.
 
 <DocCallOut color="success" title="Tip">
     More APIs let you interact with data, capabilities, and settings inside of specific projects. Refer to the [Serverless API reference page](https://docs.elastic.co/api-reference).


### PR DESCRIPTION
This will update our documentation to point to the api spec hosted on bump.sh