### PR TITLE
[DOCS] Add link to Elastic Cloud SAML SSO details

### DIFF
--- a/serverless/pages/manage-access-to-org.mdx
+++ b/serverless/pages/manage-access-to-org.mdx
@@ -7,6 +7,8 @@ tags: [ 'serverless', 'general', 'organization', 'overview' ]
 
 To allow other users to interact with your projects, you must invite them to join your organization and grant them access to your organization resources and instances.
 
+Alternatively, [configure ((ecloud)) SAML SSO](((cloud))/ec-saml-sso.html) to enable your organization members to join the {ecloud} organization automatically. <DocBadge template="technical preview" />
+
 1. Go to the user icon on the header bar and select **Organization**.
 
 2. Click **Invite members**.

--- a/serverless/pages/manage-access-to-org.mdx
+++ b/serverless/pages/manage-access-to-org.mdx
@@ -7,7 +7,7 @@ tags: [ 'serverless', 'general', 'organization', 'overview' ]
 
 To allow other users to interact with your projects, you must invite them to join your organization and grant them access to your organization resources and instances.
 
-Alternatively, [configure ((ecloud)) SAML SSO](((cloud))/ec-saml-sso.html) to enable your organization members to join the {ecloud} organization automatically. <DocBadge template="technical preview" />
+Alternatively, [configure ((ecloud)) SAML SSO](((cloud))/ec-saml-sso.html) to enable your organization members to join the ((ecloud)) organization automatically. <DocBadge template="technical preview" />
 
 1. Go to the user icon on the header bar and select **Organization**.
 


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/cloud/pull/130976

It adds a link from https://www.elastic.co/docs/current/serverless/general/manage-access-to-organization to a new page under https://www.elastic.co/guide/en/cloud/current/ec-organizations.html

### Preview

https://elastic-dot-co-docs-production-ehjmlh7f2-elastic-dev.vercel.app/current/serverless/general/manage-access-to-organization

NOTE: The link within that preview will work after https://github.com/elastic/docs/pull/3048 is merged