### PR TITLE
[Serverless] Fixes serverless references 

### DIFF
--- a/serverless/index-serverless-general.asciidoc
+++ b/serverless/index-serverless-general.asciidoc
@@ -1,5 +1,5 @@
 [[intro]]
-== Welcome to Elastic serverless
+== Welcome to {serverless-full}
 
 include::{docs-content-root}/serverless/pages/welcome-to-serverless.asciidoc[leveloffset=+2]
 

--- a/serverless/index.asciidoc
+++ b/serverless/index.asciidoc
@@ -11,8 +11,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :sec-badge: <<what-is-security-serverless,image:images/sec-badge.svg[Security]>>
 
 // The values of these attributes are different in stateful vs serverless
-:observability: Elastic Observability Serverless
-:security: Elastic Security Serverless
 
 = Serverless
 

--- a/serverless/pages/manage-billing-stop-project.asciidoc
+++ b/serverless/pages/manage-billing-stop-project.asciidoc
@@ -6,7 +6,7 @@
 
 Got a project you no longer need and don't want to be charged for? Simply delete it.
 
-Warning: All data is lost. Billing for usage is by the hour and any outstanding charges for usage before you deleted the project will still appear on your next bill.
+WARNING: All data is lost. Billing for usage is by the hour and any outstanding charges for usage before you deleted the project will still appear on your next bill.
 
 To stop being charged for a project:
 

--- a/serverless/pages/ml-nlp-auto-scale.asciidoc
+++ b/serverless/pages/ml-nlp-auto-scale.asciidoc
@@ -63,7 +63,7 @@ Increasing the number of threads will make the search processes more performant.
 
 [discrete]
 [[enabling-autoscaling-in-kibana-adaptive-resources]]
-== Enabling autoscaling in Kibana - adaptive resources
+== Enabling autoscaling in {kib} - adaptive resources
 
 You can enable adaptive resources for your models when starting or updating the model deployment.
 Adaptive resources make it possible for {es} to scale up or down the available resources based on the load on the process.
@@ -74,7 +74,7 @@ When the load is low, the number of VCUs that the process can use is automatical
 
 You can choose from three levels of resource usage for your trained model deployment; autoscaling will occur within the selected level's range.
 
-Refer to the tables in the auto-scaling-matrix section to find out the setings for the level you selected.
+Refer to the tables in the auto-scaling-matrix section to find out the settings for the level you selected.
 
 image::images/ml-nlp-deployment.png[ML model deployment with adaptive resources enabled.]
 
@@ -154,7 +154,7 @@ No static allocations for Security and Observability
 
 [discrete]
 [[deployments-on-serverless-optimized-for-search]]
-=== Deployments on serverless optimized for search
+=== Deployments on serverless optimized for Search
 
 [discrete]
 [[adaptive-resources-enabled-for-search]]

--- a/serverless/pages/service-status.asciidoc
+++ b/serverless/pages/service-status.asciidoc
@@ -6,7 +6,7 @@
 Serverless projects run on cloud platforms, which may undergo changes in availability.
 When availability changes, Elastic makes sure to provide you with a current service status.
 
-To check current and past service availability, go to the Elastic serverless https://serverless-preview-status.statuspage.io/[service status] page.
+To check current and past service availability, go to the {serverless-full} https://serverless-preview-status.statuspage.io/[service status] page.
 
 [discrete]
 [[general-serverless-status-subscribe-to-updates]]
@@ -16,7 +16,7 @@ You can be notified about changes to the service status automatically.
 
 To receive service status updates:
 
-. Go to the Elastic serverless https://serverless-preview-status.statuspage.io/[service status] page.
+. Go to the {serverless-full} https://serverless-preview-status.statuspage.io/[service status] page.
 . Select **SUBSCRIBE TO UPDATES**.
 . You can be notified in the following ways:
 +

--- a/serverless/pages/welcome-to-serverless.asciidoc
+++ b/serverless/pages/welcome-to-serverless.asciidoc
@@ -10,15 +10,15 @@
 </style>
 ++++
 
-Elastic serverless products allow you to deploy and use Elastic for your use cases without managing the underlying Elastic cluster,
+{serverless-full} products allow you to deploy and use Elastic for your use cases without managing the underlying Elastic cluster,
 such as nodes, data tiers, and scaling. Serverless instances are fully-managed, autoscaled, and automatically upgraded by Elastic so you can
 focus more on gaining value and insight from your data.
 
 Elastic provides three serverless solutions available on {ecloud}:
 
 * **{es-serverless}**: Build powerful applications and search experiences using a rich ecosystem of vector search capabilities, APIs, and libraries.
-* **{observability}**: Monitor your own platforms and services using powerful machine learning and analytics tools with your logs, metrics, traces, and APM data.
-* **{elastic-sec}**: Detect, investigate, and respond to threats, with SIEM, endpoint protection, and AI-powered analytics capabilities.
+* **{obs-serverless}**: Monitor your own platforms and services using powerful machine learning and analytics tools with your logs, metrics, traces, and APM data.
+* **{sec-serverless}**: Detect, investigate, and respond to threats, with SIEM, endpoint protection, and AI-powered analytics capabilities.
 
 Serverless instances of the Elastic Stack that you create in {ecloud} are called **serverless projects**.
 

--- a/serverless/pages/what-is-elasticsearch-serverless.asciidoc
+++ b/serverless/pages/what-is-elasticsearch-serverless.asciidoc
@@ -12,7 +12,7 @@
 If you haven't used {es} before, first learn the basics in the https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html[core {es} documentation].
 ====
 
-{es} is one of the three available project types on <<intro,{serverless-full}>>.
+{es-serverless} is one of the three available project types on <<intro,{serverless-full}>>.
 
 This project type enables you to use the core functionality of {es}: searching, indexing, storing, and analyzing data of all shapes and sizes.
 


### PR DESCRIPTION
Addresses part of https://github.com/elastic/security-docs/issues/6026 (from our serverless bug bash), mostly in the [general serverless](https://www.elastic.co/guide/en/serverless/current/intro.html) content set.  

Fixes serverless references + a few other slight nits I noticed while browsing. 

Attributes: 
```
:serverless-full:  Elastic Cloud Serverless
:serverless-short: Serverless
:es-serverless:    Elasticsearch Serverless
:es3:              {es-serverless}
:obs-serverless:   Elastic Observability Serverless
:sec-serverless:   Elastic Security Serverless
:serverless-docs:  https://docs.elastic.co/serverless
```