### PR TITLE
Update name for 'Elasticsearch Service'

### DIFF
--- a/docset.yml
+++ b/docset.yml
@@ -153,7 +153,7 @@ subs:
   apm-php-ref-v:   "https://www.elastic.co/guide/en/apm/agent/php/{{apm-php-branch}}"
   ecloud:   "Elastic Cloud"
   esf:   "Elastic Serverless Forwarder"
-  ess:   "Elasticsearch Service"
+  ess:   "Elastic Cloud Hosted"
   ece:   "Elastic Cloud Enterprise"
   eck:   "Elastic Cloud on Kubernetes"
   serverless-full:   "Elastic Cloud Serverless"


### PR DESCRIPTION
According to the last naming update I've seen, `Elasticsearch Service` is now `Elastic Cloud Hosted`. 

The `{{ess}}` attribute has been carried over into the migrated docs, I think it makes sense to continue using this attribute with the new name.

CC @eedugon, @kosabogi, @shainaraskas  since I know you've been working on what were the Cloud docs.