### PR TITLE
Security projects new retention settings

### DIFF
--- a/serverless/pages/manage-your-project.mdx
+++ b/serverless/pages/manage-your-project.mdx
@@ -97,6 +97,30 @@ Each project type offers different settings that let you adjust the performance 
   </DocRow>
   <DocRow>
     <DocCell>
+      **Data Retention - Maximum data retention period**
+    </DocCell>
+    <DocCell>
+      When enabled, this setting determines the maximum length of time that data can be retained in any data streams of this project.
+
+      Editing this setting replaces the data retention set for all data streams of the project that have a longer data retention defined. Data older than the new maximum retention period that you set is permanently deleted.
+    </DocCell>
+    <DocCell>
+      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>
+      **Data Retention - Default data retention period**
+    </DocCell>
+    <DocCell>
+      When enabled, this setting determines the default retention period that is automatically applied to all data streams in your project that do not have a custom retention period already set.
+    </DocCell>
+    <DocCell>
+      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+    </DocCell>
+  </DocRow>
+  <DocRow>
+    <DocCell>
       **Project features**
     </DocCell>
     <DocCell>

--- a/serverless/pages/manage-your-project.mdx
+++ b/serverless/pages/manage-your-project.mdx
@@ -96,10 +96,10 @@ Each project type offers different settings that let you adjust the performance 
     </DocCell>
   </DocRow>
   <DocRow>
+    <DocCell/>
     <DocCell>
-      **Data Retention - Maximum data retention period**
-    </DocCell>
-    <DocCell>
+      **Maximum data retention period**
+
       When enabled, this setting determines the maximum length of time that data can be retained in any data streams of this project.
 
       Editing this setting replaces the data retention set for all data streams of the project that have a longer data retention defined. Data older than the new maximum retention period that you set is permanently deleted.
@@ -109,10 +109,10 @@ Each project type offers different settings that let you adjust the performance 
     </DocCell>
   </DocRow>
   <DocRow>
+    <DocCell/>
     <DocCell>
-      **Data Retention - Default data retention period**
-    </DocCell>
-    <DocCell>
+      **Default data retention period**
+
       When enabled, this setting determines the default retention period that is automatically applied to all data streams in your project that do not have a custom retention period already set.
     </DocCell>
     <DocCell>


### PR DESCRIPTION
This PR adds 2 new options (maximum retention and default retention) to the Data retention project settings. These settings are valid for Security project only.

They're now visible on production.

Note: I'm documenting them where all other similar settings are documented. There is a page about Security project settings un the Security docs tree, which contains a simple link to the central project settings page, which I haven't touched to not scatter the information.

Closes: https://github.com/elastic/platform-docs-team/issues/491