### PR TITLE
Delete solution badges

### DIFF
--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 The list of available connectors varies by project type.
 

--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 The list of available connectors varies by project type.
 
 <DocRelatedArticles

--- a/serverless/pages/action-connectors.mdx
+++ b/serverless/pages/action-connectors.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 The list of available connectors varies by project type.
 
 <DocRelatedArticles

--- a/serverless/pages/api-keys.mdx
+++ b/serverless/pages/api-keys.mdx
@@ -6,7 +6,7 @@ tags: ["serverless", "Elasticsearch", "Observability", "Security"]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 API keys are security mechanisms used to authenticate and authorize access to ((stack)) resources,
 and ensure that only authorized users or applications are able to interact with the ((stack)).

--- a/serverless/pages/api-keys.mdx
+++ b/serverless/pages/api-keys.mdx
@@ -6,11 +6,13 @@ tags: ["serverless", "Elasticsearch", "Observability", "Security"]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 API keys are security mechanisms used to authenticate and authorize access to ((stack)) resources,
 and ensure that only authorized users or applications are able to interact with the ((stack)).
 

--- a/serverless/pages/api-keys.mdx
+++ b/serverless/pages/api-keys.mdx
@@ -6,8 +6,11 @@ tags: ["serverless", "Elasticsearch", "Observability", "Security"]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 API keys are security mechanisms used to authenticate and authorize access to ((stack)) resources,
 and ensure that only authorized users or applications are able to interact with the ((stack)).
 

--- a/serverless/pages/custom-roles.mdx
+++ b/serverless/pages/custom-roles.mdx
@@ -10,10 +10,12 @@ tags: [ 'serverless', 'Elasticsearch', 'Security' ]
 
 <DocIf condition={"((serverlessCustomRoles))" === "true"}>
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((security))
+
 The built-in <DocLink slug="/serverless/general/assign-user-roles" section="organization-level-roles">organization-level roles</DocLink> and <DocLink slug="/serverless/general/assign-user-roles" section="instance-access-roles">instance access roles</DocLink> are great for getting started with ((serverless-full)), and for system administrators who do not need more restrictive access.
 
 As an administrator, however, you have the ability to create your own roles to describe exactly the kind of access your users should have within a specific project.

--- a/serverless/pages/custom-roles.mdx
+++ b/serverless/pages/custom-roles.mdx
@@ -10,7 +10,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Security' ]
 
 <DocIf condition={"((serverlessCustomRoles))" === "true"}>
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="security" />
 
 The built-in <DocLink slug="/serverless/general/assign-user-roles" section="organization-level-roles">organization-level roles</DocLink> and <DocLink slug="/serverless/general/assign-user-roles" section="instance-access-roles">instance access roles</DocLink> are great for getting started with ((serverless-full)), and for system administrators who do not need more restrictive access.
 

--- a/serverless/pages/custom-roles.mdx
+++ b/serverless/pages/custom-roles.mdx
@@ -10,8 +10,10 @@ tags: [ 'serverless', 'Elasticsearch', 'Security' ]
 
 <DocIf condition={"((serverlessCustomRoles))" === "true"}>
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((security))
 The built-in <DocLink slug="/serverless/general/assign-user-roles" section="organization-level-roles">organization-level roles</DocLink> and <DocLink slug="/serverless/general/assign-user-roles" section="instance-access-roles">instance access roles</DocLink> are great for getting started with ((serverless-full)), and for system administrators who do not need more restrictive access.
 
 As an administrator, however, you have the ability to create your own roles to describe exactly the kind of access your users should have within a specific project.

--- a/serverless/pages/data-views.mdx
+++ b/serverless/pages/data-views.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 A ((data-source)) can point to one or more indices, [data streams](((ref))/data-streams.html), or [index aliases](((ref))/alias.html).
 For example, a ((data-source)) can point to your log data from yesterday or all indices that contain your data.
 

--- a/serverless/pages/data-views.mdx
+++ b/serverless/pages/data-views.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 A ((data-source)) can point to one or more indices, [data streams](((ref))/data-streams.html), or [index aliases](((ref))/alias.html).
 For example, a ((data-source)) can point to your log data from yesterday or all indices that contain your data.
 

--- a/serverless/pages/data-views.mdx
+++ b/serverless/pages/data-views.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 A ((data-source)) can point to one or more indices, [data streams](((ref))/data-streams.html), or [index aliases](((ref))/alias.html).
 For example, a ((data-source)) can point to your log data from yesterday or all indices that contain your data.

--- a/serverless/pages/debug-grok-expressions.mdx
+++ b/serverless/pages/debug-grok-expressions.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 <div id="xpack-grokdebugger"></div>
 
 You can build and debug grok patterns in the **Grok Debugger** before you use them in your data processing pipelines.

--- a/serverless/pages/debug-grok-expressions.mdx
+++ b/serverless/pages/debug-grok-expressions.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 <div id="xpack-grokdebugger"></div>
 

--- a/serverless/pages/debug-grok-expressions.mdx
+++ b/serverless/pages/debug-grok-expressions.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 <div id="xpack-grokdebugger"></div>
 
 You can build and debug grok patterns in the **Grok Debugger** before you use them in your data processing pipelines.

--- a/serverless/pages/debug-painless-scripts.mdx
+++ b/serverless/pages/debug-painless-scripts.mdx
@@ -6,8 +6,10 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((observability))
+- ((security))
 <div id="painlesslab"></div>
 
 <DocCallOut template="beta" />

--- a/serverless/pages/debug-painless-scripts.mdx
+++ b/serverless/pages/debug-painless-scripts.mdx
@@ -6,10 +6,12 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((observability))
 - ((security))
+
 <div id="painlesslab"></div>
 
 <DocCallOut template="beta" />

--- a/serverless/pages/debug-painless-scripts.mdx
+++ b/serverless/pages/debug-painless-scripts.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
 
 <div id="painlesslab"></div>
 

--- a/serverless/pages/files.mdx
+++ b/serverless/pages/files.mdx
@@ -6,11 +6,13 @@ tags: ["serverless", "Elasticsearch", "Observability", "Security"]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 Several ((serverless-full)) features let you upload files. For example, you can add files to <DocLink slug="/serverless/observability/cases" text="cases" /> or upload a logo to an **Image** panel in a <DocLink slug="/serverless/elasticsearch/explore-your-data-dashboards" text="dashboard" />.
 
 You can access these uploaded files in **((project-settings)) → ((manage-app)) → ((files-app))**.

