### PR TITLE
Add pricing info everywhere

### DIFF
--- a/serverless/pages/get-started.mdx
+++ b/serverless/pages/get-started.mdx
@@ -5,6 +5,8 @@ description: Get started with ((es3)) in a few steps
 tags: [ 'serverless', 'elasticsearch', 'getstarted', 'overview' ]
 ---
 
+import MinimumVcusDetail from '../partials/minimum-vcus-detail.mdx'
+
 <DocBadge template="technical preview" />
 Follow along to set up your ((es)) project and get started with some sample documents.
 Then, choose how to continue with your own data.
@@ -29,6 +31,8 @@ Use your ((ecloud)) account to create a fully-managed ((es)) project:
 1. Once the project is ready, select **Continue**.
 
 You should now see **Get started with ((es))**, and you're ready to continue.
+
+<MinimumVcusDetail />
 
 ## Create API key
 

--- a/serverless/pages/manage-billing-monitor-usage.mdx
+++ b/serverless/pages/manage-billing-monitor-usage.mdx
@@ -5,6 +5,8 @@ description: Check the usage breakdown of your account.
 tags: [ 'serverless', 'general', 'billing', 'usage' ]
 ---
 
+import MinimumVcus from '../partials/minimum-vcus.mdx'
+
 <DocBadge template="technical preview" />
 To find more details about your account usage:
 
@@ -21,3 +23,4 @@ On the **Usage** page you can:
 The usage breakdown information is an estimate. To get the exact amount you owe for a given month, check your invoices in the <DocLink slug="/serverless/general/billing-history" text="billing history"/>.
 </DocCallOut>
 
+<MinimumVcus />

--- a/serverless/pages/manage-billing-monitor-usage.mdx
+++ b/serverless/pages/manage-billing-monitor-usage.mdx
@@ -5,8 +5,6 @@ description: Check the usage breakdown of your account.
 tags: [ 'serverless', 'general', 'billing', 'usage' ]
 ---
 
-import MinimumVcus from '../partials/minimum-vcus.mdx'
-
 <DocBadge template="technical preview" />
 To find more details about your account usage:
 
@@ -23,4 +21,6 @@ On the **Usage** page you can:
 The usage breakdown information is an estimate. To get the exact amount you owe for a given month, check your invoices in the <DocLink slug="/serverless/general/billing-history" text="billing history"/>.
 </DocCallOut>
 
-<MinimumVcus />
+<DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
+    When you create an Elasticsearch Serverless project, to maintain basic ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project, incurring a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+</DocCallOut>

--- a/serverless/pages/manage-billing-monitor-usage.mdx
+++ b/serverless/pages/manage-billing-monitor-usage.mdx
@@ -22,5 +22,5 @@ The usage breakdown information is an estimate. To get the exact amount you owe 
 </DocCallOut>
 
 <DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-    When you create an Elasticsearch Serverless project, to maintain basic ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project, incurring a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+    When you create an Elasticsearch Serverless project, to maintain basic ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project. These VCUs incur a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
 </DocCallOut>

--- a/serverless/pages/manage-billing-monitor-usage.mdx
+++ b/serverless/pages/manage-billing-monitor-usage.mdx
@@ -22,5 +22,5 @@ The usage breakdown information is an estimate. To get the exact amount you owe 
 </DocCallOut>
 
 <DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-    When you create an Elasticsearch Serverless project, to maintain basic ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project. These VCUs incur a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+    When you create an Elasticsearch Serverless project, a minimum number of VCUs are always allocated to your project to maintain basic ingest and search capabilities. These VCUs incur a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
 </DocCallOut>

--- a/serverless/pages/manage-billing-pricing-model.mdx
+++ b/serverless/pages/manage-billing-pricing-model.mdx
@@ -5,16 +5,12 @@ description: Understand how usage affects serverless pricing.
 tags: [ 'serverless', 'general', 'billing', 'pricing model' ]
 ---
 
