### PR TITLE
Add missing mapped URL for explore and analyze

### DIFF
--- a/explore-analyze/index.md
+++ b/explore-analyze/index.md
@@ -6,6 +6,7 @@ mapped_urls:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-explore-your-data.html
   - https://www.elastic.co/guide/en/kibana/current/introduction.html#visualize-and-analyze
   - https://www.elastic.co/guide/en/kibana/current/get-started.html
+  - https://www.elastic.co/guide/en/kibana/current/accessibility.html
 ---
 
 # Explore and analyze


### PR DESCRIPTION
See https://github.com/elastic/docs-projects/issues/412#issuecomment-2663899798

I moved the content of the accessibility page into the index, but missed to bring the mapped URL along with it. This PR corrects it.