### PR TITLE
[Search] Add search approaches content, rename querying-for-search doc

### DIFF
--- a/deploy-manage/production-guidance/optimize-performance/search-speed.md
+++ b/deploy-manage/production-guidance/optimize-performance/search-speed.md
@@ -424,5 +424,5 @@ The `constant_keyword` is not strictly required for this optimization: it is als
 
 ## Default search timeout [_default_search_timeout] 
 
-By default, search requests don’t time out. You can set a timeout using the [`search.default_search_timeout`](../../../solutions/search/querying-for-search-searching.md#search-timeout) setting.
+By default, search requests don’t time out. You can set a timeout using the [`search.default_search_timeout`](../../../solutions/search/querying-for-search.md#search-timeout) setting.
 

--- a/deploy-manage/production-guidance/optimize-performance/search-speed.md
+++ b/deploy-manage/production-guidance/optimize-performance/search-speed.md
@@ -424,5 +424,5 @@ The `constant_keyword` is not strictly required for this optimization: it is als
 
 ## Default search timeout [_default_search_timeout] 
 
-By default, search requests don’t time out. You can set a timeout using the [`search.default_search_timeout`](../../../solutions/search/querying-for-search-searching-with-the-search-api.md#search-timeout) setting.
+By default, search requests don’t time out. You can set a timeout using the [`search.default_search_timeout`](../../../solutions/search/querying-for-search-searching.md#search-timeout) setting.
 

--- a/explore-analyze/aggregations.md
+++ b/explore-analyze/aggregations.md
@@ -21,7 +21,7 @@ An aggregation summarizes your data as metrics, statistics, or other analytics. 
 
 ## Run an aggregation [run-an-agg] 
 
-You can run aggregations as part of a [search](../solutions/search/querying-for-search-searching-with-the-search-api.md) by specifying the [search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html)'s `aggs` parameter. The following search runs a [terms aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) on `my-field`:
+You can run aggregations as part of a [search](../solutions/search/querying-for-search-searching.md) by specifying the [search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html)'s `aggs` parameter. The following search runs a [terms aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) on `my-field`:
 
 ```console
 GET /my-index-000001/_search

--- a/explore-analyze/aggregations.md
+++ b/explore-analyze/aggregations.md
@@ -21,7 +21,7 @@ An aggregation summarizes your data as metrics, statistics, or other analytics. 
 
 ## Run an aggregation [run-an-agg] 
 
-You can run aggregations as part of a [search](../solutions/search/querying-for-search-searching.md) by specifying the [search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html)'s `aggs` parameter. The following search runs a [terms aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) on `my-field`:
+You can run aggregations as part of a [search](../solutions/search/querying-for-search.md) by specifying the [search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html)'s `aggs` parameter. The following search runs a [terms aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) on `my-field`:
 
 ```console
 GET /my-index-000001/_search

--- a/explore-analyze/query-filter.md
+++ b/explore-analyze/query-filter.md
@@ -34,7 +34,7 @@ Refer to [Query languages](#search-analyze-query-languages) for a full overview 
 
 [Query DSL](query-filter/languages/querydsl.md) is a full-featured JSON-style query language that enables complex searching, filtering, and aggregations. It is the original and most powerful query language for {{es}} today.
 
-The [`_search` endpoint](../solutions/search/querying-for-search-searching.md) accepts queries written in Query DSL syntax.
+The [`_search` endpoint](../solutions/search/querying-for-search.md) accepts queries written in Query DSL syntax.
 
 
 #### Search and filter with Query DSL [search-analyze-query-dsl-search-filter]

--- a/explore-analyze/query-filter.md
+++ b/explore-analyze/query-filter.md
@@ -34,7 +34,7 @@ Refer to [Query languages](#search-analyze-query-languages) for a full overview 
 
 [Query DSL](query-filter/languages/querydsl.md) is a full-featured JSON-style query language that enables complex searching, filtering, and aggregations. It is the original and most powerful query language for {{es}} today.
 
-The [`_search` endpoint](../solutions/search/querying-for-search-searching-with-the-search-api.md) accepts queries written in Query DSL syntax.
+The [`_search` endpoint](../solutions/search/querying-for-search-searching.md) accepts queries written in Query DSL syntax.
 
 
 #### Search and filter with Query DSL [search-analyze-query-dsl-search-filter]

--- a/explore-analyze/query-filter/languages.md
+++ b/explore-analyze/query-filter/languages.md
@@ -34,7 +34,7 @@ Refer to [Query languages](../query-filter.md#search-analyze-query-languages) fo
 
 [Query DSL](languages/querydsl.md) is a full-featured JSON-style query language that enables complex searching, filtering, and aggregations. It is the original and most powerful query language for {{es}} today.
 
-The [`_search` endpoint](../../solutions/search/querying-for-search-searching-with-the-search-api.md) accepts queries written in Query DSL syntax.
+The [`_search` endpoint](../../solutions/search/querying-for-search-searching.md) accepts queries written in Query DSL syntax.
 
 
 #### Search and filter with Query DSL [search-analyze-query-dsl-search-filter]

--- a/explore-analyze/query-filter/languages.md
+++ b/explore-analyze/query-filter/languages.md
@@ -34,7 +34,7 @@ Refer to [Query languages](../query-filter.md#search-analyze-query-languages) fo
 
 [Query DSL](languages/querydsl.md) is a full-featured JSON-style query language that enables complex searching, filtering, and aggregations. It is the original and most powerful query language for {{es}} today.
 
-The [`_search` endpoint](../../solutions/search/querying-for-search-searching.md) accepts queries written in Query DSL syntax.
+The [`_search` endpoint](../../solutions/search/querying-for-search.md) accepts queries written in Query DSL syntax.
 
 
 #### Search and filter with Query DSL [search-analyze-query-dsl-search-filter]

--- a/manage-data/use-case-use-elasticsearch-to-manage-time-series-data.md
+++ b/manage-data/use-case-use-elasticsearch-to-manage-time-series-data.md
@@ -409,7 +409,7 @@ GET my-data-stream/_search
 }
 ```
 
-{{es}} searches are synchronous by default. Searches across frozen data, long time ranges, or large datasets may take longer. Use the [async search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html#submit-async-search) to run searches in the background. For more search options, see [*The search API*](../solutions/search/querying-for-search-searching.md).
+{{es}} searches are synchronous by default. Searches across frozen data, long time ranges, or large datasets may take longer. Use the [async search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html#submit-async-search) to run searches in the background. For more search options, see [*The search API*](../solutions/search/querying-for-search.md).
 
 ```console
 POST my-data-stream/_async_search

--- a/manage-data/use-case-use-elasticsearch-to-manage-time-series-data.md
+++ b/manage-data/use-case-use-elasticsearch-to-manage-time-series-data.md
@@ -409,7 +409,7 @@ GET my-data-stream/_search
 }
 ```
 
-{{es}} searches are synchronous by default. Searches across frozen data, long time ranges, or large datasets may take longer. Use the [async search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html#submit-async-search) to run searches in the background. For more search options, see [*The search API*](../solutions/search/querying-for-search-searching-with-the-search-api.md).
+{{es}} searches are synchronous by default. Searches across frozen data, long time ranges, or large datasets may take longer. Use the [async search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html#submit-async-search) to run searches in the background. For more search options, see [*The search API*](../solutions/search/querying-for-search-searching.md).
 
 ```console
 POST my-data-stream/_async_search

--- a/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data-the-search-api.md
+++ b/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data-the-search-api.md
@@ -6,7 +6,7 @@ A search may also contain additional information used to better process its quer
 
 You can use the [search API](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-search) to search and aggregate data stored in {{es}} data streams or indices.
 
-For more information, refer to [the search API overview](../../../solutions/search/querying-for-search-searching.md) in the core {{es}} docs.
+For more information, refer to [the search API overview](../../../solutions/search/querying-for-search.md) in the core {{es}} docs.
 
 
 ## Query DSL [elasticsearch-search-your-data-the-query-dsl] 
@@ -20,5 +20,5 @@ The `_search` API’s `query` request body parameter accepts queries written in 
 
 Retrievers are an alternative to Query DSL that allow you to configure complex retrieval pipelines using a simplified syntax. Retrievers simplify the user experience by allowing entire retrieval pipelines to be configured in a single `_search` API call.
 
-Learn more in the [Retrievers overview](../../../solutions/search/querying-for-search-searching.md) in the core {{es}} docs.
+Learn more in the [Retrievers overview](../../../solutions/search/querying-for-search.md) in the core {{es}} docs.
 

--- a/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data-the-search-api.md
+++ b/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data-the-search-api.md
@@ -6,7 +6,7 @@ A search may also contain additional information used to better process its quer
 
 You can use the [search API](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-search) to search and aggregate data stored in {{es}} data streams or indices.
 
-For more information, refer to [the search API overview](../../../solutions/search/querying-for-search-searching-with-the-search-api.md) in the core {{es}} docs.
+For more information, refer to [the search API overview](../../../solutions/search/querying-for-search-searching.md) in the core {{es}} docs.
 
 
 ## Query DSL [elasticsearch-search-your-data-the-query-dsl] 
@@ -20,5 +20,5 @@ The `_search` API’s `query` request body parameter accepts queries written in 
 
 Retrievers are an alternative to Query DSL that allow you to configure complex retrieval pipelines using a simplified syntax. Retrievers simplify the user experience by allowing entire retrieval pipelines to be configured in a single `_search` API call.
 
-Learn more in the [Retrievers overview](../../../solutions/search/querying-for-search-searching-with-the-search-api.md) in the core {{es}} docs.
+Learn more in the [Retrievers overview](../../../solutions/search/querying-for-search-searching.md) in the core {{es}} docs.
 

--- a/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data.md
+++ b/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data.md
@@ -22,7 +22,7 @@ Learn about the various query languages you can use to search your data in the [
 
 The subpages in this section provide some high-level information about selected important search-related topics:
 
-* [The search API](../../../solutions/search/querying-for-search-searching-with-the-search-api.md)
+* [The search API](../../../solutions/search/querying-for-search-searching.md)
 * [K-Nearest Neighbors (KNN) search](../../../solutions/search/vector/knn.md)
 * [Semantic search](../../../solutions/search/semantic-search.md)
 

--- a/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data.md
+++ b/raw-migrated-files/docs-content/serverless/elasticsearch-search-your-data.md
@@ -22,7 +22,7 @@ Learn about the various query languages you can use to search your data in the [
 
 The subpages in this section provide some high-level information about selected important search-related topics:
 
-* [The search API](../../../solutions/search/querying-for-search-searching.md)
+* [The search API](../../../solutions/search/querying-for-search.md)
 * [K-Nearest Neighbors (KNN) search](../../../solutions/search/vector/knn.md)
 * [Semantic search](../../../solutions/search/semantic-search.md)
 

--- a/raw-migrated-files/elasticsearch/elasticsearch-reference/full-text-filter-tutorial.md
+++ b/raw-migrated-files/elasticsearch/elasticsearch-reference/full-text-filter-tutorial.md
@@ -196,7 +196,7 @@ At search time, {{es}} defaults to the analyzer defined in the field mapping. In
 }
 ```
 
-1. The `hits` object contains the total number of matching documents and their relation to the total. Refer to [Track total hits](../../../solutions/search/querying-for-search-searching-with-the-search-api.md#track-total-hits) for more details about the `hits` object.
+1. The `hits` object contains the total number of matching documents and their relation to the total. Refer to [Track total hits](../../../solutions/search/querying-for-search.md#track-total-hits) for more details about the `hits` object.
 2. `max_score` is the highest relevance score among all matching documents. In this example, we only have one matching document.
 3. `_score` is the relevance score for a specific document, indicating how well it matches the query. Higher scores indicate better matches. In this example the `max_score` is the same as the `_score`, as there is only one matching document.
 4. The title contains both "Fluffy" and "Pancakes", matching our search terms exactly.

--- a/raw-migrated-files/elasticsearch/elasticsearch-reference/getting-started.md
+++ b/raw-migrated-files/elasticsearch/elasticsearch-reference/getting-started.md
@@ -353,7 +353,7 @@ This allows you to combine explicit and dynamic mappings. Learn more about [mana
 
 ## Step 4: Search your index [getting-started-search-data]
 
-Indexed documents are available for search in near real-time, using the [`_search` API](../../../solutions/search/querying-for-search-searching-with-the-search-api.md).
+Indexed documents are available for search in near real-time, using the [`_search` API](../../../solutions/search/querying-for-search-searching.md).
 
 
 ### Search all documents [getting-started-search-all-documents]

--- a/raw-migrated-files/elasticsearch/elasticsearch-reference/getting-started.md
+++ b/raw-migrated-files/elasticsearch/elasticsearch-reference/getting-started.md
@@ -353,7 +353,7 @@ This allows you to combine explicit and dynamic mappings. Learn more about [mana
 
 ## Step 4: Search your index [getting-started-search-data]
 
-Indexed documents are available for search in near real-time, using the [`_search` API](../../../solutions/search/querying-for-search-searching.md).
+Indexed documents are available for search in near real-time, using the [`_search` API](../../../solutions/search/querying-for-search.md).
 
 
 ### Search all documents [getting-started-search-all-documents]

--- a/raw-migrated-files/elasticsearch/elasticsearch-reference/search-analyze.md
+++ b/raw-migrated-files/elasticsearch/elasticsearch-reference/search-analyze.md
@@ -29,7 +29,7 @@ Refer to [Query languages](../../../explore-analyze/query-filter.md#search-analy
 
 [Query DSL](../../../explore-analyze/query-filter/languages/querydsl.md) is a full-featured JSON-style query language that enables complex searching, filtering, and aggregations. It is the original and most powerful query language for {{es}} today.
 
-The [`_search` endpoint](../../../solutions/search/querying-for-search-searching-with-the-search-api.md) accepts queries written in Query DSL syntax.
+The [`_search` endpoint](../../../solutions/search/querying-for-search.md) accepts queries written in Query DSL syntax.
 
 
 #### Search and filter with Query DSL [search-analyze-query-dsl-search-filter]

--- a/raw-migrated-files/elasticsearch/elasticsearch-reference/search-with-elasticsearch.md
+++ b/raw-migrated-files/elasticsearch/elasticsearch-reference/search-with-elasticsearch.md
@@ -25,7 +25,7 @@ Vector search
 
 To run a search request, you can use the search API or Search Applications.
 
-[Search API](../../../solutions/search/querying-for-search-searching-with-the-search-api.md)
+[Search API](../../../solutions/search/querying-for-search.md)
 :   The [search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html) enables you to search and [aggregate](../../../explore-analyze/aggregations.md) data stored in {{es}} using a query language called the [Query DSL](../../../explore-analyze/query-filter/languages/querydsl.md).
 
 [Search Applications](../../../solutions/search/applications.md)

--- a/solutions/search/querying-for-search.md
+++ b/solutions/search/querying-for-search.md
@@ -8,7 +8,7 @@ mapped_urls:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/_retrievers_examples.html
 ---
 
-# Querying for search / searching with the search API
+# Query languages for search
 
 % What needs to be done: Lift-and-shift
 

--- a/solutions/search/rag/playground-query.md
+++ b/solutions/search/rag/playground-query.md
@@ -40,7 +40,7 @@ Remember that the next step in the workflow is to send the retrieved documents t
 [Troubleshooting](playground-troubleshooting.md) provides tips on how to diagnose and fix relevance issues.
 
 ::::{note}
-Playground uses the [`retriever`](https://www.elastic.co/guide/en/elasticsearch/reference/current/retriever.html) syntax for {{es}} queries. Retrievers make it easier to compose and test different retrieval strategies in your search pipelines. Refer to [documentation](../querying-for-search-searching-with-the-search-api.md) for a high level overview of retrievers.
+Playground uses the [`retriever`](https://www.elastic.co/guide/en/elasticsearch/reference/current/retriever.html) syntax for {{es}} queries. Retrievers make it easier to compose and test different retrieval strategies in your search pipelines. Refer to [documentation](../querying-for-search-searching.md) for a high level overview of retrievers.
 
 ::::
 

--- a/solutions/search/rag/playground-query.md
+++ b/solutions/search/rag/playground-query.md
@@ -40,7 +40,7 @@ Remember that the next step in the workflow is to send the retrieved documents t
 [Troubleshooting](playground-troubleshooting.md) provides tips on how to diagnose and fix relevance issues.
 
 ::::{note}
-Playground uses the [`retriever`](https://www.elastic.co/guide/en/elasticsearch/reference/current/retriever.html) syntax for {{es}} queries. Retrievers make it easier to compose and test different retrieval strategies in your search pipelines. Refer to [documentation](../querying-for-search-searching.md) for a high level overview of retrievers.
+Playground uses the [`retriever`](https://www.elastic.co/guide/en/elasticsearch/reference/current/retriever.html) syntax for {{es}} queries. Retrievers make it easier to compose and test different retrieval strategies in your search pipelines. Refer to [documentation](../querying-for-search.md) for a high level overview of retrievers.
 
 ::::
 

--- a/solutions/search/ranking/learning-to-rank-search-usage.md
+++ b/solutions/search/ranking/learning-to-rank-search-usage.md
@@ -17,7 +17,7 @@ This feature was introduced in version 8.12.0 and is only available to certain s
 
 ## Learning To Rank as a rescorer [learning-to-rank-rescorer] 
 
-Once your LTR model is trained and deployed in {{es}}, it can be used as a [rescorer](https://www.elastic.co/guide/en/elasticsearch/reference/current/filter-search-results.html#rescore) in the [search API](../querying-for-search-searching-with-the-search-api.md):
+Once your LTR model is trained and deployed in {{es}}, it can be used as a [rescorer](https://www.elastic.co/guide/en/elasticsearch/reference/current/filter-search-results.html#rescore) in the [search API](../querying-for-search-searching.md):
 
 ```console
 GET my-index/_search

--- a/solutions/search/ranking/learning-to-rank-search-usage.md
+++ b/solutions/search/ranking/learning-to-rank-search-usage.md
@@ -17,7 +17,7 @@ This feature was introduced in version 8.12.0 and is only available to certain s
 
 ## Learning To Rank as a rescorer [learning-to-rank-rescorer] 
 
-Once your LTR model is trained and deployed in {{es}}, it can be used as a [rescorer](https://www.elastic.co/guide/en/elasticsearch/reference/current/filter-search-results.html#rescore) in the [search API](../querying-for-search-searching.md):
+Once your LTR model is trained and deployed in {{es}}, it can be used as a [rescorer](https://www.elastic.co/guide/en/elasticsearch/reference/current/filter-search-results.html#rescore) in the [search API](../querying-for-search.md):
 
 ```console
 GET my-index/_search

--- a/solutions/search/ranking/semantic-reranking.md
+++ b/solutions/search/ranking/semantic-reranking.md
@@ -133,7 +133,7 @@ POST _search
 ## Learn more [semantic-reranking-learn-more] 
 
 * Read the [retriever reference documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/retriever.html) for syntax and implementation details
-* Learn more about the [retrievers](../querying-for-search-searching.md) abstraction
+* Learn more about the [retrievers](../querying-for-search.md) abstraction
 * Learn more about the Elastic [Inference APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html)
 * Check out our [Python notebook](https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/integrations/cohere/cohere-elasticsearch.ipynb) for using Cohere with {es}
 

--- a/solutions/search/ranking/semantic-reranking.md
+++ b/solutions/search/ranking/semantic-reranking.md
@@ -133,7 +133,7 @@ POST _search
 ## Learn more [semantic-reranking-learn-more] 
 
 * Read the [retriever reference documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/retriever.html) for syntax and implementation details
-* Learn more about the [retrievers](../querying-for-search-searching-with-the-search-api.md) abstraction
+* Learn more about the [retrievers](../querying-for-search-searching.md) abstraction
 * Learn more about the Elastic [Inference APIs](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-apis.html)
 * Check out our [Python notebook](https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/integrations/cohere/cohere-elasticsearch.ipynb) for using Cohere with {es}
 

--- a/solutions/search/search-approaches.md
+++ b/solutions/search/search-approaches.md
@@ -19,4 +19,4 @@ The following table provides an overview of the fundamental search techniques av
 
 ## Next step
 
-Once you've chosen your search approach(es), you'll need to select a query language to implement them. Refer to [query languages for search use cases]() to learn about the available options.
+Once you've chosen your search approach(es), you'll need to select a query language to implement them. Refer to [query languages for search use cases](querying-for-search.md) to learn about the available options.

--- a/solutions/search/search-approaches.md
+++ b/solutions/search/search-approaches.md
@@ -9,8 +9,8 @@ The following table provides an overview of the fundamental search techniques av
 | [**Full-text search**](full-text.md) | Traditional lexical search with analyzers and relevance tuning | Essential foundation for keyword matching, works out of the box |
 | [**Vector search**](vector.md) | Similarity search using numerical vectors | Requires extra setup/resources, ideal for finding similar documents |
 | [**Semantic search**](semantic-search.md) | Meaning-based search using natural language understanding | Requires ML models and vector infrastructure |
-| [**Hybrid search**](hybrid.md) | Combines lexical and vector/semantic approaches | Best balance for both keyword precision and semantic relevance |
-| [**Re-ranking**](semantic-reranking.md) | Post-processing results to improve relevance | Optional ML-based enhancement for fine-tuned relevance |
+| [**Hybrid search**](hybrid-search.md) | Combines lexical and vector/semantic approaches | Best balance for both keyword precision and semantic relevance |
+| [**Re-ranking**](ranking/semantic-reranking.md) | Post-processing results to improve relevance | Optional ML-based enhancement for fine-tuned relevance |
 | [**Geospatial search**](/explore-analyze/geospatial-analysis.md) | Location-based search and spatial relationships | For maps, distance calculations, and shape queries |
 
 :::::{tip}

--- a/solutions/search/search-approaches.md
+++ b/solutions/search/search-approaches.md
@@ -1,5 +1,22 @@
 # Search approaches
 
-% What needs to be done: Write from scratch
+To deliver relevant search results, you need to choose the right search approach for your data and use case.
 
-% Scope notes: ml, full text, hybrid
+The following table provides an overview of the fundamental search techniques available in {{es}}:
+
+| Name | Description | Notes |
+|------|-------------|--------|
+| [**Full-text search**](full-text.md) | Traditional lexical search with analyzers and relevance tuning | Essential foundation for keyword matching, works out of the box |
+| [**Vector search**](vector.md) | Similarity search using numerical vectors | Requires extra setup/resources, ideal for finding similar documents |
+| [**Semantic search**](semantic-search.md) | Meaning-based search using natural language understanding | Requires ML models and vector infrastructure |
+| [**Hybrid search**](hybrid.md) | Combines lexical and vector/semantic approaches | Best balance for both keyword precision and semantic relevance |
+| [**Re-ranking**](semantic-reranking.md) | Post-processing results to improve relevance | Optional ML-based enhancement for fine-tuned relevance |
+| [**Geospatial search**](/explore-analyze/geospatial-analysis.md) | Location-based search and spatial relationships | For maps, distance calculations, and shape queries |
+
+:::::{tip}
+ Full-text search is a very powerful tool in itself. One of the key strengths of {{es}} is its flexibility, allowing you to start with full-text search and gradually incorporate more complex or resource-intensive approaches over time.
+:::::
+
+## Next step
+
+Once you've chosen your search approach(es), you'll need to select a query language to implement them. Refer to [query languages for search use cases]() to learn about the available options.

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -588,7 +588,7 @@ toc:
         children:
           - file: search/search-approaches/long-running-searches.md
           - file: search/search-approaches/near-real-time-search.md
-      - file: search/querying-for-search-searching-with-the-search-api.md
+      - file: search/querying-for-search.md
       - file: search/inference-api.md
         children:
           - file: search/inference-api/elastic-inference-service-eis.md

--- a/troubleshoot/elasticsearch/high-jvm-memory-pressure.md
+++ b/troubleshoot/elasticsearch/high-jvm-memory-pressure.md
@@ -78,7 +78,7 @@ Expensive searches may have a large [`size` argument](https://www.elastic.co/gui
 * Lower the `size` limit using the [`index.max_result_window`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-result-window) index setting.
 * Decrease the maximum number of allowed aggregation buckets using the [search.max_buckets](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html#search-settings-max-buckets) cluster setting.
 * Disable expensive queries using the [`search.allow_expensive_queries`](../../explore-analyze/query-filter/languages/querydsl.md#query-dsl-allow-expensive-queries) cluster setting.
-* Set a default search timeout using the [`search.default_search_timeout`](../../solutions/search/querying-for-search-searching.md#search-timeout) cluster setting.
+* Set a default search timeout using the [`search.default_search_timeout`](../../solutions/search/querying-for-search.md#search-timeout) cluster setting.
 
 ```console
 PUT _settings

--- a/troubleshoot/elasticsearch/high-jvm-memory-pressure.md
+++ b/troubleshoot/elasticsearch/high-jvm-memory-pressure.md
@@ -78,7 +78,7 @@ Expensive searches may have a large [`size` argument](https://www.elastic.co/gui
 * Lower the `size` limit using the [`index.max_result_window`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-result-window) index setting.
 * Decrease the maximum number of allowed aggregation buckets using the [search.max_buckets](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html#search-settings-max-buckets) cluster setting.
 * Disable expensive queries using the [`search.allow_expensive_queries`](../../explore-analyze/query-filter/languages/querydsl.md#query-dsl-allow-expensive-queries) cluster setting.
-* Set a default search timeout using the [`search.default_search_timeout`](../../solutions/search/querying-for-search-searching-with-the-search-api.md#search-timeout) cluster setting.
+* Set a default search timeout using the [`search.default_search_timeout`](../../solutions/search/querying-for-search-searching.md#search-timeout) cluster setting.
 
 ```console
 PUT _settings


### PR DESCRIPTION
Added new content to [search-approaches.md](https://github.com/elastic/docs-content/pull/291/files#diff-7f6dc9fb2c6e42aba2edee343783a6bbb4776cbae83d10a854708515765faac6)
- [👁️PREVIEW](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/291/solutions/search/search-approaches.html)

 Updated page name/links:

- `querying-for-search-searching-with-the-search-api.md` was renamed to `querying-for-search.md`. 
  - all links have been updated (this section needs to be fleshed out with subpages in subsequent PRs and references checked for relevance)
  - Also changed title from "Querying for search / searching with the search API" to "Query languages for search"


## `FYI`
I tried using `docs-builder mv` to rename the `querying-for-search` file but I couldn't get it working and ran out of time, so just manually updated links
