### PR TITLE
Fix API feedback template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-feedback.yaml
+++ b/.github/ISSUE_TEMPLATE/api-feedback.yaml
@@ -13,8 +13,8 @@ body:
     attributes:
       label: Was the documentation helpful?
       options:
-        - Yes
-        - No
+        - "Yes"
+        - "No"
       default: 0
     validations:
       required: true


### PR DESCRIPTION
This PR fixes the following error that was occurring for the API feedback template: 

```
There is a problem with this template
body[1]: options must not include booleans. Please wrap values such as 'yes', and 'true' in quotes.
```
[Learn more about this error.](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#bodyi-options-must-not-include-booleans-please-wrap-values-such-as-yes-and-true-in-quotes)