--- a/serverless/pages/files.mdx
+++ b/serverless/pages/files.mdx
@@ -6,8 +6,11 @@ tags: ["serverless", "Elasticsearch", "Observability", "Security"]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 Several ((serverless-full)) features let you upload files. For example, you can add files to <DocLink slug="/serverless/observability/cases" text="cases" /> or upload a logo to an **Image** panel in a <DocLink slug="/serverless/elasticsearch/explore-your-data-dashboards" text="dashboard" />.
 
 You can access these uploaded files in **((project-settings)) → ((manage-app)) → ((files-app))**.

--- a/serverless/pages/files.mdx
+++ b/serverless/pages/files.mdx
@@ -6,7 +6,7 @@ tags: ["serverless", "Elasticsearch", "Observability", "Security"]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 Several ((serverless-full)) features let you upload files. For example, you can add files to <DocLink slug="/serverless/observability/cases" text="cases" /> or upload a logo to an **Image** panel in a <DocLink slug="/serverless/elasticsearch/explore-your-data-dashboards" text="dashboard" />.
 

--- a/serverless/pages/fleet-and-elastic-agent.mdx
+++ b/serverless/pages/fleet-and-elastic-agent.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'ingest', 'fleet', 'elastic agent' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
 
 ((agent)) is a single, unified way to add monitoring for logs, metrics, and other types of data to a host.
 It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more.

