### PR TITLE
Add banners noting that serverless clients are serverless only

### DIFF
--- a/serverless/pages/clients-dot-net-getting-started.asciidoc
+++ b/serverless/pages/clients-dot-net-getting-started.asciidoc
@@ -6,6 +6,11 @@
 
 preview:[]
 
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 This page guides you through the installation process of the
 .NET client for {es3}, shows you how to initialize the client, and how to perform basic
 {es} operations with it.

--- a/serverless/pages/clients-go-getting-started.asciidoc
+++ b/serverless/pages/clients-go-getting-started.asciidoc
@@ -1,10 +1,15 @@
 [[elasticsearch-go-client-getting-started]]
-= Get started with the serverless Go Client
+= Get started with the serverless Go client
 
 // :description: Set up and use the Go client for {es3}.
 // :keywords: serverless, elasticsearch, go, how to
 
 preview:[]
+
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
 
 This page guides you through the installation process of the Go
 client for {es3}, shows you how to initialize the client, and how to perform basic

--- a/serverless/pages/clients-java-getting-started.asciidoc
+++ b/serverless/pages/clients-java-getting-started.asciidoc
@@ -6,6 +6,11 @@
 
 preview:[]
 
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 This page guides you through the installation process of the Java
 client for {es3}, shows you how to initialize the client, and how to perform basic
 {es} operations with it.

--- a/serverless/pages/clients-nodejs-getting-started.asciidoc
+++ b/serverless/pages/clients-nodejs-getting-started.asciidoc
@@ -6,6 +6,11 @@
 
 preview:[]
 
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 This page guides you through the installation process of the Node.js
 client for {es3}, shows you how to initialize the client, and how to perform basic
 {es} operations with it.

--- a/serverless/pages/clients-php-getting-started.asciidoc
+++ b/serverless/pages/clients-php-getting-started.asciidoc
@@ -6,6 +6,11 @@
 
 preview:[]
 
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 This page guides you through the installation process of the
 PHP client for {es3}, shows you how to initialize the client, and how to perform basic
 {es} operations with it.

--- a/serverless/pages/clients-python-getting-started.asciidoc
+++ b/serverless/pages/clients-python-getting-started.asciidoc
@@ -6,6 +6,11 @@
 
 preview:[]
 
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 This page guides you through the installation process of the Python
 client for {es3}, shows you how to initialize the client, and how to perform basic
 {es} operations with it.

--- a/serverless/pages/clients-ruby-getting-started.asciidoc
+++ b/serverless/pages/clients-ruby-getting-started.asciidoc
@@ -6,6 +6,11 @@
 
 preview:[]
 
+[NOTE]
+====
+This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 This page guides you through the installation process Ruby
 client for {es3}, shows you how to initialize the client, and how to perform basic
 {es} operations with it.

--- a/serverless/pages/clients.asciidoc
+++ b/serverless/pages/clients.asciidoc
@@ -6,7 +6,13 @@
 
 preview:[]
 
-{es3} provides official language clients to use {es} REST APIs.
+{es3} provides official language clients for {es} REST APIs.
+
+[NOTE]
+====
+These clients are for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+====
+
 Currently, the following language clients are supported:
 
 * <<elasticsearch-go-client-getting-started,Go>> | https://github.com/elastic/elasticsearch-serverless-go[Repository]


### PR DESCRIPTION
For Serverless GA: Fix #80 by adding banners to serverless client docs.

**Note:** These won't look right until https://github.com/elastic/docs-content/pull/196/ is merged to fix the `{es}` variable -- for example:

Before #196 is merged:
<img width="597" alt="Screenshot 2024-11-17 at 9 05 34 AM" src="https://github.com/user-attachments/assets/edb4a08d-753a-4a57-acc5-4f93919c7d9c">

After #196 is merged:
<img width="630" alt="Screenshot 2024-11-17 at 9 05 59 AM" src="https://github.com/user-attachments/assets/a071c760-eb11-4391-a843-75fc51f77406">
