### PR TITLE
Fix 404 links to serverless API ref

### DIFF
--- a/serverless/pages/clients-php-getting-started.mdx
+++ b/serverless/pages/clients-php-getting-started.mdx
@@ -140,7 +140,7 @@ print_r($response['hits']['hits']); # list of books
 
 For more information about the `search` API's query parameters and the response type,
 refer to the
-[Search API](/api-reference/search/search-2)
+[Search API](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-search)
 docs.
 
 ### Updating documents

--- a/serverless/pages/developer-tools-troubleshooting.mdx
+++ b/serverless/pages/developer-tools-troubleshooting.mdx
@@ -16,21 +16,14 @@ Elasticsearch returns an `index_not_found_exception` when the data stream, index
 or alias you try to query does not exist. This can happen when you misspell the
 name or when the data has been indexed to a different data stream or index.
 
-Use the [**Exists API**](/api-reference/search/indices-exists) to check whether 
+Use the [**Exists API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-exists-index-template) to check whether 
 a data stream, index, or alias exists:
 
 ```js
-HEAD my-data-stream 
+HEAD my-index 
 ```
 
-Use the [**Data stream stats API**](/api-reference/search/indices-data-streams-stats)
-to list all data streams:
-
-```js
-GET /_data_stream/_stats
-```
-
-Use the [**Get index API**](/api-reference/search/indices-get)
+Use the [**Get index API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-get)
 to list all indices and their aliases:
 
 ```js
@@ -53,7 +46,7 @@ This can happen when there is a data ingestion issue.
 For example, the data may have been indexed to a data stream or index with 
 another name.
 
-Use the [**Count API**](/api-reference/search/count-3)
+Use the [**Count API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-count-1)
 to retrieve the number of documents in a data
 stream or index.
 Check that `count` in the response is not 0.
@@ -73,7 +66,7 @@ configured with the correct time field.
 ## Check that the field exists and its capabilities
 
 Querying a field that does not exist will not return any results.
-Use the [**Field capabilities API**](/api-reference/search/field-caps)
+Use the [**Field capabilities API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-field-caps)
 to check whether a field exists:
 
 ```js
@@ -110,7 +103,7 @@ searchable and aggregatable.
 ## Check the field's mappings
 
 A field's capabilities are determined by its [mapping](((ref))/mapping.html).
-To retrieve the mapping, use the [**Get mapping API**](/api-reference/search/indices-get-mapping-1):
+To retrieve the mapping, use the [**Get mapping API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-get-mapping):
 
 ```js
 GET /my-index-000001/_mappings
@@ -118,7 +111,7 @@ GET /my-index-000001/_mappings
 
 If you query a `text` field, pay attention to the analyzer that may have been
 configured.
-You can use the [**Analyze API**](/api-reference/search/indices-analyze)
+You can use the [**Analyze API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-analyze)
 to check how a field's analyzer processes values and query terms:
 
 ```js
@@ -129,7 +122,7 @@ GET /my-index-000001/_analyze
 }
 ```
 
-To change the mapping of an existing field use the [**Update mapping API**](/api-reference/search/indices-put-mapping).
+To change the mapping of an existing field use the [**Update mapping API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-put-mapping-1).
 
 ## Check the field's values
 
@@ -203,7 +196,7 @@ GET /my-index-000001/_search?sort=@timestamp:desc&size=1
 When a query returns unexpected results, Elasticsearch offers several tools to
 investigate why.
 
-The [**Validate API**](/api-reference/search/indices-validate-query-2)
+The [**Validate API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-validate-query)
 enables you to validate a query.
 Use the `rewrite` parameter to return the Lucene query an Elasticsearch query is
 rewritten into:
@@ -251,7 +244,7 @@ Index settings {/* <DocLink id="enElasticsearchReferenceIndexModules" section="i
 can influence search results.
 For example, the `index.query.default_field` setting, which determines the field
 that is queried when a query specifies no explicit field.
-Use the [**Get index settings API**](/api-reference/search/indices-get-settings-1)
+Use the [**Get index settings API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-get-settings)
 to retrieve the settings for an index:
 
 ```bash
@@ -259,7 +252,7 @@ GET /my-index-000001/_settings
 ```
 
 You can update dynamic index settings with the 
-[**Update index settings API**](/api-reference/search/indices-put-settings-1). 
+[**Update index settings API**](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-indices-put-settings). 
 Changing dynamic index settings for a data stream 
 {/*  <DocLink id="enElasticsearchReferenceModifyDataStreams" section="change-a-dynamic-index-setting-for-a-data-stream">Changing dynamic index settings for a data stream</DocLink> */} requires changing the index template used by the data stream.
 

--- a/serverless/pages/search-your-data-the-search-api.mdx
+++ b/serverless/pages/search-your-data-the-search-api.mdx
@@ -20,4 +20,4 @@ aggregate data stored in ((es)) data streams or indices.
 The API's `query` request body parameter accepts queries written in
 [Query DSL](((ref))/query-dsl.html).
 
-For more information, refer to [The search API](((ref))/search-your-data.html).
+For more information, refer to [the search API overview](((ref))/search-your-data.html) in the classic ((es)) docs.

--- a/serverless/pages/search-your-data-the-search-api.mdx
+++ b/serverless/pages/search-your-data-the-search-api.mdx
@@ -15,7 +15,7 @@ A search may also contain additional information used to better process its
 queries. For example, a search may be limited to a specific index or only return
 a specific number of results.
 
-You can use the [search API](/api-reference/search/search-2) to search and
+You can use the [search API](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-search) to search and
 aggregate data stored in ((es)) data streams or indices.
 The API's `query` request body parameter accepts queries written in
 [Query DSL](((ref))/query-dsl.html).


### PR DESCRIPTION
We have some 404s due to old relative links 