--- a/serverless/pages/fleet-and-elastic-agent.mdx
+++ b/serverless/pages/fleet-and-elastic-agent.mdx
@@ -6,10 +6,12 @@ tags: [ 'serverless', 'ingest', 'fleet', 'elastic agent' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((observability))
 - ((security))
+
 ((agent)) is a single, unified way to add monitoring for logs, metrics, and other types of data to a host.
 It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more.
 A single agent makes it easier and faster to deploy monitoring across your infrastructure.

--- a/serverless/pages/fleet-and-elastic-agent.mdx
+++ b/serverless/pages/fleet-and-elastic-agent.mdx
@@ -6,8 +6,10 @@ tags: [ 'serverless', 'ingest', 'fleet', 'elastic agent' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((observability))
+- ((security))
 ((agent)) is a single, unified way to add monitoring for logs, metrics, and other types of data to a host.
 It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more.
 A single agent makes it easier and faster to deploy monitoring across your infrastructure.

--- a/serverless/pages/general-developer-tools.mdx
+++ b/serverless/pages/general-developer-tools.mdx
@@ -26,35 +26,35 @@ tags: [ 'serverless', 'dev tools', 'overview' ]
         <DocCell><DocLink slug="/serverless/devtools/run-api-requests-in-the-console">Console</DocLink></DocCell>
         <DocCell>Interact with Elastic REST APIs.</DocCell>
         <DocCell>
-            <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-            <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-            <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+            <DocBadge template="elasticsearch" />
+            <DocBadge template="observability" />
+            <DocBadge template="security" />
         </DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/profile-queries-and-aggregations">((searchprofiler))</DocLink></DocCell>
         <DocCell>Inspect and analyze your search queries.</DocCell>
         <DocCell>
-            <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-            <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-            <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+            <DocBadge template="elasticsearch" />
+            <DocBadge template="observability" />
+            <DocBadge template="security" />
         </DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/debug-grok-expressions">Grok Debugger</DocLink></DocCell>
         <DocCell>Build and debug grok patterns before you use them in your data processing pipelines.</DocCell>
         <DocCell>
-            <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-            <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-            <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+            <DocBadge template="elasticsearch" />
+            <DocBadge template="observability" />
+            <DocBadge template="security" />
         </DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/debug-painless-scripts">Painless Lab</DocLink></DocCell>
         <DocCell>Use an interactive code editor to test and debug Painless scripts in real time.</DocCell>
         <DocCell>
-            <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-            <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+            <DocBadge template="observability" />
+            <DocBadge template="security" />
         </DocCell>
     </DocRow>
 </DocTable>

--- a/serverless/pages/general-developer-tools.mdx
+++ b/serverless/pages/general-developer-tools.mdx
@@ -26,35 +26,35 @@ tags: [ 'serverless', 'dev tools', 'overview' ]
         <DocCell><DocLink slug="/serverless/devtools/run-api-requests-in-the-console">Console</DocLink></DocCell>
         <DocCell>Interact with Elastic REST APIs.</DocCell>
         <DocCell>
-            <DocBadge template="elasticsearch" />
-            <DocBadge template="observability" />
-            <DocBadge template="security" />
-        </DocCell>
+            
+- ((es))
+- ((observability))
+- ((security))</DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/profile-queries-and-aggregations">((searchprofiler))</DocLink></DocCell>
         <DocCell>Inspect and analyze your search queries.</DocCell>
         <DocCell>
-            <DocBadge template="elasticsearch" />
-            <DocBadge template="observability" />
-            <DocBadge template="security" />
-        </DocCell>
+            
+- ((es))
+- ((observability))
+- ((security))</DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/debug-grok-expressions">Grok Debugger</DocLink></DocCell>
         <DocCell>Build and debug grok patterns before you use them in your data processing pipelines.</DocCell>
         <DocCell>
-            <DocBadge template="elasticsearch" />
-            <DocBadge template="observability" />
-            <DocBadge template="security" />
-        </DocCell>
+            
+- ((es))
+- ((observability))
+- ((security))</DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/debug-painless-scripts">Painless Lab</DocLink></DocCell>
         <DocCell>Use an interactive code editor to test and debug Painless scripts in real time.</DocCell>
         <DocCell>
-            <DocBadge template="observability" />
-            <DocBadge template="security" />
-        </DocCell>
+            
+- ((observability))
+- ((security))</DocCell>
     </DocRow>
 </DocTable>

--- a/serverless/pages/general-developer-tools.mdx
+++ b/serverless/pages/general-developer-tools.mdx
@@ -53,8 +53,8 @@ tags: [ 'serverless', 'dev tools', 'overview' ]
         <DocCell><DocLink slug="/serverless/devtools/debug-painless-scripts">Painless Lab</DocLink></DocCell>
         <DocCell>Use an interactive code editor to test and debug Painless scripts in real time.</DocCell>
         <DocCell>
-            
-- ((observability))
-- ((security))</DocCell>
+        - ((observability))
+        - ((security))
+        </DocCell>
     </DocRow>
 </DocTable>

--- a/serverless/pages/general-developer-tools.mdx
+++ b/serverless/pages/general-developer-tools.mdx
@@ -26,28 +26,28 @@ tags: [ 'serverless', 'dev tools', 'overview' ]
         <DocCell><DocLink slug="/serverless/devtools/run-api-requests-in-the-console">Console</DocLink></DocCell>
         <DocCell>Interact with Elastic REST APIs.</DocCell>
         <DocCell>
-            
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/profile-queries-and-aggregations">((searchprofiler))</DocLink></DocCell>
         <DocCell>Inspect and analyze your search queries.</DocCell>
         <DocCell>
-            
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/debug-grok-expressions">Grok Debugger</DocLink></DocCell>
         <DocCell>Build and debug grok patterns before you use them in your data processing pipelines.</DocCell>
         <DocCell>
-            
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
     </DocRow>
     <DocRow>
         <DocCell><DocLink slug="/serverless/devtools/debug-painless-scripts">Painless Lab</DocLink></DocCell>

--- a/serverless/pages/index-management.mdx
+++ b/serverless/pages/index-management.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 Elastic's index management features are an easy, convenient way to manage your cluster's indices, data streams, index templates, and enrich policies.
 Practicing good index management ensures your data is stored correctly and in the most cost-effective way possible.
 {/* <DocLink id="enElasticsearchReferenceDataStreams">data streams</DocLink> , and <DocLink id="enElasticsearchReferenceIndexTemplates">index

--- a/serverless/pages/index-management.mdx
+++ b/serverless/pages/index-management.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 Elastic's index management features are an easy, convenient way to manage your cluster's indices, data streams, index templates, and enrich policies.
 Practicing good index management ensures your data is stored correctly and in the most cost-effective way possible.

--- a/serverless/pages/index-management.mdx
+++ b/serverless/pages/index-management.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 Elastic's index management features are an easy, convenient way to manage your cluster's indices, data streams, index templates, and enrich policies.
 Practicing good index management ensures your data is stored correctly and in the most cost-effective way possible.
 {/* <DocLink id="enElasticsearchReferenceDataStreams">data streams</DocLink> , and <DocLink id="enElasticsearchReferenceIndexTemplates">index

--- a/serverless/pages/ingest-pipelines.mdx
+++ b/serverless/pages/ingest-pipelines.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 [((ingest-pipelines-cap))](((ref))/ingest.html) let you perform common transformations on your data before indexing.
 For example, you can use pipelines to remove fields, extract values from text, and enrich your data.
 

--- a/serverless/pages/ingest-pipelines.mdx
+++ b/serverless/pages/ingest-pipelines.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 [((ingest-pipelines-cap))](((ref))/ingest.html) let you perform common transformations on your data before indexing.
 For example, you can use pipelines to remove fields, extract values from text, and enrich your data.

--- a/serverless/pages/ingest-pipelines.mdx
+++ b/serverless/pages/ingest-pipelines.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 [((ingest-pipelines-cap))](((ref))/ingest.html) let you perform common transformations on your data before indexing.
 For example, you can use pipelines to remove fields, extract values from text, and enrich your data.
 

--- a/serverless/pages/integrations.mdx
+++ b/serverless/pages/integrations.mdx
@@ -6,8 +6,10 @@ tags: [ 'serverless', 'ingest', 'integration' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((observability))
+- ((security))
 Elastic integrations are a streamlined way to connect your data to Elastic.
 Integrations are available for popular services and platforms, like Nginx, AWS, and MongoDB,
 as well as many generic input types like log files.

--- a/serverless/pages/integrations.mdx
+++ b/serverless/pages/integrations.mdx
@@ -6,10 +6,12 @@ tags: [ 'serverless', 'ingest', 'integration' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((observability))
 - ((security))
+
 Elastic integrations are a streamlined way to connect your data to Elastic.
 Integrations are available for popular services and platforms, like Nginx, AWS, and MongoDB,
 as well as many generic input types like log files.

--- a/serverless/pages/integrations.mdx
+++ b/serverless/pages/integrations.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'ingest', 'integration' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
 
 Elastic integrations are a streamlined way to connect your data to Elastic.
 Integrations are available for popular services and platforms, like Nginx, AWS, and MongoDB,

--- a/serverless/pages/logstash-pipelines.mdx
+++ b/serverless/pages/logstash-pipelines.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 In **((project-settings)) → ((manage-app)) → ((ls-pipelines-app))**, you can control multiple ((ls)) instances and pipeline configurations.
 
 ![((ls-pipelines-app))"](../images/logstash-pipelines-management.png)

--- a/serverless/pages/logstash-pipelines.mdx
+++ b/serverless/pages/logstash-pipelines.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 In **((project-settings)) → ((manage-app)) → ((ls-pipelines-app))**, you can control multiple ((ls)) instances and pipeline configurations.
 
 ![((ls-pipelines-app))"](../images/logstash-pipelines-management.png)

--- a/serverless/pages/logstash-pipelines.mdx
+++ b/serverless/pages/logstash-pipelines.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 In **((project-settings)) → ((manage-app)) → ((ls-pipelines-app))**, you can control multiple ((ls)) instances and pipeline configurations.
 

--- a/serverless/pages/machine-learning.mdx
+++ b/serverless/pages/machine-learning.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to:  <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to:  <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 To view your ((ml)) resources, go to **((project-settings)) → ((manage-app)) → ((ml-app))**:
 

--- a/serverless/pages/machine-learning.mdx
+++ b/serverless/pages/machine-learning.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 To view your ((ml)) resources, go to **((project-settings)) → ((manage-app)) → ((ml-app))**:
 
 !["Anomaly detection job management"](../images/ml-security-management.png)

--- a/serverless/pages/machine-learning.mdx
+++ b/serverless/pages/machine-learning.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to:  <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 To view your ((ml)) resources, go to **((project-settings)) → ((manage-app)) → ((ml-app))**:
 
 !["Anomaly detection job management"](../images/ml-security-management.png)

--- a/serverless/pages/maintenance-windows.mdx
+++ b/serverless/pages/maintenance-windows.mdx
@@ -6,10 +6,12 @@ tags: [ 'serverless', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((observability))
 - ((security))
+
 <DocCallOut template="technical_preview" />
 You can schedule single or recurring ((maint-windows)) to temporarily reduce rule notifications.
 For example, a maintenance window prevents false alarms during planned outages.

--- a/serverless/pages/maintenance-windows.mdx
+++ b/serverless/pages/maintenance-windows.mdx
@@ -6,8 +6,10 @@ tags: [ 'serverless', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((observability))
+- ((security))
 <DocCallOut template="technical_preview" />
 You can schedule single or recurring ((maint-windows)) to temporarily reduce rule notifications.
 For example, a maintenance window prevents false alarms during planned outages.

--- a/serverless/pages/maintenance-windows.mdx
+++ b/serverless/pages/maintenance-windows.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="observability" /> <DocBadge template="security" />
 
 <DocCallOut template="technical_preview" />
 You can schedule single or recurring ((maint-windows)) to temporarily reduce rule notifications.

--- a/serverless/pages/manage-your-project.mdx
+++ b/serverless/pages/manage-your-project.mdx
@@ -64,7 +64,7 @@ Each project type offers different settings that let you adjust the performance 
       The **Performance** Search Power setting provides more computing resources in addition to the searchable data cache, in order to respond quickly to higher query volumes and more complex queries. 
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
+      <DocBadge template="elasticsearch" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -77,7 +77,7 @@ Each project type offers different settings that let you adjust the performance 
       Increasing the window results in a bigger portion of time series project data included in the total search-ready data volume.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
+      <DocBadge template="elasticsearch" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -90,9 +90,9 @@ Each project type offers different settings that let you adjust the performance 
       You can specify different retention periods for specific data streams in your project.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -105,7 +105,7 @@ Each project type offers different settings that let you adjust the performance 
       Editing this setting replaces the data retention set for all data streams of the project that have a longer data retention defined. Data older than the new maximum retention period that you set is permanently deleted.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -116,7 +116,7 @@ Each project type offers different settings that let you adjust the performance 
       When enabled, this setting determines the default retention period that is automatically applied to all data streams in your project that do not have a custom retention period already set.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -127,7 +127,7 @@ Each project type offers different settings that let you adjust the performance 
       Controls <DocLink slug="/serverless/elasticsearch/manage-project" section="project-features-add-ons">feature tiers and add-on options</DocLink> for your ((elastic-sec)) project.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>  
 </DocTable>
@@ -136,7 +136,7 @@ Each project type offers different settings that let you adjust the performance 
 
 ## Project features and add-ons
 
-<DocBadge template="security" slug="/serverless/security/what-is-security-serverless" /> For ((elastic-sec)) projects, edit the **Project features** to select a feature tier and enable add-on options for specific use cases.
+<DocBadge template="security" /> For ((elastic-sec)) projects, edit the **Project features** to select a feature tier and enable add-on options for specific use cases.
 
 <DocTable columns={[
   {

--- a/serverless/pages/manage-your-project.mdx
+++ b/serverless/pages/manage-your-project.mdx
@@ -64,8 +64,8 @@ Each project type offers different settings that let you adjust the performance 
       The **Performance** Search Power setting provides more computing resources in addition to the searchable data cache, in order to respond quickly to higher query volumes and more complex queries. 
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-    </DocCell>
+      
+- ((es))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -77,8 +77,8 @@ Each project type offers different settings that let you adjust the performance 
       Increasing the window results in a bigger portion of time series project data included in the total search-ready data volume.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-    </DocCell>
+      
+- ((es))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -90,10 +90,10 @@ Each project type offers different settings that let you adjust the performance 
       You can specify different retention periods for specific data streams in your project.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell/>
@@ -105,8 +105,8 @@ Each project type offers different settings that let you adjust the performance 
       Editing this setting replaces the data retention set for all data streams of the project that have a longer data retention defined. Data older than the new maximum retention period that you set is permanently deleted.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell/>
@@ -116,8 +116,8 @@ Each project type offers different settings that let you adjust the performance 
       When enabled, this setting determines the default retention period that is automatically applied to all data streams in your project that do not have a custom retention period already set.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -127,8 +127,8 @@ Each project type offers different settings that let you adjust the performance 
       Controls <DocLink slug="/serverless/elasticsearch/manage-project" section="project-features-add-ons">feature tiers and add-on options</DocLink> for your ((elastic-sec)) project.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((security))</DocCell>
   </DocRow>  
 </DocTable>
 
@@ -136,7 +136,9 @@ Each project type offers different settings that let you adjust the performance 
 
 ## Project features and add-ons
 
-<DocBadge template="security" /> For ((elastic-sec)) projects, edit the **Project features** to select a feature tier and enable add-on options for specific use cases.
+
+- ((security))
+For ((elastic-sec)) projects, edit the **Project features** to select a feature tier and enable add-on options for specific use cases.
 
 <DocTable columns={[
   {

--- a/serverless/pages/manage-your-project.mdx
+++ b/serverless/pages/manage-your-project.mdx
@@ -63,9 +63,7 @@ Each project type offers different settings that let you adjust the performance 
 
       The **Performance** Search Power setting provides more computing resources in addition to the searchable data cache, in order to respond quickly to higher query volumes and more complex queries. 
     </DocCell>
-    <DocCell>
-      
-- ((es))</DocCell>
+    <DocCell>((es))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -76,9 +74,7 @@ Each project type offers different settings that let you adjust the performance 
 
       Increasing the window results in a bigger portion of time series project data included in the total search-ready data volume.
     </DocCell>
-    <DocCell>
-      
-- ((es))</DocCell>
+    <DocCell>((es))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -90,10 +86,10 @@ Each project type offers different settings that let you adjust the performance 
       You can specify different retention periods for specific data streams in your project.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell/>
@@ -104,9 +100,7 @@ Each project type offers different settings that let you adjust the performance 
 
       Editing this setting replaces the data retention set for all data streams of the project that have a longer data retention defined. Data older than the new maximum retention period that you set is permanently deleted.
     </DocCell>
-    <DocCell>
-      
-- ((security))</DocCell>
+    <DocCell>((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell/>
@@ -115,9 +109,7 @@ Each project type offers different settings that let you adjust the performance 
 
       When enabled, this setting determines the default retention period that is automatically applied to all data streams in your project that do not have a custom retention period already set.
     </DocCell>
-    <DocCell>
-      
-- ((security))</DocCell>
+    <DocCell>((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -126,9 +118,7 @@ Each project type offers different settings that let you adjust the performance 
     <DocCell>
       Controls <DocLink slug="/serverless/elasticsearch/manage-project" section="project-features-add-ons">feature tiers and add-on options</DocLink> for your ((elastic-sec)) project.
     </DocCell>
-    <DocCell>
-      
-- ((security))</DocCell>
+    <DocCell>((security))</DocCell>
   </DocRow>  
 </DocTable>
 

--- a/serverless/pages/maps.mdx
+++ b/serverless/pages/maps.mdx
@@ -6,9 +6,11 @@ tags: [ 'serverless', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((security))
+
 In **((project-settings)) → ((maps-app))** you can:
 
 - Build maps with multiple layers and indices.

--- a/serverless/pages/maps.mdx
+++ b/serverless/pages/maps.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="security" />
 
 In **((project-settings)) → ((maps-app))** you can:
 

--- a/serverless/pages/maps.mdx
+++ b/serverless/pages/maps.mdx
@@ -6,8 +6,9 @@ tags: [ 'serverless', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="security" />
+This content applies to: 
 
+- ((security))
 In **((project-settings)) → ((maps-app))** you can:
 
 - Build maps with multiple layers and indices.

--- a/serverless/pages/profile-queries-and-aggregations.mdx
+++ b/serverless/pages/profile-queries-and-aggregations.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 {/* TODO: The following content was copied verbatim from the ES docs on Oct 5, 2023. It should be included through
 transclusion. */}

--- a/serverless/pages/profile-queries-and-aggregations.mdx
+++ b/serverless/pages/profile-queries-and-aggregations.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 {/* TODO: The following content was copied verbatim from the ES docs on Oct 5, 2023. It should be included through
 transclusion. */}
 

--- a/serverless/pages/profile-queries-and-aggregations.mdx
+++ b/serverless/pages/profile-queries-and-aggregations.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 {/* TODO: The following content was copied verbatim from the ES docs on Oct 5, 2023. It should be included through
 transclusion. */}
 

--- a/serverless/pages/project-and-management-settings.mdx
+++ b/serverless/pages/project-and-management-settings.mdx
@@ -9,9 +9,9 @@ tags: [ 'serverless', 'observability', 'security', 'elasticsearch', 'overview' ]
 The documentation in this section describes shared capabilities that are available in multiple solutions.
 Look for the doc badge on each page to see if the page is valid for your solution:
 
-* <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> for the ((es)) solution
-* <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> for the ((observability)) solution
-* <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" /> for the ((security)) solution
+* <DocBadge template="elasticsearch" /> for the ((es)) solution
+* <DocBadge template="observability" /> for the ((observability)) solution
+* <DocBadge template="security" /> for the ((security)) solution
 
 <DocCallOut title="Important">
 Some solutions provide versions of these capabilities tailored to your use case.

--- a/serverless/pages/project-and-management-settings.mdx
+++ b/serverless/pages/project-and-management-settings.mdx
@@ -7,8 +7,11 @@ tags: [ 'serverless', 'observability', 'security', 'elasticsearch', 'overview' ]
 
 <DocBadge template="technical preview" />
 The documentation in this section describes shared capabilities that are available in multiple solutions.
-Look for the doc badge on each page to see if the page is valid for your solution:
+Check to see if each page is valid for your solution:
 
-* <DocBadge template="elasticsearch" /> for the <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="(es) solution"/>
-* <DocBadge template="observability" /> for the <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability)) solution"/>
-* <DocBadge template="security" /> for the <DocLink slug="/serverless/security/what-is-security-serverless" text="((security)) solution"/>
+- ((es))
+for the <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="(es) solution"/>
+- ((observability))
+for the <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability)) solution"/>
+- ((security))
+for the <DocLink slug="/serverless/security/what-is-security-serverless" text="((security)) solution"/>

