### PR TITLE
Add Google Gemini connector

### DIFF
--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -16,25 +16,25 @@ The list of available connectors varies by project type.
       {
         "title": "Amazon Bedrock",
         "description": "Send a request to Amazon Bedrock.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/bedrock-action-type.html",
+        "href": "((kibana-ref))/bedrock-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Cases",
         "description": "Add alerts to cases.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/cases-action-type.html",
+        "href": "((kibana-ref))/cases-action-type.html",
         "target": "_blank"
       },
       {
         "title": "D3 Security",
         "description": "Create an event or trigger playbook workflow actions in D3 SOAR.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/d3security-action-type.html",
+        "href": "((kibana-ref))/d3security-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Email",
         "description": "Send email from your server.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/email-action-type.html",
+        "href": "((kibana-ref))/email-action-type.html",
         "target": "_blank"
       },
       {
@@ -46,121 +46,121 @@ The list of available connectors varies by project type.
       {
         "title": "IBM Resilient",
         "description": "Create an incident in IBM Resilient.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/resilient-action-type.html",
+        "href": "((kibana-ref))/resilient-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Index",
         "description": "Index data into Elasticsearch.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/index-action-type.html",
+        "href": "((kibana-ref))/index-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Jira",
         "description": "Create an incident in Jira.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/jira-action-type.html",
+        "href": "((kibana-ref))/jira-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Microsoft Teams",
         "description": "Send a message to a Microsoft Teams channel.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/teams-action-type.html",
+        "href": "((kibana-ref))/teams-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Observability AI Assistant",
         "description": "Add AI-driven insights and custom actions to your workflow.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/obs-ai-assistant-action-type.html",
+        "href": "((kibana-ref))/obs-ai-assistant-action-type.html",
         "target": "_blank"
       },
       {
         "title": "OpenAI",
         "description": "Send a request to OpenAI.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/openai-action-type.html",
+        "href": "((kibana-ref))/openai-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Opsgenie",
         "description": "Create or close an alert in Opsgenie.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/opsgenie-action-type.html",
+        "href": "((kibana-ref))/opsgenie-action-type.html",
         "target": "_blank"
       },
       {
         "title": "PagerDuty",
         "description": "Send an event in PagerDuty.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/pagerduty-action-type.html",
+        "href": "((kibana-ref))/pagerduty-action-type.html",
         "target": "_blank"
       },
       {
         "title": "SentinelOne",
         "description": "Perform response actions on SentinelOne-protected hosts.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/sentinelone-action-type.html",
+        "href": "((kibana-ref))/sentinelone-action-type.html",
         "target": "_blank"
       },
       {
         "title": "ServerLog",
         "description": "Add a message to a Kibana log.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/server-log-action-type.html",
+        "href": "((kibana-ref))/server-log-action-type.html",
         "target": "_blank"
       },
       {
         "title": "ServiceNow ITOM",
         "description": "Create an event in ServiceNow ITOM.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/servicenow-itom-action-type.html",
+        "href": "((kibana-ref))/servicenow-itom-action-type.html",
         "target": "_blank"
         },
       {
         "title": "ServiceNow ITSM",
         "description": "Create an incident in ServiceNow ITSM.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/servicenow-action-type.html",
+        "href": "((kibana-ref))/servicenow-action-type.html",
         "target": "_blank"
       },
       {
         "title": "ServiceNow SecOps",
         "description": "Create a security incident in ServiceNow SecOps.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/servicenow-sir-action-type.html",
+        "href": "((kibana-ref))/servicenow-sir-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Slack",
         "description": "Send messages to Slack channels.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/slack-action-type.html",
+        "href": "((kibana-ref))/slack-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Swimlane",
         "description": "Create records in Swimlane.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/swimlane-action-type.html",
+        "href": "((kibana-ref))/swimlane-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Tines",
         "description": "Send events to a story.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/tines-action-type.html",
+        "href": "((kibana-ref))/tines-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Torq",
         "description": "Trigger a Torq workflow.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/torq-action-type.html",
+        "href": "((kibana-ref))/torq-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Webhook",
         "description": "Send a request to a web service.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/webhook-action-type.html",
+        "href": "((kibana-ref))/webhook-action-type.html",
         "target": "_blank"
       },
       {
         "title": "Webhook - Case Management",
         "description": "Send a request to a Case Management web service.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/cases-webhook-action-type.html",
+        "href": "((kibana-ref))/cases-webhook-action-type.html",
         "target": "_blank"
         },
       {
         "title": "xMatters",
         "description": "Trigger an xMatters workflow.",
-        "href": "https://www.elastic.co/guide/en/kibana/current/xmatters-action-type.html",
+        "href": "((kibana-ref))/xmatters-action-type.html",
         "target": "_blank"
       },
     ]

--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -38,6 +38,12 @@ The list of available connectors varies by project type.
         "target": "_blank"
       },
       {
+        "title": "Google Gemini",
+        "description": "Send a request to Google Gemini.",
+        "href": "https://www.elastic.co/guide/en/kibana/master/gemini-action-type.html",
+        "target": "_blank"
+      },
+      {
         "title": "IBM Resilient",
         "description": "Create an incident in IBM Resilient.",
         "href": "https://www.elastic.co/guide/en/kibana/current/resilient-action-type.html",


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/pull/183668

This PR adds the Google Gemini connector to the list of connectors in https://www.elastic.co/docs/current/serverless/action-connectors, since it's now visible in security projects on production.

It also updates the links to use variables.  At this moment, since the Gemini connector doesn't exist in "current" docs, that URL has to be hard-coded.