### PR TITLE
Update welcome-to-serverless.asciidoc

### DIFF
--- a/serverless/pages/welcome-to-serverless.asciidoc
+++ b/serverless/pages/welcome-to-serverless.asciidoc
@@ -48,9 +48,7 @@ You can run https://www.elastic.co/guide/en/cloud/current/ec-getting-started.htm
 | **Cluster management**
 | Fully managed by Elastic.
 | You provision and manage your hosted clusters. Shared responsibility with Elastic.
-| **Cluster management**
-| Fully managed by Elastic.
-| You provision and manage your hosted clusters. Shared responsibility with Elastic.
+
 | **Scaling**
 | Autoscales out of the box.
 | Manual scaling or autoscaling available for you to enable.


### PR DESCRIPTION
Removed redundant cluster management row under `Differences between serverless projects and hosted deployments on Elastic Cloud` section.