### PR TITLE
Adds Open Crawler as ingest method

### DIFF
--- a/serverless/pages/ingest-your-data.asciidoc
+++ b/serverless/pages/ingest-your-data.asciidoc
@@ -13,6 +13,7 @@ You have many options for ingesting, or indexing, data into {es}:
 * <<elasticsearch-ingest-data-file-upload,File Uploader>>
 * <<elasticsearch-ingest-data-through-beats,{beats}>>
 * <<elasticsearch-ingest-data-through-logstash,{ls}>>
+* https://github.com/elastic/crawler[Elastic Open Web Crawler]
 
 The best ingest option(s) for your use case depends on whether you are indexing general content or time series (timestamped) data.
 


### PR DESCRIPTION
### Overview

This PR updates the [Ingest your data](https://www.elastic.co/guide/en/serverless/current/elasticsearch-ingest-your-data.html) page by adding the Elastic Open Web Crawler as an ingest method.

### Related issue

https://github.com/elastic/docs-content/issues/140

### Preview