### PR TITLE
Java client jackson dependency update

### DIFF
--- a/serverless/pages/clients-java-getting-started.mdx
+++ b/serverless/pages/clients-java-getting-started.mdx
@@ -30,7 +30,7 @@ You can install the Java client as a Gradle dependency:
 ```groovy
 dependencies {
     implementation 'co.elastic.clients:elasticsearch-java-serverless:1.0.0-20231031'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
 }
 ```
 
@@ -52,7 +52,7 @@ the following to the `pom.xml` of your project:
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>2.17.0</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Updating the documentation so that the jackson-databind dependency matches the one used by the java client.