### PR TITLE
Fix link to APIs

### DIFF
--- a/serverless/pages/apis-http-apis.mdx
+++ b/serverless/pages/apis-http-apis.mdx
@@ -19,7 +19,7 @@ tags: [ 'serverless', 'elasticsearch', 'http', 'rest', 'overview' ]
       {
         "title": "API Reference",
         "description": "Explore the reference information for Elastic Serverless REST APIs.",
-        "href": "hhttps://www.elastic.co/docs/api"
+        "href": "https://www.elastic.co/docs/api/"
       }
     ]
   }


### PR DESCRIPTION
This PR fixes a broken link on https://www.elastic.co/docs/current/serverless/elasticsearch/http-apis