-import MinimumVcus from '../partials/minimum-vcus.mdx'
-
 <DocBadge template="technical preview" />
 
 Elastic Cloud serverless billing is based on your usage across these dimensions:
 
 * <DocLink slug="/serverless/general/serverless-billing" section="offerings">Offerings</DocLink>
 * <DocLink slug="/serverless/general/serverless-billing" section="add-ons">Add-ons</DocLink>
-
-<MinimumVcus />
 
 <div id="offerings"></div>
 

--- a/serverless/pages/manage-billing-pricing-model.mdx
+++ b/serverless/pages/manage-billing-pricing-model.mdx
@@ -5,13 +5,16 @@ description: Understand how usage affects serverless pricing.
 tags: [ 'serverless', 'general', 'billing', 'pricing model' ]
 ---
 
+import MinimumVcus from '../partials/minimum-vcus.mdx'
+
 <DocBadge template="technical preview" />
 
-Elastic Cloud serverless billing is based on your actual usage across these dimensions:
+Elastic Cloud serverless billing is based on your usage across these dimensions:
 
 * <DocLink slug="/serverless/general/serverless-billing" section="offerings">Offerings</DocLink>
 * <DocLink slug="/serverless/general/serverless-billing" section="add-ons">Add-ons</DocLink>
 
+<MinimumVcus />
 
 <div id="offerings"></div>
 

--- a/serverless/pages/manage-billing.mdx
+++ b/serverless/pages/manage-billing.mdx
@@ -25,3 +25,5 @@ From the **Billing pages**, you can perform the following tasks:
 
 If you have a project that you're no longer using, refer to <DocLink slug="/serverless/general/billing-stop-project" text="Stop charges for a project"/>.
 
+To learn about the serverless pricing model, refer to <DocLink slug="/serverless/general/serverless-billing" text="Serverless billing dimensions"/>.
+

--- a/serverless/pages/manage-billing.mdx
+++ b/serverless/pages/manage-billing.mdx
@@ -25,5 +25,5 @@ From the **Billing pages**, you can perform the following tasks:
 
 If you have a project that you're no longer using, refer to <DocLink slug="/serverless/general/billing-stop-project" text="Stop charges for a project"/>.
 