--- a/serverless/pages/project-and-management-settings.mdx
+++ b/serverless/pages/project-and-management-settings.mdx
@@ -9,9 +9,6 @@ tags: [ 'serverless', 'observability', 'security', 'elasticsearch', 'overview' ]
 The documentation in this section describes shared capabilities that are available in multiple solutions.
 Check to see if each page is valid for your solution:
 
-- ((es))
-for the <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="(es) solution"/>
-- ((observability))
-for the <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability)) solution"/>
-- ((security))
-for the <DocLink slug="/serverless/security/what-is-security-serverless" text="((security)) solution"/>
+- <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="(es)"/>
+- <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability))"/>
+- <DocLink slug="/serverless/security/what-is-security-serverless" text="((security))"/>

--- a/serverless/pages/project-and-management-settings.mdx
+++ b/serverless/pages/project-and-management-settings.mdx
@@ -9,6 +9,6 @@ tags: [ 'serverless', 'observability', 'security', 'elasticsearch', 'overview' ]
 The documentation in this section describes shared capabilities that are available in multiple solutions.
 Check to see if each page is valid for your solution:
 
-- <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="(es)"/>
+- <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="((es))"/>
 - <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability))"/>
 - <DocLink slug="/serverless/security/what-is-security-serverless" text="((security))"/>

