### PR TITLE
Add link to new CrowdStrike connector

### DIFF
--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -26,6 +26,12 @@ The list of available connectors varies by project type.
         "target": "_blank"
       },
       {
+        "title": "CrowdStrike",
+        "description": "Send a request to CrowdStrike.",
+        "href": "((kibana-ref))/crowdstrike-action-type.html",
+        "target": "_blank"
+      },
+      {
         "title": "D3 Security",
         "description": "Create an event or trigger playbook workflow actions in D3 SOAR.",
         "href": "((kibana-ref))/d3security-action-type.html",


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5446. 

Adds a link in the serverless general docs to the new [CrowdStrike connector docs](https://www.elastic.co/guide/en/kibana/master/crowdstrike-action-type.html), which was recently added as part of Security's bidirectional integration with CrowdStrike.

### Preview

- Click the [link below](https://github.com/elastic/docs-content/pull/46#issuecomment-2248624773), then click **View serverless docs** in any solution card. 
- Navigate to: **Project and management settings → Management → Connectors**.