### PR TITLE
Remove authentication realms from Serverless planned features

### DIFF
--- a/serverless/pages/serverless-differences.asciidoc
+++ b/serverless/pages/serverless-differences.asciidoc
@@ -156,7 +156,6 @@ The following features are planned for future support in all {serverless-full} p
 * Snapshot and restore
 * Migrations from non-serverless deployments
 * Audit logging
-* Authentication realms (native/SAML/OIDC/Kerberos/JWT)
 * Clone index API
 * Traffic filtering and VPCs
 


### PR DESCRIPTION
In the current [Serverless docs](https://www.elastic.co/guide/en/serverless/current/elasticsearch-differences.html#elasticsearch-differences-serverless-feature-planned) we state that the following feature is planned:

> Authentication realms (native/SAML/OIDC/Kerberos/JWT)

This statement is not accurate.
Serverless projects will be accessible by customers only via Elastic Cloud users, that support external authentication providers via the BYOIDP Elastic Cloud functionality.

Direct configuration and use of other Elasticsearch realms generally used for Elastic Cloud Hosted deployments (like those mentioned in the list) will not be available in Serverless.