### PR TITLE
fix overview page

### DIFF
--- a/serverless/index-serverless-elasticsearch.asciidoc
+++ b/serverless/index-serverless-elasticsearch.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>{es}</titleabbrev>
 ++++
 
+include::./pages/what-is-elasticsearch-serverless.asciidoc[leveloffset=+2]
+
 include::./pages/get-started.asciidoc[leveloffset=+2]
 
 include::./pages/connecting-to-es-endpoint.asciidoc[leveloffset=+2]


### PR DESCRIPTION
a partial was removed from the overview page in https://github.com/elastic/docs-content/pull/191, leading to the page appearing empty. restoring the include statement

before 
<img width="813" alt="image" src="https://github.com/user-attachments/assets/050d186e-ddd8-4954-ab18-3615dbe59b4a">

after
<img width="868" alt="image" src="https://github.com/user-attachments/assets/df946245-cb9d-4ade-970e-c6e370d9afee">