### PR TITLE
Add fork-friendly PR preview deployment workflows

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -6,5 +6,8 @@ on:
 jobs:
   preview:
     uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
+    with:
+      continue-on-error: true
+      strict: false
     permissions:
       contents: read

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,10 @@
+name: docs-build
+
+on:
+  pull_request: ~
+
+jobs:
+  preview:
+    uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -1,4 +1,4 @@
-name: docs
+name: docs-cleanup
 
 on:
   pull_request_target:
@@ -6,9 +6,9 @@ on:
       - closed
 
 jobs:
-  docs-preview:
+  preview:
     uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@main
     permissions:
-      contents: read
+      contents: none
       id-token: write
       deployments: write

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,16 @@
+name: docs-deploy
+
+on:
+  workflow_run:
+    workflows: [docs-build]
+    types:
+      - completed
+
+jobs:
+  preview:
+    uses: elastic/docs-builder/.github/workflows/preview-deploy.yml@main
+    permissions:
+      contents: none
+      id-token: write
+      deployments: write
+      actions: read


### PR DESCRIPTION
## Changes

Add fork-friendly PR preview deployment workflows.

Depends on https://github.com/elastic/docs-builder/pull/406 