### PR TITLE
Updates instructions on the Get started page

### DIFF
--- a/serverless/pages/get-started.asciidoc
+++ b/serverless/pages/get-started.asciidoc
@@ -36,7 +36,7 @@ include::../partials/minimum-vcus-detail.asciidoc[]
 
 Create an API key, which will enable you to access the {es} API to ingest and search data.
 
-. Scroll to **Add an API Key** and select **New**.
+. On the **Getting Started** page, scroll to **Add an API Key** and select **New**.
 . In **Create API Key**, enter a name for your key and (optionally) set an expiration date.
 . (Optional) Under **Control Security privileges**, you can set specific access permissions for this API key. By default, it has full access to all APIs.
 . (Optional) The **Add metadata** section allows you to add custom key-value pairs to help identify and organize your API keys.
@@ -58,8 +58,8 @@ You can't recover or retrieve a lost API key. Instead, you must delete the key a
 Next, copy the URL of your API endpoint.
 You'll send all {es} API requests to this URL.
 
-. Scroll to **Copy your connection details**.
-. Find the value for **Elasticsearch Endpoint**.
+. On the **Getting Started** page, scroll to **Copy your connection details** section, and find the **Elasticsearch endpoint** field.
+. Copy the URL for the Elasticsearch endpoint.
 
 Store this value along with your `encoded` API key.
 You'll use both values in the next step.


### PR DESCRIPTION
### Overview

This PR updates the "Copy URL" section of the Elasticsearch -> Get Started page.

The related issue suggested the following wording:

- At the top of the Overview page, click on "View" next to "Connection details."
- Under the "Connection details" section, find the "Elasticsearch Endpoint" field.
- Copy the URL for the Elasticsearch Endpoint, as you will use this URL to send all Elasticsearch API requests.

In the tutorial, we guide users through the Getting Started page of the Serverless deployment, not the Overview page, so I adjusted the instructions accordingly. Additionally, I clarified that these instructions should be followed on the Getting Started page of the deployment.

### Related issue

https://github.com/elastic/docs-content/issues/86