### PR TITLE
Update osquery docs to reflect new max timeout

### DIFF
--- a/raw-migrated-files/docs-content/serverless/security-alerts-run-osquery.md
+++ b/raw-migrated-files/docs-content/serverless/security-alerts-run-osquery.md
@@ -32,7 +32,7 @@ To run Osquery from an alert:
     * **Query**: Select a saved query or enter a new one in the text box. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
 
         ::::
 

--- a/raw-migrated-files/docs-content/serverless/security-invest-guide-run-osquery.md
+++ b/raw-migrated-files/docs-content/serverless/security-invest-guide-run-osquery.md
@@ -41,7 +41,7 @@ You can only add Osquery to investigation guides for custom rules because prebui
     3. Expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
 
         ::::
 
@@ -61,7 +61,7 @@ You can only add Osquery to investigation guides for custom rules because prebui
     2. Expand the **Advanced** section to set a timeout period for the query, and view or set the [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) which are included in the live query’s results (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
 
         ::::
 

--- a/raw-migrated-files/docs-content/serverless/security-osquery-response-action.md
+++ b/raw-migrated-files/docs-content/serverless/security-osquery-response-action.md
@@ -44,7 +44,7 @@ You can add Osquery Response Actions to new or existing custom query rules. Quer
     * **Query**: Select a saved query or enter a new one. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query. Mapping ECS fields is optional.
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
 
         ::::
 

--- a/raw-migrated-files/kibana/kibana/osquery.md
+++ b/raw-migrated-files/kibana/kibana/osquery.md
@@ -33,7 +33,7 @@ To inspect hosts, run a query against one or more agents or policies, then view 
     * **Query**: Select a saved query or enter a new one in the text box. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
         ::::
 
     * **Pack**: Select from available query packs. After you select a pack, all of the queries in the pack are displayed.
@@ -111,7 +111,7 @@ You can run packs as live queries or schedule packs to run for one or more agent
     * Click **Add query** and then add a saved query or enter a new query. Each query must include a unique query ID and the interval at which it should run. Optionally, set the minimum Osquery version and platform, specify a timeout period, or [map ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields). When you add a saved query to a pack, this adds a copy of the query. A connection is not maintained between saved queries and packs.
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
         ::::
 
     * Upload queries from a `.conf` query pack by dragging the pack to the drop zone under the query table. To explore the community packs that Osquery publishes, click **Example packs**.
@@ -149,7 +149,7 @@ Once you save a query, you can only edit it from the **Saved queries** tab:
     * The unique identifier (required).
     * A brief description.
     * The SQL query (required). Osquery supports multi-line queries.
-    * A timeout period (optional). Increase the query’s default timeout period to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+    * A timeout period (optional). Increase the query’s default timeout period to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
     * The [ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) to populate when the query is run (optional). These fields are also copied in when you add this query to a pack.
     * The defaults to set when you add the query to a pack.
 

--- a/raw-migrated-files/security-docs/security/alerts-run-osquery.md
+++ b/raw-migrated-files/security-docs/security/alerts-run-osquery.md
@@ -29,7 +29,7 @@ To run Osquery from an alert:
     * **Query**: Select a saved query or enter a new one in the text box. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
         ::::
 
 

--- a/raw-migrated-files/security-docs/security/invest-guide-run-osquery.md
+++ b/raw-migrated-files/security-docs/security/invest-guide-run-osquery.md
@@ -38,7 +38,7 @@ You can only add Osquery to investigation guides for custom rules because prebui
     3. Expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
         ::::
 
 
@@ -62,7 +62,7 @@ You can only add Osquery to investigation guides for custom rules because prebui
     2. Expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
         ::::
 
 6. Click **Submit** to run the query. Query results display in the flyout.

--- a/raw-migrated-files/security-docs/security/osquery-response-action.md
+++ b/raw-migrated-files/security-docs/security/osquery-response-action.md
@@ -41,7 +41,7 @@ You can add Osquery Response Actions to new or existing custom query rules. Quer
     * **Query**: Select a saved query or enter a new one. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](../../../solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
         ::::
 
 


### PR DESCRIPTION
In osquery, the maximum query timeout has been increased to 86400 seconds (24 hours). This updates the docs to use the new max timeout value.

---

I don't really know the correct procedure for updating the docs. I'll need help from the docs team to get this deployed in the  correct places. This change needs to be applied to the docs for 9.x, and 8.16, 8.17. 8.18 (and will apply to 8.19)