### PR TITLE
[Jul 31] Add cloud region info

### DIFF
--- a/serverless/nav/serverless-general.docnav.json
+++ b/serverless/nav/serverless-general.docnav.json
@@ -60,6 +60,9 @@
     },
     {
       "slug": "/serverless/general/user-profile"
+    },
+    {
+      "slug": "/serverless/regions"
     }
   ]
 }

--- a/serverless/pages/cloud-regions.mdx
+++ b/serverless/pages/cloud-regions.mdx
@@ -7,7 +7,7 @@ tags: ["serverless", "regions", "aws", "cloud"]
 
 A region is the geographic area where the data center of the cloud provider that hosts your project is located. Review the available Elastic Cloud Serverless regions to decide which region to use. If you aren't sure which region to pick, choose one that is geographically close to you to reduce latency. 
 
-Elastic Cloud Serverless handles all hosting details for you, and doesn't require any additional accounts with the underlying cloud provider. You are unable to change the region after you create a project. 
+Elastic Cloud Serverless handles all hosting details for you. You are unable to change the region after you create a project. 
 
 <DocCallOut title="Note">
 Currently, a limited number of Amazon Web Services (AWS) regions are available. More regions for AWS, as well as Microsoft Azure and Google Cloud Platform (GCP), will be added in the future.
@@ -15,7 +15,7 @@ Currently, a limited number of Amazon Web Services (AWS) regions are available. 
 
 ## Amazon Web Services (AWS) regions
 
-The following AWS regions are available:
+The following AWS regions are currently available:
 
 | Region | Name | 
 |--------|------|

--- a/serverless/pages/cloud-regions.mdx
+++ b/serverless/pages/cloud-regions.mdx
@@ -5,9 +5,9 @@ description: Index, search, and manage ((es)) data in your preferred language.
 tags: ["serverless", "regions", "aws", "cloud"]
 ---
 
-A region is the geographic area where the data center of the cloud provider that hosts your deployment is located. Review the available Elastic serverless regions to decide which region to use. If you aren't sure which region to pick, choose a one that is geographically close to you to reduce latency. 
+A region is the geographic area where the data center of the cloud provider that hosts your project is located. Review the available Elastic Cloud Serverless regions to decide which region to use. If you aren't sure which region to pick, choose a one that is geographically close to you to reduce latency. 
 
-Elastic serverless handles all hosting details for you, and doesn't require any additional accounts with the underlying cloud provider. The region you select can't be changed after you create a project. 
+Elastic Cloud Serverless handles all hosting details for you, and doesn't require any additional accounts with the underlying cloud provider. You are unable to change the region after you create a project. 
 
 <DocCallOut title="Note">
 Currently, a limited number of Amazon Web Services (AWS) regions are available. More regions for AWS, as well as Microsoft Azure and Google Cloud Platform (GCP), will be added in the future.

--- a/serverless/pages/cloud-regions.mdx
+++ b/serverless/pages/cloud-regions.mdx
@@ -1,0 +1,26 @@
+---
+slug: /serverless/regions
+title: Serverless regions
+description: Index, search, and manage ((es)) data in your preferred language.
+tags: ["serverless", "regions", "aws", "cloud"]
+---
+
+A region is the geographic area where the data center of the cloud provider that hosts your deployment is located. Review the available Elastic serverless regions to decide which region to use. If you aren't sure which region to pick, choose a one that is geographically close to you to reduce latency. 
+
+Elastic serverless handles all hosting details for you, and doesn't require any additional accounts with the underlying cloud provider. The region you select can't be changed after you create a project. 
+
+<DocCallOut title="Note">
+Currently, only limited Amazon Web Services (AWS) regions are available. More regions for AWS, as well as Microsoft Azure and Google Cloud Platform (GCP), will be added in the future.
+</DocCallOut>
+
+## Amazon Web Services (AWS) regions
+
+The following AWS regions are available:
+
+| Region | Name | 
+|--------|------|
+| ap-southeast-1 | Asia Pacific (Singapore) |
+| eu-west-1 | Europe (Ireland) |
+| us-east-1 | US East (N. Virginia) |
+| us-west-2 | US West (Oregon) |
+

--- a/serverless/pages/cloud-regions.mdx
+++ b/serverless/pages/cloud-regions.mdx
@@ -5,7 +5,7 @@ description: Index, search, and manage ((es)) data in your preferred language.
 tags: ["serverless", "regions", "aws", "cloud"]
 ---
 
