### PR TITLE
Fixes security attribute

### DIFF
--- a/serverless/pages/machine-learning.asciidoc
+++ b/serverless/pages/machine-learning.asciidoc
@@ -19,7 +19,7 @@ The {ml-features} that are available vary by project type:
 
 * {es-serverless} projects have trained models.
 * {observability} projects have {anomaly-jobs}.
-* {security} projects have {anomaly-jobs}, {dfanalytics-jobs}, and trained models.
+* {elastic-sec} projects have {anomaly-jobs}, {dfanalytics-jobs}, and trained models.
 
 For more information, go to {ml-docs}/ml-ad-overview.html[{anomaly-detect-cap}], {ml-docs}/ml-dfanalytics.html[{dfanalytics-cap}] and {ml-docs}/ml-nlp.html[Natural language processing].
 

--- a/serverless/pages/manage-access-to-org-user-roles.asciidoc
+++ b/serverless/pages/manage-access-to-org-user-roles.asciidoc
@@ -28,7 +28,7 @@ To subsequently edit the roles assigned to a user:
 Each serverless project type has a set of predefined roles that you can assign to your organization members.
 You can assign the predefined roles:
 
-* globally, for all projects of the same type ({es-serverless}, {observability}, or {security}). In this case, the role will also apply to new projects created later.
+* globally, for all projects of the same type ({es-serverless}, {observability}, or {elastic-sec}). In this case, the role will also apply to new projects created later.
 * individually, for specific projects only. To do that, you have to set the **Role for all** field of that specific project type to **None**.
 
 For example, you can assign a user the developer role for a specific {es-serverless} project:
@@ -61,7 +61,7 @@ endif::[]
 
 [discrete]
 [[general-assign-user-roles-security]]
-=== {security}
+=== {elastic-sec}
 
 * **Admin**. Has full access to project management, properties, and security privileges. Admins log into projects with superuser role privileges.
 * **Editor**. Configures all Security projects. Has read-only access to data indices. Has full access to all project features.

--- a/serverless/pages/project-and-management-settings.asciidoc
+++ b/serverless/pages/project-and-management-settings.asciidoc
@@ -8,7 +8,7 @@ Look for the doc badge on each page to see if the page is valid for your solutio
 
 * {es-badge} for the {es} solution
 * {obs-badge} for the {observability} solution
-* {sec-badge} for the {security} solution
+* {sec-badge} for the {elastic-sec} solution
 
 [IMPORTANT]
 ====
@@ -17,5 +17,5 @@ Read the main solution docs to learn how to use those capabilities:
 
 * <<what-is-elasticsearch-serverless,{es-serverless} docs>>
 * <<what-is-observability-serverless,{observability} serverless docs>>
-* <<what-is-security-serverless,{security} serverless docs>>
+* <<what-is-security-serverless,{elastic-sec} serverless docs>>
 ====

--- a/serverless/pages/welcome-to-serverless.asciidoc
+++ b/serverless/pages/welcome-to-serverless.asciidoc
@@ -20,7 +20,7 @@ Elastic provides three serverless solutions available on {ecloud}:
 
 * **{es}**: Build powerful applications and search experiences using a rich ecosystem of vector search capabilities, APIs, and libraries.
 * **Elastic {observability}**: Monitor your own platforms and services using powerful machine learning and analytics tools with your logs, metrics, traces, and APM data.
-* **Elastic Security**: Detect, investigate, and respond to threats, with SIEM, endpoint protection, and AI-powered analytics capabilities.
+* **{elastic-sec}**: Detect, investigate, and respond to threats, with SIEM, endpoint protection, and AI-powered analytics capabilities.
 
 Serverless instances of the Elastic Stack that you create in {ecloud} are called **serverless projects**.
 


### PR DESCRIPTION
As Liam reported in [this thread](https://elastic.slack.com/archives/C05PP2LEC1X/p1730884542702359), some attributes were incorrect post migration of serverless docs from mdx to asciidoc. This PR updates the occurrences of the `{security}` attribute to `{elastic-sec}`.