### PR TITLE
Update Elasticsearch Serverless landing page/overview

### DIFF
--- a/serverless/index-serverless-elasticsearch.asciidoc
+++ b/serverless/index-serverless-elasticsearch.asciidoc
@@ -1,6 +1,5 @@
 [[what-is-elasticsearch-serverless]]
-== {es}
-
+== {es-serverless}
 ++++
 <titleabbrev>{es}</titleabbrev>
 ++++

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -9,7 +9,7 @@ preview:[]
 [TIP]
 ====
 If you haven't used {es} before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main {es} documentation].
-=======
+====
 {es} allows you to build custom applications. Whether you have structured or unstructured text, numerical data, or geospatial data, {es} can efficiently store and index it in a way that supports fast searches.
 
 {es} is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use {es} to search, index, store, and analyze data of all shapes and sizes.

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -8,14 +8,14 @@ preview:[]
 
 [TIP]
 ====
-If you haven't used Elasticsearch before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main Elasticsearch documentation].
+If you haven't used {es} before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main {es} documentation].
 ====
 
-Elasticsearch is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use Elasticsearch to search, index, store, and analyze data of all shapes and sizes.
+{es} is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use {es} to search, index, store, and analyze data of all shapes and sizes.
 
-Elasticsearch is one of the three available project types on <<intro,Elastic Cloud Serverless>>.
+{es} is one of the three available project types on <<intro,{serverless-full}>>.
 
-When using Elasticsearch on Elastic Cloud Serverless you don’t need to worry about managing the infrastructure that keeps Elasticsearch distributed and available: nodes, shards, and replicas. These resources are 100% automated on the serverless platform, which is designed to scale up and down with your workload.
+When using {es} on {serverless-full} you don’t need to worry about managing the infrastructure that keeps {es} distributed and available: nodes, shards, and replicas. These resources are 100% automated on the serverless platform, which is designed to scale up and down with your workload.
 
 This allows you to focus on building your search applications and solutions, without worrying about the underlying infrastructure.
 
@@ -27,22 +27,22 @@ This allows you to focus on building your search applications and solutions, wit
 |===
 | 🚀
 a| [.card-title]#<<elasticsearch-get-started,*Create project →*>># +
-Get started by creating your first Elasticsearch project on serverless.
+Get started by creating your first {es} project on serverless.
 
 | 🔌
-a| [.card-title]#<<elasticsearch-get-started,*Connect to Elasticsearch →*>># +
-Learn how to connect your applications to your serverless Elasticsearch endpoint.
+a| [.card-title]#<<elasticsearch-get-started,*Connect to {es} →*>># +
+Learn how to connect your applications to your {es-serverless} endpoint.
 
 // TODO add coming link to new page about connecting to your serverless endpoint
 // <<elasticsearch-connecting-to-es-serverless-endpoint,*Connect your application →*>>
 
 | 🔄
 a| [.card-title]#<<elasticsearch-ingest-your-data,*Ingest data →*>># +
-Learn how to get your data into Elasticsearch and start building your search application.
+Learn how to get your data into {es} and start building your search application.
 
 | 🛝
 a| [.card-title]#https://www.elastic.co/guide/en/kibana/master/playground.html[*Try Search Playground →*]# +
-Once you've added some data, use the Search Playground to test out queries and combine Elasticsearch with the power of Generative AI in your applications.
+Once you've added some data, use the Search Playground to test out queries and combine {es} with the power of Generative AI in your applications.
 |===
 
 [discrete]
@@ -53,9 +53,9 @@ Once you've added some data, use the Search Playground to test out queries and c
 |===
 | ❓
 a| [.card-title]#<<elasticsearch-differences,*What's different on serverless? →*>># +
-Understand the differences between Elasticsearch on Elastic Cloud Serverless and other deployment types.
+Understand the differences between {es} on {serverless-full} and other deployment types.
 
 | 🧾
 a| [.card-title]#<<elasticsearch-billing,*Billing →*>># +
-Learn about the billing model for Elasticsearch on Elastic Cloud Serverless.
+Learn about the billing model for {es} on {serverless-full}.
 |===

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -11,9 +11,10 @@ preview:[]
 If you haven't used {es} before, first learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[core {es} documentation].
 ====
 
-{es} is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use {es} to search, index, store, and analyze data of all shapes and sizes.
 
 {es} is one of the three available project types on <<intro,{serverless-full}>>.