--- a/serverless/pages/project-and-management-settings.mdx
+++ b/serverless/pages/project-and-management-settings.mdx
@@ -9,16 +9,6 @@ tags: [ 'serverless', 'observability', 'security', 'elasticsearch', 'overview' ]
 The documentation in this section describes shared capabilities that are available in multiple solutions.
 Look for the doc badge on each page to see if the page is valid for your solution:
 
-* <DocBadge template="elasticsearch" /> for the ((es)) solution
-* <DocBadge template="observability" /> for the ((observability)) solution
-* <DocBadge template="security" /> for the ((security)) solution
-
-<DocCallOut title="Important">
-Some solutions provide versions of these capabilities tailored to your use case.
-Read the main solution docs to learn how to use those capabilities:
-
-* <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="((es-serverless)) docs"/>
-* <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability)) serverless docs"/>
-* <DocLink slug="/serverless/security/what-is-security-serverless" text="((security)) serverless docs"/>
-
-</DocCallOut>
+* <DocBadge template="elasticsearch" /> for the <DocLink slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" text="(es) solution"/>
+* <DocBadge template="observability" /> for the <DocLink slug="/serverless/observability/what-is-observability-serverless" text="((observability)) solution"/>
+* <DocBadge template="security" /> for the <DocLink slug="/serverless/security/what-is-security-serverless" text="((security)) solution"/>

--- a/serverless/pages/project-settings.mdx
+++ b/serverless/pages/project-settings.mdx
@@ -55,10 +55,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     <DocCell>
       Create and manage reusable connectors for triggering actions.
     </DocCell>
-      <DocCell>
-      - ((es))
-      - ((security))
-      </DocCell>
+    <DocCell>
+    - ((es))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocIf condition={"((serverlessCustomRoles))" === "true"}>
     <DocRow>

--- a/serverless/pages/project-settings.mdx
+++ b/serverless/pages/project-settings.mdx
@@ -34,10 +34,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage keys that can send requests on behalf of users.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -47,8 +47,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Bulk assign asset criticality to multiple entities by importing a text file.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((security))</DocCell>
     </DocRow>
   <DocRow>
     <DocCell>
@@ -58,18 +58,18 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage reusable connectors for triggering actions.
     </DocCell>
       <DocCell>
-        <DocBadge template="elasticsearch" />
-        <DocBadge template="security" />
-    </DocCell>
+        
+- ((es))
+- ((security))</DocCell>
   </DocRow>
   <DocIf condition={"((serverlessCustomRoles))" === "true"}>
     <DocRow>
       <DocCell><DocLink slug="/serverless/custom-roles"/></DocCell>
       <DocCell>Create and manage roles that grant privileges within your project.</DocCell>
       <DocCell>
-        <DocBadge template="elasticsearch" />
-        <DocBadge template="security" />
-      </DocCell>
+        
+- ((es))
+- ((security))</DocCell>
     </DocRow>
   </DocIf>
   <DocRow>
