### PR TITLE
Adds definition of time series data

### DIFF
--- a/serverless/pages/manage-your-project.asciidoc
+++ b/serverless/pages/manage-your-project.asciidoc
@@ -36,6 +36,11 @@ The total volume of search-ready data is the sum of the following:
 . The volume of non-time series project data
 . The volume of time series project data included in the Search Boost Window
 
+[NOTE]
+====
+Time series data refers to any document in standard indices or data streams that include the `@timestamp` field. This field determines whether the data will be subject to the Search Boost Window setting.
+====
+
 Each project type offers different settings that let you adjust the performance and volume of search-ready data, as well as the features available in your projects.
 
 [discrete]


### PR DESCRIPTION
### Overview

This PR adds a definition of time series data to the [Manage performance and general settings
](http://localhost:8000/guide/elasticsearch-manage-project.html) page.

### Related issue

https://github.com/elastic/docs-content/issues/216

### Preview

![Screenshot 2024-12-03 at 14 06 26](https://github.com/user-attachments/assets/40692d9c-06d9-48bf-83ee-074226004ee6)

