### PR TITLE
Adds notes to Connector clients and Connectors page

### DIFF
--- a/serverless/pages/action-connectors.asciidoc
+++ b/serverless/pages/action-connectors.asciidoc
@@ -4,6 +4,11 @@
 // :description: Configure connections to third party systems for use in cases and rules.
 // :keywords: serverless
 
+[NOTE]
+====
+This page is about Kibana connectors that integrate with services like generative AI model providers. If you're looking for Search connectors that synchronize third-party data into {es}, see <<elasticsearch-ingest-data-through-integrations-connector-client,Connector clients>>.
+====
+
 This content applies to: {es-badge} {obs-badge} {sec-badge}
 
 The list of available connectors varies by project type.

--- a/serverless/pages/action-connectors.asciidoc
+++ b/serverless/pages/action-connectors.asciidoc
@@ -6,7 +6,7 @@
 
 [NOTE]
 ====
-This page is about Kibana connectors that integrate with services like generative AI model providers. If you're looking for Search connectors that synchronize third-party data into {es}, see <<elasticsearch-ingest-data-through-integrations-connector-client,Connector clients>>.
+This page is about Kibana connectors that integrate with services like generative AI model providers. If you're looking for Search connectors that synchronize third-party data into {es}, refer to <<elasticsearch-ingest-data-through-integrations-connector-client,Connector clients>>.
 ====
 
 This content applies to: {es-badge} {obs-badge} {sec-badge}

--- a/serverless/pages/ingest-your-data-ingest-data-through-integrations-connector-client.asciidoc
+++ b/serverless/pages/ingest-your-data-ingest-data-through-integrations-connector-client.asciidoc
@@ -6,6 +6,11 @@
 
 [NOTE]
 ====
+This page is about Search connectors that synchronize third-party data into {es}. If you're looking for Kibana connectors to integrate with services like generative AI model providers, see <<action-connectors,Kibana Connectors>>.
+====
+
+[NOTE]
+====
 This page contains high-level instructions about setting up connector clients in your project's UI.
 Because prerequisites and configuration details vary by data source, you'll need to refer to the individual connector documentation for specific details.
 ====

--- a/serverless/pages/ingest-your-data-ingest-data-through-integrations-connector-client.asciidoc
+++ b/serverless/pages/ingest-your-data-ingest-data-through-integrations-connector-client.asciidoc
@@ -6,7 +6,7 @@
 
 [NOTE]
 ====
-This page is about Search connectors that synchronize third-party data into {es}. If you're looking for Kibana connectors to integrate with services like generative AI model providers, see <<action-connectors,Kibana Connectors>>.
+This page is about Search connectors that synchronize third-party data into {es}. If you're looking for Kibana connectors to integrate with services like generative AI model providers, refer to <<action-connectors,Kibana Connectors>>.
 ====
 
 [NOTE]


### PR DESCRIPTION
### Overview
This PR adds notes to the Connector clients and Connectors pages to provide users with more context about the content of these pages.
### Related issue
https://github.com/elastic/docs-content/issues/98
### Preview
Connector [clients](https://docs-content_bk_215.docs-preview.app.elstc.co/guide/en/serverless/current/elasticsearch-ingest-data-through-integrations-connector-client.html)
[Connectors](https://docs-content_bk_215.docs-preview.app.elstc.co/guide/en/serverless/current/action-connectors.html)
