### PR TITLE
Fix dev tools overview page typo #150

### DIFF
--- a/serverless/pages/elasticsearch-developer-tools.mdx
+++ b/serverless/pages/elasticsearch-developer-tools.mdx
@@ -12,7 +12,7 @@ A number of developer tools are available in your project's UI under the **Dev T
 
 - <DocLink slug="/serverless/devtools/run-api-requests-in-the-console" text="Console"/>: Make API calls to your Elasticsearch instance using the Query DSL and view the responses.
 - <DocLink slug="/serverless/devtools/profile-queries-and-aggregations" text="Search Profiler"/>: Inspect and analyze your search queries to identify performance bottlenecks.
-- <DocLink slug="/serverless/devtools/debug-grok-expressions" text="Grok Debugger" />>: Build and debug grok patterns before you use them in your data processing pipelines.
+- <DocLink slug="/serverless/devtools/debug-grok-expressions" text="Grok Debugger" />: Build and debug grok patterns before you use them in your data processing pipelines.
 
 
 {/* ## Troubleshooting */}


### PR DESCRIPTION
There was an extra > on the Dev Tools overview page in the Elasticsearch serverless docs at the end of the Grok Debugger bullet point and link. Fixed the output by removing the unnecessary character.