### PR TITLE
Add link to new stop billing page

### DIFF
--- a/serverless/pages/manage-billing.mdx
+++ b/serverless/pages/manage-billing.mdx
@@ -22,7 +22,6 @@ From the **Billing pages**, you can perform the following tasks:
 - <DocLink slug="/serverless/general/check-subscription" text="Check your subscription overview"/>
 - <DocLink slug="/serverless/general/monitor-usage" text="Monitor and analyze your account usage"/>
 - <DocLink slug="/serverless/general/billing-history" text="Check your billing history"/>
-- <DocLink slug="/serverless/general/billing-stop-project" text="Stop charges for a project"/>
 
-
+If you have a project that you're no longer using, refer to <DocLink slug="/serverless/general/billing-stop-project" text="Stop charges for a project"/>.
 

--- a/serverless/pages/manage-billing.mdx
+++ b/serverless/pages/manage-billing.mdx
@@ -22,3 +22,7 @@ From the **Billing pages**, you can perform the following tasks:
 - <DocLink slug="/serverless/general/check-subscription" text="Check your subscription overview"/>
 - <DocLink slug="/serverless/general/monitor-usage" text="Monitor and analyze your account usage"/>
 - <DocLink slug="/serverless/general/billing-history" text="Check your billing history"/>
+- <DocLink slug="/serverless/general/billing-stop-project" text="Stop charges for a project"/>
+
+
+


### PR DESCRIPTION
Earlier today I added a new page about stopping charges for a project ([PR](https://github.com/elastic/docs-content/pull/36)) but I clumsily forgot to add a link to that new page from the main [Manage billing](https://www.elastic.co/docs/current/serverless/general/manage-billing) page. So, this adds in that missing link. It's not grouped with the other links because it's not part of the "Billing" flow that the other tasks are part of.

---

![Screenshot 2024-06-28 at 1 07 43 PM](https://github.com/elastic/docs-content/assets/41695641/686c73d0-c429-4944-a0b5-a3445c9dfb79)
