### PR TITLE
[Reference AI] Create reference overviews placeholder

### DIFF
--- a/reference/overviews/reference-overview.md
+++ b/reference/overviews/reference-overview.md
@@ -1,0 +1,37 @@
+---
+title: APIs and reference
+---
+
+Explore the reference documentation for Elastic APIs.
+
+
+## Elasticsearch
+
+- Elasticsearch
+- Elasticsearch Serverless
+
+## Kibana
+
+- Kibana
+- Kibana Serverless
+- Fleet
+- Observability Serverless SLOs
+- Elastic Security
+- Elastic Security Serverless
+
+## Logstash
+
+- Monitoring Logstash
+
+## APM
+
+- APM
+- APM Serverless
+- Observability intake Serverless
+
+## Elastic Cloud
+
+- Elasticsearch Service
+- Elastic Cloud Serverless
+- Elastic Cloud Enterprise
+- Elastic Cloud on Kubernetes

--- a/reference/overviews/security-overview.md
+++ b/reference/overviews/security-overview.md
@@ -1,0 +1,5 @@
+---
+title: Security overview
+---
+
+Can we reuse content from https://www.elastic.co/guide/en/security/current/security-apis.html?


### PR DESCRIPTION
This PR creates a placeholder to store initial drafts of the overview sections L1 required as per [Migration planning - Reference](https://docs.google.com/document/d/1oritpwjd6D6FhP84Wg9Pm6RVgcF1C0n81lpmsl4a2H8/edit?tab=t.0).