+
+This project type enables you to use the core functionality of {es}: searching, indexing, storing, and analyzing data of all shapes and sizes.
 
 When using {es} on {serverless-full} you don’t need to worry about managing the infrastructure that keeps {es} distributed and available: nodes, shards, and replicas. These resources are completely automated on the serverless platform, which is designed to scale up and down with your workload.
 

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -11,8 +11,6 @@ preview:[]
 If you haven't used {es} before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main {es} documentation].
 ====
 
-{es} allows you to build custom applications. Whether you have structured or unstructured text, numerical data, or geospatial data, {es} can efficiently store and index it in a way that supports fast searches.
-
 {es} is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use {es} to search, index, store, and analyze data of all shapes and sizes.
 
 {es} is one of the three available project types on <<intro,{serverless-full}>>.

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -43,7 +43,7 @@ Learn how to get your data into {es} and start building your search application.
 
 | 🛝
 a| [.card-title]#https://www.elastic.co/guide/en/kibana/master/playground.html[*Try Playground →*]# +
-After you've added some data, use the Search Playground to test out queries and combine {es} with the power of Generative AI in your applications.
+After you've added some data, use Playground to test out queries and combine {es} with the power of Generative AI in your applications.
 |===
 
 [discrete]

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -1,32 +1,61 @@
-////
-To be rewritten/refined
-////
+// ℹ️ THIS CONTENT IS RENDERERED ON THE index-serverless-elasticsearch.asciidoc PAGE
+// Use the id <<what-is-elasticsearch-serverless>> to link to this page
 
 // :description: Build search solutions and applications with {es}.
 // :keywords: serverless, elasticsearch, overview
 
 preview:[]
 
-Elasticsearch allows you to build custom applications. Whether you have structured or unstructured text, numerical data, or geospatial data, Elasticsearch can efficiently store and index it in a way that supports fast searches.
-
-.Understanding Elasticsearch on serverless
-[IMPORTANT]
+[TIP]
 ====
-Refer to <<elasticsearch-differences,Serverless differences>> and <<elasticsearch-technical-preview-limitations,Technical preview limitations>> for important details, including features and limitations specific to {es} on serverless.
+If you haven't used Elasticsearch before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main Elasticsearch documentation].
 ====
 
+Elasticsearch is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use Elasticsearch to search, index, store, and analyze data of all shapes and sizes.
+
+Elasticsearch is one of the three available project types on <<intro,Elastic Cloud Serverless>>.
+
+When using Elasticsearch on Elastic Cloud Serverless you don’t need to worry about managing the infrastructure that keeps Elasticsearch distributed and available: nodes, shards, and replicas. These resources are 100% automated on the serverless platform, which is designed to scale up and down with your workload.
+
+This allows you to focus on building your search applications and solutions, without worrying about the underlying infrastructure.
+
 [discrete]
-== Get started
+[[elasticsearch-overview-get-started]]
+== Get started 
 
-* <<elasticsearch-get-started,*Create your Elasticsearch project*>>: Create your first Elasticsearch project.
-* <<elasticsearch-ingest-your-data,*Ingest your data*>>: Learn how to get your data into Elasticsearch.
+[cols="2"]
+|===
+| 🚀
+a| [.card-title]#<<elasticsearch-get-started,*Create project →*>># +
+Get started by creating your first Elasticsearch project on serverless.
+
+| 🔌
+a| [.card-title]#<<elasticsearch-get-started,*Connect to Elasticsearch →*>># +
+Learn how to connect your applications to your serverless Elasticsearch endpoint.
+
+// TODO add coming link to new page about connecting to your serverless endpoint
+// <<elasticsearch-connecting-to-es-serverless-endpoint,*Connect your application →*>>
+
+| 🔄
+a| [.card-title]#<<elasticsearch-ingest-your-data,*Ingest data →*>># +
+Learn how to get your data into Elasticsearch and start building your search application.
+
+| 🛝
+a| [.card-title]#https://www.elastic.co/guide/en/kibana/master/playground.html[*Try Search Playground →*]# +
+Once you've added some data, use the Search Playground to test out queries and combine Elasticsearch with the power of Generative AI in your applications.
+|===
 
 [discrete]
-== How to
+[[elasticsearch-overview-learn-more]]
+== Learn more
 
-* <<elasticsearch-search-your-data,*Search your data*>>: Build your queries to perform and combine many types of searches.
-* <<elasticsearch-explore-your-data,*Explore your data*>>: Search, filter your data, and display your findings.
-* <<elasticsearch-explore-your-data-alerting,*Manage alerts*>>: Create rules to detect complex conditions and trigger alerts.
-* <<elasticsearch-dev-tools,*Use developer tools*>>: Send requests with Console and profile queries with Search Profiler.
-* <<elasticsearch-manage-project,*Manage your project*>>: Manage user access, billing, and check performance metrics.
+[cols="2"]
+|===
+| ❓
+a| [.card-title]#<<elasticsearch-differences,*What's different on serverless? →*>># +
+Understand the differences between Elasticsearch on Elastic Cloud Serverless and other deployment types.
 