-A region is the geographic area where the data center of the cloud provider that hosts your project is located. Review the available Elastic Cloud Serverless regions to decide which region to use. If you aren't sure which region to pick, choose a one that is geographically close to you to reduce latency. 
+A region is the geographic area where the data center of the cloud provider that hosts your project is located. Review the available Elastic Cloud Serverless regions to decide which region to use. If you aren't sure which region to pick, choose one that is geographically close to you to reduce latency. 
 
 Elastic Cloud Serverless handles all hosting details for you, and doesn't require any additional accounts with the underlying cloud provider. You are unable to change the region after you create a project. 
 

--- a/serverless/pages/cloud-regions.mdx
+++ b/serverless/pages/cloud-regions.mdx
@@ -10,7 +10,7 @@ A region is the geographic area where the data center of the cloud provider that
 Elastic serverless handles all hosting details for you, and doesn't require any additional accounts with the underlying cloud provider. The region you select can't be changed after you create a project. 
 
 <DocCallOut title="Note">
-Currently, only limited Amazon Web Services (AWS) regions are available. More regions for AWS, as well as Microsoft Azure and Google Cloud Platform (GCP), will be added in the future.
+Currently, a limited number of Amazon Web Services (AWS) regions are available. More regions for AWS, as well as Microsoft Azure and Google Cloud Platform (GCP), will be added in the future.
 </DocCallOut>
 
 ## Amazon Web Services (AWS) regions

--- a/serverless/pages/get-started.mdx
+++ b/serverless/pages/get-started.mdx
@@ -25,7 +25,7 @@ Use your ((ecloud)) account to create a fully-managed ((es)) project:
      - **General purpose**. For general search use cases across various data types.
      - **Optimized for Vectors**. For search use cases using vectors and near real-time retrieval.
 
-1. Provide a name for the project and optionally edit the project settings, such as the cloud platform <DocLink slug="/serverless/region">region</DocLink>.
+1. Provide a name for the project and optionally edit the project settings, such as the cloud platform <DocLink slug="/serverless/region" text="region"/>.
    Select **Create project** to continue.
 
 1. Once the project is ready, select **Continue**.

--- a/serverless/pages/get-started.mdx
+++ b/serverless/pages/get-started.mdx
@@ -25,7 +25,7 @@ Use your ((ecloud)) account to create a fully-managed ((es)) project:
      - **General purpose**. For general search use cases across various data types.
      - **Optimized for Vectors**. For search use cases using vectors and near real-time retrieval.
 
-1. Provide a name for the project and optionally edit the project settings, such as the cloud platform <DocLink slug="/serverless/region" text="region"/>.
+1. Provide a name for the project and optionally edit the project settings, such as the cloud platform <DocLink slug="/serverless/regions" text="region"/>.
    Select **Create project** to continue.
 
 1. Once the project is ready, select **Continue**.

--- a/serverless/pages/get-started.mdx
+++ b/serverless/pages/get-started.mdx
@@ -25,7 +25,7 @@ Use your ((ecloud)) account to create a fully-managed ((es)) project:
      - **General purpose**. For general search use cases across various data types.
      - **Optimized for Vectors**. For search use cases using vectors and near real-time retrieval.
 
-1. Provide a name for the project and optionally edit the project settings, such as the cloud platform region.
+1. Provide a name for the project and optionally edit the project settings, such as the cloud platform <DocLink slug="/serverless/region">region</DocLink>.
    Select **Create project** to continue.
 
 1. Once the project is ready, select **Continue**.


### PR DESCRIPTION
Adds information about available cloud regions: [cloud regions](https://elastic-dot-co-docs-production-fxkx6n78d-elastic-dev.vercel.app/current/serverless/regions)

links to cloud region docs in ES project creation docs: [link](https://elastic-dot-co-docs-production-fxkx6n78d-elastic-dev.vercel.app/current/serverless/elasticsearch/get-started#create-project)

<img width="739" alt="image" src="https://github.com/user-attachments/assets/41cd8427-27c3-43eb-925a-5eb58b674375">

Added links in obs and sec project creation docs as well: 
https://github.com/elastic/observability-docs/pull/4093
https://github.com/elastic/security-docs/pull/5604

