### PR TITLE
Fix issues on client subpages before consolidating

### DIFF
--- a/serverless/pages/clients-go-getting-started.asciidoc
+++ b/serverless/pages/clients-go-getting-started.asciidoc
@@ -1,16 +1,16 @@
 [[elasticsearch-go-client-getting-started]]
-= Get started with the Elasticsearch Go client
+= Get started with the Go client
 
 // :description: Set up and use the Go client.
 // :keywords: serverless, elasticsearch, go, how to
 
 [NOTE]
 ====
-This client is for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
+{es-serverless} uses https://www.elastic.co/guide/en/elasticsearch/client/index.html[standard language clients] for {es} REST APIs. Some API endpoints are <<elasticsearch-differences-serverless-apis-availability,not available>>.
 ====
 
 This page guides you through the installation process of the Go
-client for {es3}, shows you how to initialize the client, and how to perform basic
+client, shows you how to initialize the client, and how to perform basic
 {es} operations with it.
 
 [discrete]

--- a/serverless/pages/clients-python-getting-started.asciidoc
+++ b/serverless/pages/clients-python-getting-started.asciidoc
@@ -1,5 +1,5 @@
 [[elasticsearch-python-client-getting-started]]
-= Get started with the Elasticsearch Python client
+= Get started with the Python client
 
 // :description: Set up and use the Python client for {es3}.
 // :keywords: serverless, elasticsearch, python, how to

--- a/serverless/pages/clients.asciidoc
+++ b/serverless/pages/clients.asciidoc
@@ -4,22 +4,15 @@
 // :description: Index, search, and manage {es} data in your preferred language.
 // :keywords: serverless, elasticsearch, clients, overview
 
-{es3} provides official language clients for {es} REST APIs.
+You can use the following language clients with {es-serverless}:
 
-[NOTE]
-====
-These clients are for use with {es-serverless} only. See also the https://www.elastic.co/guide/en/elasticsearch/client/index.html[{es} clients]. 
-====
-
-Currently, the following language clients are supported:
-
-* <<elasticsearch-go-client-getting-started,Go>> | https://github.com/elastic/elasticsearch-serverless-go[Repository]
-* <<elasticsearch-java-client-getting-started,Java>> | https://github.com/elastic/elasticsearch-java/tree/main/java-client-serverless[Repository]
-* <<elasticsearch-dot-net-client-getting-started,.NET>> | https://github.com/elastic/elasticsearch-net[Repository]
-* <<elasticsearch-nodejs-client-getting-started,Node.JS>> | https://github.com/elastic/elasticsearch-serverless-js[Repository]
-* <<elasticsearch-php-client-getting-started,PHP>> | https://github.com/elastic/elasticsearch-serverless-php[Repository]
-* <<elasticsearch-python-client-getting-started,Python>> | https://github.com/elastic/elasticsearch-serverless-python[Repository]
-* <<elasticsearch-ruby-client-getting-started,Ruby>> | https://github.com/elastic/elasticsearch-serverless-ruby[Repository]
+* <<elasticsearch-go-client-getting-started,Go>> 
+* <<elasticsearch-java-client-getting-started,Java>>
+* <<elasticsearch-dot-net-client-getting-started,.NET>> 
+* <<elasticsearch-nodejs-client-getting-started,Node.JS>>
+* <<elasticsearch-php-client-getting-started,PHP>> 
+* <<elasticsearch-python-client-getting-started,Python>> 
+* <<elasticsearch-ruby-client-getting-started,Ruby>> 
 
 [TIP]
 ====


### PR DESCRIPTION
I'm working on a PR to consolidate the client subpages in the serverless docs and point to the standard/stack clients instead. In the meantime, quick-fixing some issues that crept in with other early PRs in this effort:
- Remove (now inaccurate) serverless banner on the Go subpage
- Remove repository links to avoid conflicts with pointers to standard clients
- Match Java subpage title, mostly for brevity in the left nav