+| 🧾
+a| [.card-title]#<<elasticsearch-billing,*Billing →*>># +
+Learn about the billing model for Elasticsearch on Elastic Cloud Serverless.
+|===

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -8,16 +8,16 @@ preview:[]
 
 [TIP]
 ====
-If you haven't used {es} before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main {es} documentation].
+If you haven't used {es} before, first learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[core {es} documentation].
 ====
 
 {es} is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use {es} to search, index, store, and analyze data of all shapes and sizes.
 
 {es} is one of the three available project types on <<intro,{serverless-full}>>.
 
-When using {es} on {serverless-full} you don’t need to worry about managing the infrastructure that keeps {es} distributed and available: nodes, shards, and replicas. These resources are 100% automated on the serverless platform, which is designed to scale up and down with your workload.
+When using {es} on {serverless-full} you don’t need to worry about managing the infrastructure that keeps {es} distributed and available: nodes, shards, and replicas. These resources are completely automated on the serverless platform, which is designed to scale up and down with your workload.
 
-This allows you to focus on building your search applications and solutions, without worrying about the underlying infrastructure.
+This automation allows you to focus on building your search applications and solutions.
 
 [discrete]
 [[elasticsearch-overview-get-started]]
@@ -26,7 +26,7 @@ This allows you to focus on building your search applications and solutions, wit
 [cols="2"]
 |===
 | 🚀
-a| [.card-title]#<<elasticsearch-get-started,*Create project →*>># +
+a| [.card-title]#<<elasticsearch-get-started,*Create a project →*>># +
 Get started by creating your first {es} project on serverless.
 
 | 🔌
@@ -36,13 +36,13 @@ Learn how to connect your applications to your {es-serverless} endpoint.
 // TODO add coming link to new page about connecting to your serverless endpoint
 // <<elasticsearch-connecting-to-es-serverless-endpoint,*Connect your application →*>>
 
-| 🔄
+| ⤵️
 a| [.card-title]#<<elasticsearch-ingest-your-data,*Ingest data →*>># +
 Learn how to get your data into {es} and start building your search application.
 
 | 🛝
-a| [.card-title]#https://www.elastic.co/guide/en/kibana/master/playground.html[*Try Search Playground →*]# +
-Once you've added some data, use the Search Playground to test out queries and combine {es} with the power of Generative AI in your applications.
+a| [.card-title]#https://www.elastic.co/guide/en/kibana/master/playground.html[*Try Playground →*]# +
+After you've added some data, use the Search Playground to test out queries and combine {es} with the power of Generative AI in your applications.
 |===
 
 [discrete]

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -10,6 +10,7 @@ preview:[]
 ====
 If you haven't used {es} before, you might want to learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[main {es} documentation].
 ====
+
 {es} allows you to build custom applications. Whether you have structured or unstructured text, numerical data, or geospatial data, {es} can efficiently store and index it in a way that supports fast searches.
 
 {es} is an open source distributed search and analytics engine, scalable data store, and vector database. It’s optimized for speed and relevance on production-scale workloads. Use {es} to search, index, store, and analyze data of all shapes and sizes.
@@ -19,7 +20,6 @@ If you haven't used {es} before, you might want to learn the basics in the https
 When using {es} on {serverless-full} you don’t need to worry about managing the infrastructure that keeps {es} distributed and available: nodes, shards, and replicas. These resources are 100% automated on the serverless platform, which is designed to scale up and down with your workload.
 
 This allows you to focus on building your search applications and solutions, without worrying about the underlying infrastructure.
-
 
 [discrete]
 [[elasticsearch-overview-get-started]]


### PR DESCRIPTION
- 🔴  [Existing page](https://www.elastic.co/guide/en/serverless/current/what-is-elasticsearch-serverless.html)

- 🟢  [Preview new page](https://github.com/user-attachments/assets/b22bdc93-5a57-4a2f-9ddb-f3c10a90fe62)

## Summary

Tries to simplify and clarify the CTAs for readers:

- Added reference to page rendering location
- Expanded Elasticsearch definition and serverless context
- Restructured "Get Started" section into cards
- Added "Learn More" section with cards
- Removed "How to" section and its subsections
- Added tip about checking main Elasticsearch docs for beginners