@@ -80,10 +80,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage the fields in the data views that retrieve your data from ((es)).
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
     </DocRow>
     <DocRow>
     <DocCell>
@@ -93,8 +93,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage entity risk scoring, and preview risky entities.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((security))</DocCell>
     </DocRow>  
     <DocRow>
     <DocCell>
@@ -104,10 +104,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage files that are stored in ((kib)).
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -117,10 +117,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       View index settings, mappings, and statistics and perform operations on indices.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -130,10 +130,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage ingest pipelines that parse, transform, and enrich your data.
     </DocCell>
       <DocCell>
-        <DocBadge template="elasticsearch" />
-        <DocBadge template="observability" />
-        <DocBadge template="security" />
-    </DocCell>
+        
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -143,10 +143,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage ((ls)) pipelines that parse, transform, and enrich your data.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -156,10 +156,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     View, export, and import your ((anomaly-detect)) and ((dfanalytics)) jobs and trained models.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -169,9 +169,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Suppress rule notifications for scheduled periods of time.
     </DocCell>
     <DocCell>
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
     <DocRow>
     <DocCell>
@@ -181,8 +181,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create maps from your geographical data.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -192,10 +192,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage and download reports such as CSV files generated from saved searches.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
    <DocRow>
     <DocCell>
@@ -205,8 +205,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
      Create and manage rules that generate alerts.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-    </DocCell>
+      
+- ((es))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -217,10 +217,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       These include dashboards, visualizations, maps, ((data-sources)), and more.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -230,10 +230,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Organize your project and objects into multiple spaces.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -243,10 +243,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create, manage, and assign tags to your saved objects.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -256,9 +256,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Use transforms to pivot existing ((es)) indices into summarized or entity-centric indices.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" />
-      <DocBadge template="observability" />
-      <DocBadge template="security" />
-    </DocCell>
+      
+- ((es))
+- ((observability))
+- ((security))</DocCell>
   </DocRow>
 </DocTable>

--- a/serverless/pages/project-settings.mdx
+++ b/serverless/pages/project-settings.mdx
@@ -34,10 +34,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage keys that can send requests on behalf of users.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -46,9 +46,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     <DocCell>
       Bulk assign asset criticality to multiple entities by importing a text file.
     </DocCell>
-    <DocCell>
-      
-- ((security))</DocCell>
+    <DocCell>((security))</DocCell>
     </DocRow>
   <DocRow>
     <DocCell>
@@ -80,10 +78,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage the fields in the data views that retrieve your data from ((es)).
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
     </DocRow>
     <DocRow>
     <DocCell>
@@ -92,9 +90,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     <DocCell>
       Manage entity risk scoring, and preview risky entities.
     </DocCell>
-    <DocCell>
-      
-- ((security))</DocCell>
+    <DocCell>((security))</DocCell>
     </DocRow>  
     <DocRow>
     <DocCell>
@@ -104,10 +100,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage files that are stored in ((kib)).
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -117,10 +113,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       View index settings, mappings, and statistics and perform operations on indices.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -130,10 +126,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage ingest pipelines that parse, transform, and enrich your data.
     </DocCell>
       <DocCell>
-        
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -143,10 +139,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage ((ls)) pipelines that parse, transform, and enrich your data.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -156,10 +152,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     View, export, and import your ((anomaly-detect)) and ((dfanalytics)) jobs and trained models.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -169,9 +165,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Suppress rule notifications for scheduled periods of time.
     </DocCell>
     <DocCell>
-      
-- ((observability))
-- ((security))</DocCell>
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
     <DocRow>
     <DocCell>
@@ -180,9 +176,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     <DocCell>
       Create maps from your geographical data.
     </DocCell>
-    <DocCell>
-      
-- ((security))</DocCell>
+    <DocCell>((security))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -192,10 +186,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage and download reports such as CSV files generated from saved searches.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
    <DocRow>
     <DocCell>
@@ -204,9 +198,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     <DocCell>
      Create and manage rules that generate alerts.
     </DocCell>
-    <DocCell>
-      
-- ((es))</DocCell>
+    <DocCell>((es))</DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -217,10 +209,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       These include dashboards, visualizations, maps, ((data-sources)), and more.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -230,10 +222,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Organize your project and objects into multiple spaces.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -243,10 +235,10 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create, manage, and assign tags to your saved objects.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
   <DocRow>
     <DocCell>
@@ -256,9 +248,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Use transforms to pivot existing ((es)) indices into summarized or entity-centric indices.
     </DocCell>
     <DocCell>
-      
-- ((es))
-- ((observability))
-- ((security))</DocCell>
+    - ((es))
+    - ((observability))
+    - ((security))
+    </DocCell>
   </DocRow>
 </DocTable>

--- a/serverless/pages/project-settings.mdx
+++ b/serverless/pages/project-settings.mdx
@@ -56,18 +56,18 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage reusable connectors for triggering actions.
     </DocCell>
       <DocCell>
-        
-- ((es))
-- ((security))</DocCell>
+      - ((es))
+      - ((security))
+      </DocCell>
   </DocRow>
   <DocIf condition={"((serverlessCustomRoles))" === "true"}>
     <DocRow>
       <DocCell><DocLink slug="/serverless/custom-roles"/></DocCell>
       <DocCell>Create and manage roles that grant privileges within your project.</DocCell>
       <DocCell>
-        
-- ((es))
-- ((security))</DocCell>
+      - ((es))
+      - ((security))
+      </DocCell>
     </DocRow>
   </DocIf>
   <DocRow>

--- a/serverless/pages/project-settings.mdx
+++ b/serverless/pages/project-settings.mdx
@@ -34,9 +34,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage keys that can send requests on behalf of users.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -47,7 +47,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Bulk assign asset criticality to multiple entities by importing a text file.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="security" />
     </DocCell>
     </DocRow>
   <DocRow>
@@ -58,8 +58,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage reusable connectors for triggering actions.
     </DocCell>
       <DocCell>
-        <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-        <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+        <DocBadge template="elasticsearch" />
+        <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocIf condition={"((serverlessCustomRoles))" === "true"}>
@@ -67,8 +67,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       <DocCell><DocLink slug="/serverless/custom-roles"/></DocCell>
       <DocCell>Create and manage roles that grant privileges within your project.</DocCell>
       <DocCell>
-        <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-        <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+        <DocBadge template="elasticsearch" />
+        <DocBadge template="security" />
       </DocCell>
     </DocRow>
   </DocIf>
@@ -80,9 +80,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage the fields in the data views that retrieve your data from ((es)).
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
     </DocRow>
     <DocRow>
