### PR TITLE
Updates page navigation wording

### DIFF
--- a/serverless/pages/project-settings.asciidoc
+++ b/serverless/pages/project-settings.asciidoc
@@ -11,6 +11,7 @@
 preview:[]
 
 Go to **Project settings**, then ** Management** to manage your indices, data views, saved objects, settings, and more.
+You can also open Management by using the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 Access to individual features is governed by Elastic user roles.
 Consult your administrator if you do not have the appropriate access.


### PR DESCRIPTION
This is a follow-up PR to **Serverless updates** #185. 
It updates the wording for navigation to the Management page to align with the new [style guide guidelines](https://docs.elastic.dev/tech-writing-guidelines/ui-writing#referring-to-apps-and-pages).