### PR TITLE
Fix stateful vs serverless attribute conflicts

### DIFF
--- a/serverless/index-serverless-devtools.asciidoc
+++ b/serverless/index-serverless-devtools.asciidoc
@@ -1,8 +1,3 @@
-:doctype: book
-
-include::{asciidoc-dir}/../../shared/versions/stack/master.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-
 [[devtools-developer-tools]]
 == Dev tools
 

--- a/serverless/index-serverless-elasticsearch.asciidoc
+++ b/serverless/index-serverless-elasticsearch.asciidoc
@@ -1,8 +1,3 @@
-:doctype: book
-
-include::{asciidoc-dir}/../../shared/versions/stack/master.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-
 [[what-is-elasticsearch-serverless]]
 == Elasticsearch
 

--- a/serverless/index-serverless-general.asciidoc
+++ b/serverless/index-serverless-general.asciidoc
@@ -1,8 +1,3 @@
-:doctype: book
-
-include::{asciidoc-dir}/../../shared/versions/stack/master.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-
 [[intro]]
 == Welcome to Elastic serverless
 

--- a/serverless/index-serverless-project-settings.asciidoc
+++ b/serverless/index-serverless-project-settings.asciidoc
@@ -1,8 +1,3 @@
-:doctype: book
-
-include::{asciidoc-dir}/../../shared/versions/stack/master.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-
 [[project-and-management-settings]]
 == Project and management settings
 


### PR DESCRIPTION
Removes attribute `include`s in `index*.asciidoc` files that are subsections of the new Serverless book. These files will inherit attributes from [`serverless/index.asciidoc`](https://github.com/elastic/docs-content/blob/main/serverless/index.asciidoc?plain=1).

h/t @leemthompo for pointing out incorrect attribute values on rendered pages!