@@ -93,7 +93,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage entity risk scoring, and preview risky entities.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="security" />
     </DocCell>
     </DocRow>  
     <DocRow>
@@ -104,9 +104,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage files that are stored in ((kib)).
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -117,9 +117,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       View index settings, mappings, and statistics and perform operations on indices.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -130,9 +130,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage ingest pipelines that parse, transform, and enrich your data.
     </DocCell>
       <DocCell>
-        <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-        <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-        <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+        <DocBadge template="elasticsearch" />
+        <DocBadge template="observability" />
+        <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -143,9 +143,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create and manage ((ls)) pipelines that parse, transform, and enrich your data.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -156,9 +156,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
     View, export, and import your ((anomaly-detect)) and ((dfanalytics)) jobs and trained models.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -169,8 +169,8 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Suppress rule notifications for scheduled periods of time.
     </DocCell>
     <DocCell>
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
     <DocRow>
@@ -181,7 +181,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create maps from your geographical data.
     </DocCell>
     <DocCell>
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -192,9 +192,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Manage and download reports such as CSV files generated from saved searches.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
    <DocRow>
@@ -205,7 +205,7 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
      Create and manage rules that generate alerts.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
+      <DocBadge template="elasticsearch" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -217,9 +217,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       These include dashboards, visualizations, maps, ((data-sources)), and more.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -230,9 +230,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Organize your project and objects into multiple spaces.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -243,9 +243,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Create, manage, and assign tags to your saved objects.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
   <DocRow>
@@ -256,9 +256,9 @@ To learn more about roles, refer to <DocLink slug="/serverless/general/assign-us
       Use transforms to pivot existing ((es)) indices into summarized or entity-centric indices.
     </DocCell>
     <DocCell>
-      <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
-      <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" />
-      <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+      <DocBadge template="elasticsearch" />
+      <DocBadge template="observability" />
+      <DocBadge template="security" />
     </DocCell>
   </DocRow>
 </DocTable>

--- a/serverless/pages/reports.mdx
+++ b/serverless/pages/reports.mdx
@@ -7,7 +7,7 @@ related: ['serverlessElasticsearchExploreYourDataDiscoverYourData']
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 ((kib)) provides you with several options to share saved searches, dashboards, and visualizations.
 

--- a/serverless/pages/reports.mdx
+++ b/serverless/pages/reports.mdx
@@ -7,8 +7,11 @@ related: ['serverlessElasticsearchExploreYourDataDiscoverYourData']
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 ((kib)) provides you with several options to share saved searches, dashboards, and visualizations.
 
 For example, in **Discover**, you can create and download comma-separated values (CSV) files for saved searches.

--- a/serverless/pages/reports.mdx
+++ b/serverless/pages/reports.mdx
@@ -7,11 +7,13 @@ related: ['serverlessElasticsearchExploreYourDataDiscoverYourData']
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 ((kib)) provides you with several options to share saved searches, dashboards, and visualizations.
 
 For example, in **Discover**, you can create and download comma-separated values (CSV) files for saved searches.

