### PR TITLE
Add navigation_title to inference pages

### DIFF
--- a/solutions/search/inference-api/alibabacloud-ai-search-inference-integration.md
+++ b/solutions/search/inference-api/alibabacloud-ai-search-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "AlibabaCloud AI Search"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-alibabacloud-ai-search.html
 ---

--- a/solutions/search/inference-api/alibabacloud-ai-search-inference-integration.md
+++ b/solutions/search/inference-api/alibabacloud-ai-search-inference-integration.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: "AlibabaCloud AI Search"
+navigation_title: "Alibaba Cloud AI Search"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-alibabacloud-ai-search.html
 ---

--- a/solutions/search/inference-api/amazon-bedrock-inference-integration.md
+++ b/solutions/search/inference-api/amazon-bedrock-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Amazon Bedrock"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-amazon-bedrock.html
 ---

--- a/solutions/search/inference-api/anthropic-inference-integration.md
+++ b/solutions/search/inference-api/anthropic-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Anthropic"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-anthropic.html
 ---

--- a/solutions/search/inference-api/azure-ai-studio-inference-integration.md
+++ b/solutions/search/inference-api/azure-ai-studio-inference-integration.md
@@ -1,9 +1,10 @@
 ---
+navigation_title: "Azure AI Studio"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-azure-ai-studio.html
 ---
 
-# Azure AI studio inference integration [infer-service-azure-ai-studio]
+# Azure AI Studio inference integration [infer-service-azure-ai-studio]
 
 ::::{admonition} New API reference
 For the most up-to-date API details, refer to [{{infer-cap}} APIs](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-inference).

--- a/solutions/search/inference-api/azure-openai-inference-integration.md
+++ b/solutions/search/inference-api/azure-openai-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Azure OpenAI"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-azure-openai.html
 ---

--- a/solutions/search/inference-api/chat-completion-inference-api.md
+++ b/solutions/search/inference-api/chat-completion-inference-api.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Chat completion"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/master/chat-completion-inference-api.html
 ---

--- a/solutions/search/inference-api/cohere-inference-integration.md
+++ b/solutions/search/inference-api/cohere-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Cohere"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-cohere.html
 ---

--- a/solutions/search/inference-api/elastic-inference-service-eis.md
+++ b/solutions/search/inference-api/elastic-inference-service-eis.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Elastic Inference Service"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-service-elastic.html
 ---

--- a/solutions/search/inference-api/elasticsearch-inference-integration.md
+++ b/solutions/search/inference-api/elasticsearch-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Elasticsearch"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-elasticsearch.html
 ---

--- a/solutions/search/inference-api/elser-inference-integration.md
+++ b/solutions/search/inference-api/elser-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "ELSER"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-elser.html
 ---

--- a/solutions/search/inference-api/google-ai-studio-inference-integration.md
+++ b/solutions/search/inference-api/google-ai-studio-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Google AI Studio"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-google-ai-studio.html
 ---

--- a/solutions/search/inference-api/google-vertex-ai-inference-integration.md
+++ b/solutions/search/inference-api/google-vertex-ai-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Google Vertex AI"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-google-vertex-ai.html
 ---

--- a/solutions/search/inference-api/huggingface-inference-integration.md
+++ b/solutions/search/inference-api/huggingface-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "HuggingFace"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-hugging-face.html
 ---

--- a/solutions/search/inference-api/jinaai-inference-integration.md
+++ b/solutions/search/inference-api/jinaai-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "JinaAI"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-service-jinaai.html
 ---

--- a/solutions/search/inference-api/mistral-inference-integration.md
+++ b/solutions/search/inference-api/mistral-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Mistral"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-mistral.html
 ---

--- a/solutions/search/inference-api/openai-inference-integration.md
+++ b/solutions/search/inference-api/openai-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "OpenAI"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-openai.html
 ---

--- a/solutions/search/inference-api/watsonx-inference-integration.md
+++ b/solutions/search/inference-api/watsonx-inference-integration.md
@@ -1,4 +1,5 @@
 ---
+navigation_title: "Watsonx"
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-watsonx-ai.html
 ---


### PR DESCRIPTION
Add navigation_title to inference API integration pages, and fix a capitalization typo.