### PR TITLE
Fix capitalization in management page titles

### DIFF
--- a/serverless/pages/data-views.mdx
+++ b/serverless/pages/data-views.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/data-views
-title: ((data-views-app))
+title: ((data-sources-cap))
 description: Elastic requires a ((data-source)) to access the ((es)) data that you want to explore.
 tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---

--- a/serverless/pages/index-management.mdx
+++ b/serverless/pages/index-management.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/index-management
-title: ((index-manage-app))
+title: Index management
 description: Perform CRUD operations on indices and data streams. View index settings, mappings, and statistics.
 tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---

--- a/serverless/pages/ingest-pipelines.mdx
+++ b/serverless/pages/ingest-pipelines.mdx
@@ -1,14 +1,14 @@
 ---
 slug: /serverless/ingest-pipelines
-title: ((ingest-pipelines-app))
-description: Create and manage ingest pipelines to perform common transformations and enrichments on your data.
+title: ((ingest-pipelines-cap))
+description: Create and manage ((ingest-pipelines)) to perform common transformations and enrichments on your data.
 tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
 This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
 
-[Ingest pipelines](((ref))/ingest.html) let you perform common transformations on your data before indexing.
+[((ingest-pipelines-cap))](((ref))/ingest.html) let you perform common transformations on your data before indexing.
 For example, you can use pipelines to remove fields, extract values from text, and enrich your data.
 
 A pipeline consists of a series of configurable tasks called processors.

--- a/serverless/pages/logstash-pipelines.mdx
+++ b/serverless/pages/logstash-pipelines.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/logstash-pipelines
-title: ((ls-pipelines-app))
+title: ((ls-pipelines))
 description: Create, edit, and delete your ((ls)) pipeline configurations.
 tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---

--- a/serverless/pages/machine-learning.mdx
+++ b/serverless/pages/machine-learning.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/machine-learning
-title: ((ml-app))
+title: ((ml-cap))
 description: View, export, and import ((ml)) jobs and models.
 tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---

--- a/serverless/pages/maintenance-windows.mdx
+++ b/serverless/pages/maintenance-windows.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/maintenance-windows
-title: ((maint-windows-app))
+title: ((maint-windows-cap))
 description: Suppress rule notifications for scheduled periods of time.
 tags: [ 'serverless', 'Observability', 'Security' ]
 ---
@@ -9,7 +9,7 @@ tags: [ 'serverless', 'Observability', 'Security' ]
 This content applies to: <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
 
 <DocCallOut template="technical_preview" />
-You can schedule single or recurring maintenance windows to temporarily reduce rule notifications.
+You can schedule single or recurring ((maint-windows)) to temporarily reduce rule notifications.
 For example, a maintenance window prevents false alarms during planned outages.
 
 Alerts continue to be generated, however notifications are suppressed as follows:
@@ -30,9 +30,9 @@ To use maintenance windows, you must have the appropriate [subscription](((subsc
 For more details, refer to <DocLink id="enKibanaKibanaPrivileges">((kib)) privileges</DocLink>.
 */}
 
-## Create and manage maintenance windows
+## Create and manage ((maint-windows))
 
-In **((project-settings)) → ((manage-app)) → ((maint-windows-app))** you can create, edit, and archive maintenance windows.
+In **((project-settings)) → ((manage-app)) → ((maint-windows-app))** you can create, edit, and archive ((maint-windows)).
 
 When you create a maintenance window, you must provide a name and a schedule.
 You can optionally configure it to repeat daily, monthly, yearly, or on a custom interval.
@@ -57,6 +57,6 @@ A maintenance window can have any one of the following statuses:
 - `Upcoming`: It will run at the scheduled date and time.
 - `Running`: It is running.
 - `Finished`: It ended and does not have a repeat schedule.
-- `Archived`: It is archived. In a future release, archived maintenance windows will be queued for deletion.
+- `Archived`: It is archived. In a future release, archived ((maint-windows)) will be queued for deletion.
 
-When you view alert details in ((kib)), each alert shows unique identifiers for maintenance windows that affected it.
+When you view alert details in ((kib)), each alert shows unique identifiers for ((maint-windows)) that affected it.

--- a/serverless/pages/saved-objects.mdx
+++ b/serverless/pages/saved-objects.mdx
@@ -1,6 +1,6 @@
 ---
 slug: /serverless/saved-objects
-title: ((saved-objects-app))
+title: Saved objects
 description: Manage your saved objects, including dashboards, visualizations, maps, ((data-sources)), and more.
 tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---


### PR DESCRIPTION
This PR fixes the capitalization of feature names in https://www.elastic.co/docs/current/serverless/project-settings to align with https://eui.elastic.co/#/guidelines/writing/guidelines#capitalization. The pages in this section previously used the type of capitalization appropriate for apps, but IMO these pages should evolve to be more generic introductions to these features.

