### PR TITLE
Add scripted metrics to serverless differences

### DIFF
--- a/serverless/pages/explore-your-data-the-aggregations-api.mdx
+++ b/serverless/pages/explore-your-data-the-aggregations-api.mdx
@@ -17,7 +17,9 @@ Aggregations help you answer questions like:
 ((es)) organizes aggregations into three categories:
 
 * [Metric](((ref))/search-aggregations-metrics.html) aggregations that calculate metrics,
-    such as a sum or average, from field values.
+    such as a sum or an average, from field values. Note that
+    [scripted metric aggregations](((ref))/search-aggregations-metrics-scripted-metric-aggregation.html) 
+    are not available in serverless ((es)).
 
 * [Bucket](((ref))/search-aggregations-bucket.html) aggregations that
     group documents into buckets, also called bins, based on field values, ranges,

--- a/serverless/pages/serverless-differences.mdx
+++ b/serverless/pages/serverless-differences.mdx
@@ -30,6 +30,7 @@ text="data stream lifecycle"/>**.
 
   Serverless Elasticsearch manages the underlying Elastic cluster for you, optimizing nodes, shards, and replicas for your use case. 
   Because of this, various management and monitoring APIs, API parameters and settings are not available on Serverless.
+  <br/>
 - [Scripted metric aggregations](((ref))/search-aggregations-metrics-scripted-metric-aggregation.html) are not available. Refer to <DocLink slug="/serverless/elasticsearch/explore-your-data-aggregations" text="Aggregations"/> for available options.
 
 <DocCallOut title="Other limitations" color="warning">

--- a/serverless/pages/serverless-differences.mdx
+++ b/serverless/pages/serverless-differences.mdx
@@ -30,6 +30,7 @@ text="data stream lifecycle"/>**.
 
   Serverless Elasticsearch manages the underlying Elastic cluster for you, optimizing nodes, shards, and replicas for your use case. 
   Because of this, various management and monitoring APIs, API parameters and settings are not available on Serverless.
+- Certain aggregations are not available. Refer to <DocLink slug="/serverless/elasticsearch/explore-your-data-aggregations" text="Aggregations"/> for available options.
 
 <DocCallOut title="Other limitations" color="warning">
 

--- a/serverless/pages/serverless-differences.mdx
+++ b/serverless/pages/serverless-differences.mdx
@@ -31,7 +31,7 @@ text="data stream lifecycle"/>**.
   Serverless Elasticsearch manages the underlying Elastic cluster for you, optimizing nodes, shards, and replicas for your use case. 
   Because of this, various management and monitoring APIs, API parameters and settings are not available on Serverless.
   <br/>
-- [Scripted metric aggregations](((ref))/search-aggregations-metrics-scripted-metric-aggregation.html) are not available. Refer to <DocLink slug="/serverless/elasticsearch/explore-your-data-aggregations" text="Aggregations"/> for available options.
+- [Scripted metric aggregations](((ref))/search-aggregations-metrics-scripted-metric-aggregation.html) are not available.
 
 <DocCallOut title="Other limitations" color="warning">
 

--- a/serverless/pages/serverless-differences.mdx
+++ b/serverless/pages/serverless-differences.mdx
@@ -30,7 +30,7 @@ text="data stream lifecycle"/>**.
 
   Serverless Elasticsearch manages the underlying Elastic cluster for you, optimizing nodes, shards, and replicas for your use case. 
   Because of this, various management and monitoring APIs, API parameters and settings are not available on Serverless.
-- Certain aggregations are not available. Refer to <DocLink slug="/serverless/elasticsearch/explore-your-data-aggregations" text="Aggregations"/> for available options.
+- [Scripted metric aggregations](((ref))/search-aggregations-metrics-scripted-metric-aggregation.html) are not available. Refer to <DocLink slug="/serverless/elasticsearch/explore-your-data-aggregations" text="Aggregations"/> for available options.
 
 <DocCallOut title="Other limitations" color="warning">
 


### PR DESCRIPTION
Scripted metric aggregations are not available in Serverless. See also https://github.com/elastic/elasticsearch/pull/112161

Previews:
* [Differences page](https://elastic-dot-co-docs-production-oapkg1qid-elastic-dev.vercel.app/current/serverless/elasticsearch/differences)
* [Aggregations page](https://elastic-dot-co-docs-production-oapkg1qid-elastic-dev.vercel.app/current/serverless/elasticsearch/explore-your-data-aggregations)