### PR TITLE
Update Java client docs (there's no serverless version)

### DIFF
--- a/serverless/pages/clients-java-getting-started.asciidoc
+++ b/serverless/pages/clients-java-getting-started.asciidoc
@@ -4,14 +4,16 @@
 // :description: Set up and use the Java client for {es3}.
 // :keywords: serverless, elasticsearch, java, how to
 
+This page guides you through the installation process of the Java
+client, shows you how to initialize the client, and how to perform basic
+{es} operations with it.
+
+See the https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html[Java client] documentation for more detailed usage instructions.
+
 [NOTE]
 ====
-This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+The same client is used for {es3}, on-premise and managed Elasticsearch. Some API endpoints are however not available in {es3}.
 ====
-
-This page guides you through the installation process of the Java
-client for {es3}, shows you how to initialize the client, and how to perform basic
-{es} operations with it.
 
 [discrete]
 [[elasticsearch-java-client-getting-started-requirements]]
@@ -29,6 +31,8 @@ show usage with Jackson.
 You can add the Java client to your Java project using
 either Gradle or Maven.
 
+Use the version with the highest version number found on https://search.maven.org/artifact/co.elastic.clients/elasticsearch-java[Maven Central], like `8.16.1`. We refer to it as `elasticVersion` in the configuration examples below.
+
 [discrete]
 [[elasticsearch-java-client-getting-started-using-gradle]]
 === Using Gradle
@@ -38,8 +42,8 @@ You can install the Java client as a Gradle dependency:
 [source,groovy]
 ----
 dependencies {
-    implementation 'co.elastic.clients:elasticsearch-java-serverless:1.0.0-20231031'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
+    implementation "co.elastic.clients:elasticsearch-java:${elasticVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.17.0"
 }
 ----
 
@@ -57,8 +61,8 @@ the following to the `pom.xml` of your project:
 
         <dependency>
             <groupId>co.elastic.clients</groupId>
-            <artifactId>elasticsearch-java-serverless</artifactId>
-            <version>1.0.0-20231031</version>
+            <artifactId>elasticsearch-java</artifactId>
+            <version>${elasticVersion}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates the Java client docs to reflect the fact that there is no dedicated Java client for ES Serverless.