-To learn about the serverless pricing model, refer to <DocLink slug="/serverless/general/serverless-billing" text="Serverless billing dimensions"/>.
+To learn about the serverless pricing model, refer to <DocLink slug="/serverless/general/serverless-billing" text="Serverless billing dimensions"/> and our [pricing page](https://www.elastic.co/pricing/serverless-search).
 

--- a/serverless/pages/pricing.mdx
+++ b/serverless/pages/pricing.mdx
@@ -5,6 +5,8 @@ description: Learn about how Elasticsearch usage affects pricing.
 tags: [ 'serverless', 'elasticsearch', 'overview' ]
 ---
 
+import MinimumVcusDetail from '../partials/minimum-vcus-detail.mdx'
+
 <p><DocBadge template="technical preview" /></p>
 
 Elasticsearch is priced based on the consumption of the underlying 
@@ -15,6 +17,8 @@ depend on the amount and the rate of data sent to Elasticsearch and retained,
 and the number of searches and latency you require for Searches. In addition, if 
 you required ((ml)) for inference or NLP tasks, those VCUs are also 
 metered and billed.
+
+<MinimumVcusDetail />
 
 ## Information about the VCU types (Search, Ingest, and ML)
 

--- a/serverless/pages/pricing.mdx
+++ b/serverless/pages/pricing.mdx
@@ -14,7 +14,7 @@ infrastructure used to support your use case, with the performance
 characteristics you need. We measure by Virtual Compute Units (VCUs), which is a 
 slice of RAM, CPU and local disk for caching. The number of VCUs required will 
 depend on the amount and the rate of data sent to Elasticsearch and retained, 
-and the number of searches and latency you require for Searches. In addition, if 
+and the number of searches and latency you require for searches. In addition, if 
 you required ((ml)) for inference or NLP tasks, those VCUs are also 
 metered and billed.
 

--- a/serverless/pages/sign-up.mdx
+++ b/serverless/pages/sign-up.mdx
@@ -63,7 +63,7 @@ To remove limitations, subscribe to [Elastic Cloud](https://www.elastic.co/guide
 You can subscribe to Elastic Cloud at any time during your trial. [Billing](/serverless/general/serverless-billing) starts when you subscribe. To maximize the benefits of your trial, subscribe at the end of the free period. To monitor charges, anticipate future costs, and adjust your usage, check your [account usage](https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html) and [billing history](https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html). 
 
 <DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-	The way that you are billed depends on the project type that you select. Some project types have a minimum number of VCUs that are always allocated and billed to your project. <DocLink slug="/serverless/general/serverless-billing" text="Learn more"/>.
+	The way that you are billed depends on the project type that you select. Some project types have a minimum number of VCUs that are always allocated to your project, incurring a minimum cost even with no active usage. <DocLink slug="/serverless/general/serverless-billing" text="Learn more"/>.
 </DocCallOut>
 
 ## How do I get started with my trial?

--- a/serverless/pages/sign-up.mdx
+++ b/serverless/pages/sign-up.mdx
@@ -63,7 +63,7 @@ To remove limitations, subscribe to [Elastic Cloud](https://www.elastic.co/guide
 You can subscribe to Elastic Cloud at any time during your trial. [Billing](/serverless/general/serverless-billing) starts when you subscribe. To maximize the benefits of your trial, subscribe at the end of the free period. To monitor charges, anticipate future costs, and adjust your usage, check your [account usage](https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html) and [billing history](https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html). 
 
 <DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-	The way that you are billed depends on the project type that you select. Some project types have a minimum number of VCUs that are always allocated and billed to your project. [Learn more](/serverless/general/serverless-billing).
+	The way that you are billed depends on the project type that you select. Some project types have a minimum number of VCUs that are always allocated and billed to your project. <DocLink slug="/serverless/general/serverless-billing" text="Learn more"/>.
 </DocCallOut>
 
 ## How do I get started with my trial?

--- a/serverless/pages/sign-up.mdx
+++ b/serverless/pages/sign-up.mdx
@@ -60,11 +60,7 @@ To remove limitations, subscribe to [Elastic Cloud](https://www.elastic.co/guide
 - Third availability zone for your deployments.
 - Access to additional features, such as cross-cluster search and cross-cluster replication.
 
-You can subscribe to Elastic Cloud at any time during your trial. [Billing](/serverless/general/serverless-billing) starts when you subscribe. To maximize the benefits of your trial, subscribe at the end of the free period. To monitor charges, anticipate future costs, and adjust your usage, check your [account usage](https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html) and [billing history](https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html). 
-
-<DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-	The way that you are billed depends on the project type that you select. Some project types have a minimum number of VCUs that are always allocated to your project, incurring a minimum cost even with no active usage. <DocLink slug="/serverless/general/serverless-billing" text="Learn more"/>.
-</DocCallOut>
+You can subscribe to Elastic Cloud at any time during your trial. [Billing](/serverless/general/serverless-billing) starts when you subscribe. To maximize the benefits of your trial, subscribe at the end of the free period. To monitor charges, anticipate future costs, and adjust your usage, check your [account usage](https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html) and [billing history](https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html).
 
 ## How do I get started with my trial?
 

--- a/serverless/pages/sign-up.mdx
+++ b/serverless/pages/sign-up.mdx
@@ -60,7 +60,11 @@ To remove limitations, subscribe to [Elastic Cloud](https://www.elastic.co/guide
 - Third availability zone for your deployments.
 - Access to additional features, such as cross-cluster search and cross-cluster replication.
 
-You can subscribe to Elastic Cloud at any time during your trial. Billing starts when you subscribe. To maximize the benefits of your trial, subscribe at the end of the free period. To monitor charges, anticipate future costs, and adjust your usage, check your [account usage](https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html) and [billing history](https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html).
+You can subscribe to Elastic Cloud at any time during your trial. [Billing](/serverless/general/serverless-billing) starts when you subscribe. To maximize the benefits of your trial, subscribe at the end of the free period. To monitor charges, anticipate future costs, and adjust your usage, check your [account usage](https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html) and [billing history](https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html). 
+
+<DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
+	The way that you are billed depends on the project type that you select. Some project types have a minimum number of VCUs that are always allocated and billed to your project. [Learn more](/serverless/general/serverless-billing).
+</DocCallOut>
 
 ## How do I get started with my trial?
 

--- a/serverless/partials/minimum-vcus-detail.mdx
+++ b/serverless/partials/minimum-vcus-detail.mdx
@@ -1,8 +1,8 @@
 <DocCallOut color="warning" title="Minimum runtime VCUs">
     When you create an Elasticsearch Serverless project, a minimum number of VCUs are always allocated to your project to maintain basic capabilities. These VCUs are used for the following purposes: 
 
-    - **Ingest**: Ensure constant availability for ingesting data into your project.
-    - **Search**: Maintain a data cache and support low latency searches.
+    - **Ingest**: Ensure constant availability for ingesting data into your project (4 VCUs).
+    - **Search**: Maintain a data cache and support low latency searches (8 VCUs).
 
     These minimum VCUs are billed at the standard rate per VCU hour, incurring a minimum cost even when you're not actively using your project.
     Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).

--- a/serverless/partials/minimum-vcus-detail.mdx
+++ b/serverless/partials/minimum-vcus-detail.mdx
@@ -1,9 +1,9 @@
 <DocCallOut color="warning" title="Minimum runtime VCUs">
-    After you create an Elasticsearch Serverless project, to maintain basic Elasticsearch capabilities, a minimum number VCUs are always allocated to your project. These VCUs are used for the following purposes: 
+    After you create an Elasticsearch Serverless project, to maintain basic Elasticsearch capabilities, a minimum number of VCUs are always allocated to your project. These VCUs are used for the following purposes: 
 
     - **Ingest**: Ensure constant availability for ingesting data into your project.
     - **Search**: Maintain a data cache and support low latency searches.
 
-    These minimum VCUs are billed at the standard rate per VCU hour.
+    These minimum VCUs are billed at the standard rate per VCU hour, incurring a minimum cost even when you're not actively using your project.
     Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
 </DocCallOut>

--- a/serverless/partials/minimum-vcus-detail.mdx
+++ b/serverless/partials/minimum-vcus-detail.mdx
@@ -1,0 +1,9 @@
+<DocCallOut color="warning" title="Minimum runtime VCUs">
+    After you create an Elasticsearch Serverless project, to maintain basic Elasticsearch capabilities, a minimum number VCUs are always allocated to your project. These VCUs are used for the following purposes: 
+
+    - **Ingest**: Ensure constant availability for ingesting data into your project.
+    - **Search**: Maintain a data cache and support low latency searches.
+
+    These minimum VCUs are billed at the standard rate per VCU hour.
+    Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+</DocCallOut>

--- a/serverless/partials/minimum-vcus-detail.mdx
+++ b/serverless/partials/minimum-vcus-detail.mdx
@@ -1,5 +1,5 @@
 <DocCallOut color="warning" title="Minimum runtime VCUs">
-    After you create an Elasticsearch Serverless project, to maintain basic Elasticsearch capabilities, a minimum number of VCUs are always allocated to your project. These VCUs are used for the following purposes: 
+    When you create an Elasticsearch Serverless project, a minimum number of VCUs are always allocated to your project to maintain basic capabilities. These VCUs are used for the following purposes: 
 
     - **Ingest**: Ensure constant availability for ingesting data into your project.
     - **Search**: Maintain a data cache and support low latency searches.

--- a/serverless/partials/minimum-vcus.mdx
+++ b/serverless/partials/minimum-vcus.mdx
@@ -1,3 +1,3 @@
 <DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-    When you create an Elasticsearch Serverless project, to maintain basic Elasticsearch ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project, incurring a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+    When you create an Elasticsearch Serverless project, to maintain basic ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project, incurring a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
 </DocCallOut>

--- a/serverless/partials/minimum-vcus.mdx
+++ b/serverless/partials/minimum-vcus.mdx
@@ -1,3 +1,3 @@
 <DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-    When you create an Elasticsearch Serverless project, to maintain basic Elasticsearch ingest and search capabilities, a minimum number VCUs are always allocated and billed to your project.    Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+    When you create an Elasticsearch Serverless project, to maintain basic Elasticsearch ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project, incurring a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
 </DocCallOut>

--- a/serverless/partials/minimum-vcus.mdx
+++ b/serverless/partials/minimum-vcus.mdx
@@ -1,3 +1,0 @@
-<DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
-    When you create an Elasticsearch Serverless project, to maintain basic ingest and search capabilities, a minimum number of VCUs are always allocated and billed to your project, incurring a minimum cost even with no active usage. Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
-</DocCallOut>

--- a/serverless/partials/minimum-vcus.mdx
+++ b/serverless/partials/minimum-vcus.mdx
@@ -1,0 +1,3 @@
+<DocCallOut color="warning" title="Elasticsearch minimum runtime VCUs">
+    When you create an Elasticsearch Serverless project, to maintain basic Elasticsearch ingest and search capabilities, a minimum number VCUs are always allocated and billed to your project.    Learn more about [minimum VCUs on Elasticsearch Serverless](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless).
+</DocCallOut>


### PR DESCRIPTION
To resolve confusion about the ES serverless pricing model, I'm adding more explicit detail about how the minimum # of running VCUs impact billing, and what those minimum VCUs are used for.

The following pages got additional info, largely in the form of caution blocks:

[Elasticsearch billing dimensions](https://elastic-dot-co-docs-production-dng2tyfar-elastic-dev.vercel.app/current/serverless/elasticsearch/elasticsearch-billing) - big note re: min VCUs, with detail explaining what the VCUs are for. [links here](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless)

could optionally add a note about free trials here.

<img width="574" alt="image" src="https://github.com/user-attachments/assets/80b86460-aa39-4718-b0d0-0db3a239c6d3">

[Elasticsearch get started](https://elastic-dot-co-docs-production-dng2tyfar-elastic-dev.vercel.app/current/serverless/elasticsearch/get-started) - same big note re: min VCUs.  [links here](https://www.elastic.co/pricing/serverless-search#what-are-the-minimum-compute-resource-vcus-on-elasticsearch-serverless)

could optionally add a note about free trials here.

<img width="573" alt="image" src="https://github.com/user-attachments/assets/015825f4-4b61-45f5-b792-7a45524cd4ca">

[Monitor usage](https://elastic-dot-co-docs-production-dng2tyfar-elastic-dev.vercel.app/current/serverless/general/monitor-usage) - hinted at ongoing minimum usage

<img width="562" alt="image" src="https://github.com/user-attachments/assets/3ac0b419-2b0d-4d30-8c97-47af99531778">

[Manage billing of your organization](https://elastic-dot-co-docs-production-dng2tyfar-elastic-dev.vercel.app/current/serverless/general/manage-billing) - added link [further into the billing dimensions content](https://elastic-dot-co-docs-production-dng2tyfar-elastic-dev.vercel.app/current/serverless/general/serverless-billing)

<img width="751" alt="image" src="https://github.com/user-attachments/assets/4d396af1-f330-4467-83cc-e2740e79e8bb">