--- a/serverless/pages/rules.mdx
+++ b/serverless/pages/rules.mdx
@@ -11,6 +11,7 @@ related: ['serverlessActionConnectors', 'serverlessElasticsearchExploreYourDataA
 This content applies to:
 
 - ((es))
+
 In general, a rule consists of three parts:
 
 * _Conditions_: what needs to be detected?

--- a/serverless/pages/rules.mdx
+++ b/serverless/pages/rules.mdx
@@ -7,8 +7,9 @@ related: ['serverlessActionConnectors', 'serverlessElasticsearchExploreYourDataA
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" />
+This content applies to: 
 
+- ((es))
 In general, a rule consists of three parts:
 
 * _Conditions_: what needs to be detected?

--- a/serverless/pages/rules.mdx
+++ b/serverless/pages/rules.mdx
@@ -7,7 +7,8 @@ related: ['serverlessActionConnectors', 'serverlessElasticsearchExploreYourDataA
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 In general, a rule consists of three parts:

--- a/serverless/pages/rules.mdx
+++ b/serverless/pages/rules.mdx
@@ -7,7 +7,7 @@ related: ['serverlessActionConnectors', 'serverlessElasticsearchExploreYourDataA
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" />
+This content applies to: <DocBadge template="elasticsearch" />
 
 In general, a rule consists of three parts:
 

--- a/serverless/pages/run-api-requests-in-the-console.mdx
+++ b/serverless/pages/run-api-requests-in-the-console.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 **Console** lets you interact with [Elasticsearch and Kibana serverless APIs](https://www.elastic.co/docs/api) from your project.
 

--- a/serverless/pages/run-api-requests-in-the-console.mdx
+++ b/serverless/pages/run-api-requests-in-the-console.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 **Console** lets you interact with [Elasticsearch and Kibana serverless APIs](https://www.elastic.co/docs/api) from your project.
 
 Requests are made in the left pane, and responses are displayed in the right pane.

--- a/serverless/pages/run-api-requests-in-the-console.mdx
+++ b/serverless/pages/run-api-requests-in-the-console.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'dev tools', 'how-to' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 **Console** lets you interact with [Elasticsearch and Kibana serverless APIs](https://www.elastic.co/docs/api) from your project.
 
 Requests are made in the left pane, and responses are displayed in the right pane.

--- a/serverless/pages/saved-objects.mdx
+++ b/serverless/pages/saved-objects.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 To get started, go to **((project-settings)) → ((manage-app)) → ((saved-objects-app))**:
 
 ![((saved-objects-app))](../images/saved-object-management.png)

--- a/serverless/pages/saved-objects.mdx
+++ b/serverless/pages/saved-objects.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 To get started, go to **((project-settings)) → ((manage-app)) → ((saved-objects-app))**:
 
 ![((saved-objects-app))](../images/saved-object-management.png)

--- a/serverless/pages/saved-objects.mdx
+++ b/serverless/pages/saved-objects.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 To get started, go to **((project-settings)) → ((manage-app)) → ((saved-objects-app))**:
 

--- a/serverless/pages/spaces.mdx
+++ b/serverless/pages/spaces.mdx
@@ -4,7 +4,7 @@ title: Spaces
 description: Organize your project and objects into multiple spaces.
 ---
 
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 
 Spaces enable you to organize your dashboards and other saved
@@ -43,7 +43,7 @@ if you prefer to create spaces programmatically.
 <DocIf condition={"((serverlessCustomRoles))" === "true"}>
 ## Customize access to space
 
-Customizing access to a space is available for the following project types only: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+Customizing access to a space is available for the following project types only: <DocBadge template="elasticsearch" /> <DocBadge template="security" />
 
 As an administrator, you can define custom roles with specific access to certain spaces and features in a project. Refer to <DocLink slug="/serverless/custom-roles"/>.
 </DocIf>

--- a/serverless/pages/spaces.mdx
+++ b/serverless/pages/spaces.mdx
@@ -4,11 +4,13 @@ title: Spaces
 description: Organize your project and objects into multiple spaces.
 ---
 
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 Spaces enable you to organize your dashboards and other saved
 objects into meaningful categories. Once inside a space, you see only
 the dashboards and saved objects that belong to that space.

--- a/serverless/pages/spaces.mdx
+++ b/serverless/pages/spaces.mdx
@@ -4,9 +4,11 @@ title: Spaces
 description: Organize your project and objects into multiple spaces.
 ---
 
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
-
+- ((es))
+- ((observability))
+- ((security))
 Spaces enable you to organize your dashboards and other saved
 objects into meaningful categories. Once inside a space, you see only
 the dashboards and saved objects that belong to that space.
@@ -43,8 +45,9 @@ if you prefer to create spaces programmatically.
 <DocIf condition={"((serverlessCustomRoles))" === "true"}>
 ## Customize access to space
 
-Customizing access to a space is available for the following project types only: <DocBadge template="elasticsearch" /> <DocBadge template="security" />
-
+Customizing access to a space is available for the following project types only: 
+- ((es))
+- ((security))
 As an administrator, you can define custom roles with specific access to certain spaces and features in a project. Refer to <DocLink slug="/serverless/custom-roles"/>.
 </DocIf>
 

--- a/serverless/pages/tags.mdx
+++ b/serverless/pages/tags.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 To get started, go to **((project-settings)) → ((manage-app)) → ((tags-app))**:
 
 ![Tags management](../images/tag-management.png)

--- a/serverless/pages/tags.mdx
+++ b/serverless/pages/tags.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 To get started, go to **((project-settings)) → ((manage-app)) → ((tags-app))**:
 
 ![Tags management](../images/tag-management.png)

--- a/serverless/pages/tags.mdx
+++ b/serverless/pages/tags.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 To get started, go to **((project-settings)) → ((manage-app)) → ((tags-app))**:
 

--- a/serverless/pages/transforms.mdx
+++ b/serverless/pages/transforms.mdx
@@ -6,8 +6,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 ((transforms-cap)) enable you to convert existing ((es)) indices into summarized
 indices, which provide opportunities for new insights and analytics.
 

--- a/serverless/pages/transforms.mdx
+++ b/serverless/pages/transforms.mdx
@@ -6,11 +6,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 ((transforms-cap)) enable you to convert existing ((es)) indices into summarized
 indices, which provide opportunities for new insights and analytics.
 

--- a/serverless/pages/transforms.mdx
+++ b/serverless/pages/transforms.mdx
@@ -6,7 +6,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 ---
 
 <DocBadge template="technical preview" />
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 ((transforms-cap)) enable you to convert existing ((es)) indices into summarized
 indices, which provide opportunities for new insights and analytics.

--- a/serverless/pages/visualize-library.mdx
+++ b/serverless/pages/visualize-library.mdx
@@ -8,7 +8,7 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 {/* TODO: Figure out best way to deal with inconsistent location of these capabilities in different solutions.
 This content has been removed from the navigation for now because it's not useful in its current state.*/}
 
-This content applies to: <DocBadge template="elasticsearch" slug="/serverless/elasticsearch/what-is-elasticsearch-serverless" /> <DocBadge template="observability" slug="/serverless/observability/what-is-observability-serverless" /> <DocBadge template="security" slug="/serverless/security/what-is-security-serverless" />
+This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
 
 The **Visualize Library** is a space where you can save visualization panels that you may want to use across multiple dashboards. The **Visualize Library** consists of two pages:
 

--- a/serverless/pages/visualize-library.mdx
+++ b/serverless/pages/visualize-library.mdx
@@ -8,11 +8,13 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 {/* TODO: Figure out best way to deal with inconsistent location of these capabilities in different solutions.
 This content has been removed from the navigation for now because it's not useful in its current state.*/}
 
-This content applies to: 
+
+This content applies to:
 
 - ((es))
 - ((observability))
 - ((security))
+
 The **Visualize Library** is a space where you can save visualization panels that you may want to use across multiple dashboards. The **Visualize Library** consists of two pages:
 
 * **Visualizations**

--- a/serverless/pages/visualize-library.mdx
+++ b/serverless/pages/visualize-library.mdx
@@ -8,8 +8,11 @@ tags: [ 'serverless', 'Elasticsearch', 'Observability', 'Security' ]
 {/* TODO: Figure out best way to deal with inconsistent location of these capabilities in different solutions.
 This content has been removed from the navigation for now because it's not useful in its current state.*/}
 
-This content applies to: <DocBadge template="elasticsearch" /> <DocBadge template="observability" /> <DocBadge template="security" />
+This content applies to: 
 
+- ((es))
+- ((observability))
+- ((security))
 The **Visualize Library** is a space where you can save visualization panels that you may want to use across multiple dashboards. The **Visualize Library** consists of two pages:
 
 * **Visualizations**

--- a/serverless/pages/welcome-to-serverless.mdx
+++ b/serverless/pages/welcome-to-serverless.mdx
@@ -14,8 +14,8 @@ focus more on gaining value and insight from your data.
 Elastic provides three serverless solutions available on ((ecloud)):
 
 - **((es))** &mdash; Build powerful applications and search experiences using a rich ecosystem of vector search capabilities, APIs, and libraries.
-- **Elastic ((observability))** &mdash; Monitor your own platforms and services using powerful machine learning and analytics tools with your logs, metrics, traces, and APM data.
-- **Elastic ((security))** &mdash; Detect, investigate, and respond to threats, with SIEM, endpoint protection, and AI-powered analytics capabilities.
+- **((observability))** &mdash; Monitor your own platforms and services using powerful machine learning and analytics tools with your logs, metrics, traces, and APM data.
+- **((security))** &mdash; Detect, investigate, and respond to threats, with SIEM, endpoint protection, and AI-powered analytics capabilities.
 
 Serverless instances of the Elastic Stack that you create in ((ecloud)) are called **serverless projects**.
 


### PR DESCRIPTION
Addresses https://github.com/elastic/docs-content/issues/88
Closes https://github.com/elastic/docs-content/issues/146

We don't have link checking on these badges and the URLs might change again in the future, silently failing, so best to just remove solution badges entirely.

It's less pretty but `¯\_(ツ)_/¯`

### **Screenshot**:

<img width="291" alt="Screenshot 2024-10-29 at 12 03 14" src="https://github.com/user-attachments/assets/291a13d3-396f-4341-8696-4952ab7b8d22">

