### PR TITLE
More temporary deploy and manage content

### DIFF
--- a/deploy-manage/autoscaling.md
+++ b/deploy-manage/autoscaling.md
@@ -61,3 +61,10 @@ $$$ech-autoscaling-restrictions$$$
 $$$ech-autoscaling-enable$$$
 
 $$$ech-autoscaling-update$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud-heroku/ech-autoscaling.md](/raw-migrated-files/cloud/cloud-heroku/ech-autoscaling.md)
+* [/raw-migrated-files/cloud/cloud/ec-autoscaling.md](/raw-migrated-files/cloud/cloud/ec-autoscaling.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-autoscaling.md](/raw-migrated-files/cloud/cloud-enterprise/ece-autoscaling.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/xpack-autoscaling.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/xpack-autoscaling.md)

--- a/deploy-manage/autoscaling/trained-model-autoscaling.md
+++ b/deploy-manage/autoscaling/trained-model-autoscaling.md
@@ -22,3 +22,8 @@ mapped_urls:
 $$$enabling-autoscaling-in-kibana-adaptive-resources$$$
 
 $$$enabling-autoscaling-through-apis-adaptive-allocations$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/docs-content/serverless/general-ml-nlp-auto-scale.md](/raw-migrated-files/docs-content/serverless/general-ml-nlp-auto-scale.md)
+* [/raw-migrated-files/docs-content/serverless/general-ml-nlp-auto-scale.md](/raw-migrated-files/docs-content/serverless/general-ml-nlp-auto-scale.md)

--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md
@@ -30,3 +30,12 @@ $$$ece-edit-apm-fleet-tls$$$
 
 $$$ece-edit-apm-standalone-settings-ece$$$
 
+
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud-enterprise/editing-user-settings.md](/raw-migrated-files/cloud/cloud-enterprise/editing-user-settings.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-add-user-settings.md](/raw-migrated-files/cloud/cloud-enterprise/ece-add-user-settings.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-manage-kibana-settings.md](/raw-migrated-files/cloud/cloud-enterprise/ece-manage-kibana-settings.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-manage-apm-settings.md](/raw-migrated-files/cloud/cloud-enterprise/ece-manage-apm-settings.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-manage-enterprise-search-settings.md](/raw-migrated-files/cloud/cloud-enterprise/ece-manage-enterprise-search-settings.md)

--- a/deploy-manage/deploy/elastic-cloud/access-kibana.md
+++ b/deploy-manage/deploy/elastic-cloud/access-kibana.md
@@ -19,3 +19,9 @@ mapped_urls:
 
 
 $$$ec-enable-kibana2$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-access-kibana.md](/raw-migrated-files/cloud/cloud/ec-access-kibana.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-access-kibana.md](/raw-migrated-files/cloud/cloud-heroku/ech-access-kibana.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-enable-kibana2.md](/raw-migrated-files/cloud/cloud-heroku/ech-enable-kibana2.md)

--- a/deploy-manage/deploy/elastic-cloud/cloud-hosted.md
+++ b/deploy-manage/deploy/elastic-cloud/cloud-hosted.md
@@ -49,3 +49,11 @@ $$$faq-what$$$
 $$$faq-where$$$
 
 $$$faq-x-pack$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-getting-started.md](/raw-migrated-files/cloud/cloud/ec-getting-started.md)
+* [/raw-migrated-files/cloud/cloud/ec-prepare-production.md](/raw-migrated-files/cloud/cloud/ec-prepare-production.md)
+* [/raw-migrated-files/cloud/cloud/ec-faq-getting-started.md](/raw-migrated-files/cloud/cloud/ec-faq-getting-started.md)
+* [/raw-migrated-files/cloud/cloud/ec-about.md](/raw-migrated-files/cloud/cloud/ec-about.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-configure.md](/raw-migrated-files/cloud/cloud-heroku/ech-configure.md)

--- a/deploy-manage/deploy/elastic-cloud/create-an-organization.md
+++ b/deploy-manage/deploy/elastic-cloud/create-an-organization.md
@@ -22,3 +22,9 @@ mapped_urls:
 % Internal links rely on the following IDs being on this page (e.g. as a heading ID, paragraph ID, etc):
 
 $$$general-sign-up-trial-what-is-included-in-my-trial$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-getting-started-trial.md](/raw-migrated-files/cloud/cloud/ec-getting-started-trial.md)
+* [/raw-migrated-files/docs-content/serverless/general-sign-up-trial.md](/raw-migrated-files/docs-content/serverless/general-sign-up-trial.md)
+* [/raw-migrated-files/cloud/cloud/ec-getting-started-existing-email.md](/raw-migrated-files/cloud/cloud/ec-getting-started-existing-email.md)

--- a/deploy-manage/deploy/elastic-cloud/edit-stack-settings.md
+++ b/deploy-manage/deploy/elastic-cloud/edit-stack-settings.md
@@ -46,3 +46,16 @@ $$$csp-strict$$$
 $$$ec-appsearch-settings$$$
 
 $$$ec-es-elasticsearch-settings$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-add-user-settings.md](/raw-migrated-files/cloud/cloud/ec-add-user-settings.md)
+* [/raw-migrated-files/cloud/cloud/ec-editing-user-settings.md](/raw-migrated-files/cloud/cloud/ec-editing-user-settings.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-add-user-settings.md](/raw-migrated-files/cloud/cloud-heroku/ech-add-user-settings.md)
+* [/raw-migrated-files/cloud/cloud/ec-manage-kibana-settings.md](/raw-migrated-files/cloud/cloud/ec-manage-kibana-settings.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-manage-kibana-settings.md](/raw-migrated-files/cloud/cloud-heroku/ech-manage-kibana-settings.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-editing-user-settings.md](/raw-migrated-files/cloud/cloud-heroku/ech-editing-user-settings.md)
+* [/raw-migrated-files/cloud/cloud/ec-manage-apm-settings.md](/raw-migrated-files/cloud/cloud/ec-manage-apm-settings.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-manage-apm-settings.md](/raw-migrated-files/cloud/cloud-heroku/ech-manage-apm-settings.md)
+* [/raw-migrated-files/cloud/cloud/ec-manage-appsearch-settings.md](/raw-migrated-files/cloud/cloud/ec-manage-appsearch-settings.md)
+* [/raw-migrated-files/cloud/cloud/ec-manage-enterprise-search-settings.md](/raw-migrated-files/cloud/cloud/ec-manage-enterprise-search-settings.md)

--- a/deploy-manage/deploy/elastic-cloud/project-settings.md
+++ b/deploy-manage/deploy/elastic-cloud/project-settings.md
@@ -23,3 +23,8 @@ $$$elasticsearch-manage-project-search-ai-lake-settings$$$
 $$$elasticsearch-manage-project-search-power-settings$$$
 
 $$$project-features-add-ons$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/docs-content/serverless/project-and-management-settings.md](/raw-migrated-files/docs-content/serverless/project-and-management-settings.md)
+* [/raw-migrated-files/docs-content/serverless/elasticsearch-manage-project.md](/raw-migrated-files/docs-content/serverless/elasticsearch-manage-project.md)

--- a/deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md
+++ b/deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md
@@ -26,3 +26,8 @@ $$$ech-add-your-plugin$$$
 $$$ech-update-bundles-and-plugins$$$
 
 $$$ech-update-bundles$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-custom-bundles.md](/raw-migrated-files/cloud/cloud/ec-custom-bundles.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-custom-bundles.md](/raw-migrated-files/cloud/cloud-heroku/ech-custom-bundles.md)

--- a/deploy-manage/deploy/self-managed/air-gapped-install.md
+++ b/deploy-manage/deploy/self-managed/air-gapped-install.md
@@ -78,3 +78,9 @@ $$$air-gapped-agent-integration-configure-yml$$$
 $$$air-gapped-agent-integration-configure-fleet-api$$$
 
 $$$air-gapped-kibana-product-documentation$$$
+
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/stack-docs/elastic-stack/air-gapped-install.md](/raw-migrated-files/stack-docs/elastic-stack/air-gapped-install.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-install-offline.md](/raw-migrated-files/cloud/cloud-enterprise/ece-install-offline.md)

--- a/deploy-manage/deploy/self-managed/bootstrap-checks.md
+++ b/deploy-manage/deploy/self-managed/bootstrap-checks.md
@@ -25,3 +25,8 @@ $$$dev-vs-prod-mode$$$
 $$$bootstrap-checks-tls$$$
 
 $$$single-node-discovery$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/bootstrap-checks.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/bootstrap-checks.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/bootstrap-checks-xpack.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/bootstrap-checks-xpack.md)

--- a/deploy-manage/deploy/self-managed/deploy-cluster.md
+++ b/deploy-manage/deploy/self-managed/deploy-cluster.md
@@ -26,4 +26,6 @@ $$$dedicated-host$$$
 
 * [/raw-migrated-files/elasticsearch/elasticsearch-reference/elasticsearch-intro-deploy.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/elasticsearch-intro-deploy.md)
 * [/raw-migrated-files/elasticsearch/elasticsearch-reference/setup.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/setup.md)
-* [/raw-migrated-files/stack-docs/elastic-stack/installing-elastic-stack.md](/raw-migrated-files/stack-docs/elastic-stack/installing-elastic-stack.md)
+
+% Doesn't exist
+% * [/raw-migrated-files/stack-docs/elastic-stack/installing-elastic-stack.md](/raw-migrated-files/stack-docs/elastic-stack/installing-elastic-stack.md)

--- a/deploy-manage/deploy/self-managed/deploy-cluster.md
+++ b/deploy-manage/deploy/self-managed/deploy-cluster.md
@@ -21,3 +21,9 @@ mapped_urls:
 %      Notes: 1-5
 
 $$$dedicated-host$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/elasticsearch-intro-deploy.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/elasticsearch-intro-deploy.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/setup.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/setup.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/installing-elastic-stack.md](/raw-migrated-files/stack-docs/elastic-stack/installing-elastic-stack.md)

--- a/deploy-manage/deploy/self-managed/installing-elasticsearch.md
+++ b/deploy-manage/deploy/self-managed/installing-elasticsearch.md
@@ -56,3 +56,9 @@ $$$install-stack-self-overview$$$
 $$$install-stack-self-prereqs$$$
 
 $$$install-stack-self-view-data$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/install-elasticsearch.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/install-elasticsearch.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/configuring-stack-security.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/configuring-stack-security.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/installing-stack-demo-self.md](/raw-migrated-files/stack-docs/elastic-stack/installing-stack-demo-self.md)

--- a/deploy-manage/index.md
+++ b/deploy-manage/index.md
@@ -47,3 +47,14 @@ $$$faq-ip-sniffing$$$
 $$$faq-encryption-at-rest$$$
 
 $$$faq-static-ip-elastic-cloud$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/kibana/kibana/introduction.md](/raw-migrated-files/kibana/kibana/introduction.md)
+* [/raw-migrated-files/kibana/kibana/setup.md](/raw-migrated-files/kibana/kibana/setup.md)
+* [/raw-migrated-files/tech-content/starting-with-the-elasticsearch-platform-and-its-solutions/get-elastic.md](/raw-migrated-files/tech-content/starting-with-the-elasticsearch-platform-and-its-solutions/get-elastic.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/scalability.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/scalability.md)
+* [/raw-migrated-files/cloud/cloud/ec-faq-technical.md](/raw-migrated-files/cloud/cloud/ec-faq-technical.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/overview.md](/raw-migrated-files/stack-docs/elastic-stack/overview.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-administering-deployments.md](/raw-migrated-files/cloud/cloud-enterprise/ece-administering-deployments.md)
+* [/raw-migrated-files/kibana/kibana/management.md](/raw-migrated-files/kibana/kibana/management.md)

--- a/deploy-manage/index.md
+++ b/deploy-manage/index.md
@@ -50,7 +50,9 @@ $$$faq-static-ip-elastic-cloud$$$
 
 **This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
 
-* [/raw-migrated-files/kibana/kibana/introduction.md](/raw-migrated-files/kibana/kibana/introduction.md)
+% Doesn't exist
+% * [/raw-migrated-files/kibana/kibana/introduction.md](/raw-migrated-files/kibana/kibana/introduction.md)
+
 * [/raw-migrated-files/kibana/kibana/setup.md](/raw-migrated-files/kibana/kibana/setup.md)
 * [/raw-migrated-files/tech-content/starting-with-the-elasticsearch-platform-and-its-solutions/get-elastic.md](/raw-migrated-files/tech-content/starting-with-the-elasticsearch-platform-and-its-solutions/get-elastic.md)
 * [/raw-migrated-files/elasticsearch/elasticsearch-reference/scalability.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/scalability.md)

--- a/deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
+++ b/deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
@@ -26,3 +26,8 @@ $$$start-rpm$$$
 $$$_enroll_nodes_in_an_existing_cluster_3$$$
 
 $$$start-es-deb-systemd$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/starting-elasticsearch.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/starting-elasticsearch.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/stopping-elasticsearch.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/stopping-elasticsearch.md)

--- a/deploy-manage/manage-connectors.md
+++ b/deploy-manage/manage-connectors.md
@@ -19,3 +19,8 @@ mapped_urls:
 % - [ ] ./raw-migrated-files/docs-content/serverless/action-connectors.md
 
 $$$connector-management$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/kibana/kibana/action-types.md](/raw-migrated-files/kibana/kibana/action-types.md)
+* [/raw-migrated-files/docs-content/serverless/action-connectors.md](/raw-migrated-files/docs-content/serverless/action-connectors.md)

--- a/deploy-manage/monitor/stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring.md
@@ -37,3 +37,9 @@ $$$ec-es-health-preconfigured$$$
 $$$ec-es-health-warnings$$$
 
 $$$ec-health-best-practices$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/monitoring-overview.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/monitoring-overview.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/how-monitoring-works.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/how-monitoring-works.md)
+* [/raw-migrated-files/cloud/cloud/ec-monitoring.md](/raw-migrated-files/cloud/cloud/ec-monitoring.md)

--- a/deploy-manage/monitor/stack-monitoring/elastic-cloud-stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring/elastic-cloud-stack-monitoring.md
@@ -58,3 +58,12 @@ $$$ech-health-best-practices$$$
 $$$ech-logging-and-monitoring-production$$$
 
 $$$ech-logging-and-monitoring-retention$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud-heroku/ech-monitoring.md](/raw-migrated-files/cloud/cloud-heroku/ech-monitoring.md)
+* [/raw-migrated-files/cloud/cloud/ec-monitoring-setup.md](/raw-migrated-files/cloud/cloud/ec-monitoring-setup.md)
+* [/raw-migrated-files/cloud/cloud/ec-enable-logging-and-monitoring.md](/raw-migrated-files/cloud/cloud/ec-enable-logging-and-monitoring.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-enable-logging-and-monitoring.md](/raw-migrated-files/cloud/cloud-heroku/ech-enable-logging-and-monitoring.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-monitoring-setup.md](/raw-migrated-files/cloud/cloud-heroku/ech-monitoring-setup.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-restrictions-monitoring.md](/raw-migrated-files/cloud/cloud-heroku/ech-restrictions-monitoring.md)

--- a/deploy-manage/production-guidance/plan-for-production-elastic-cloud.md
+++ b/deploy-manage/production-guidance/plan-for-production-elastic-cloud.md
@@ -24,3 +24,8 @@ $$$ec-ha$$$
 $$$ec-workloads$$$
 
 $$$ech-workloads$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-planning.md](/raw-migrated-files/cloud/cloud/ec-planning.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-planning.md](/raw-migrated-files/cloud/cloud-heroku/ech-planning.md)

--- a/deploy-manage/security.md
+++ b/deploy-manage/security.md
@@ -41,3 +41,15 @@ $$$preventing-unauthorized-access$$$
 $$$preserving-data-integrity$$$
 
 $$$maintaining-audit-trail$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/security-files.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/security-files.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/secure-cluster.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/secure-cluster.md)
+* [/raw-migrated-files/kibana/kibana/xpack-security.md](/raw-migrated-files/kibana/kibana/xpack-security.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-securing-stack.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-securing-stack.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-securing-ece.md](/raw-migrated-files/cloud/cloud-enterprise/ece-securing-ece.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-security.md](/raw-migrated-files/cloud/cloud-heroku/ech-security.md)
+* [/raw-migrated-files/kibana/kibana/using-kibana-with-security.md](/raw-migrated-files/kibana/kibana/using-kibana-with-security.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/security-limitations.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/security-limitations.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/es-security-principles.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/es-security-principles.md)

--- a/deploy-manage/security/aws-privatelink-traffic-filters.md
+++ b/deploy-manage/security/aws-privatelink-traffic-filters.md
@@ -37,3 +37,8 @@ $$$ech-find-your-endpoint$$$
 $$$ech-private-link-service-names-aliases$$$
 
 $$$ech-remove-association-traffic-filter-private-link-rule-set$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-traffic-filtering-vpc.md](/raw-migrated-files/cloud/cloud/ec-traffic-filtering-vpc.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-vpc.md](/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-vpc.md)

--- a/deploy-manage/security/azure-private-link-traffic-filters.md
+++ b/deploy-manage/security/azure-private-link-traffic-filters.md
@@ -49,3 +49,8 @@ $$$ech-find-your-resource-name$$$
 $$$ech-private-link-azure-dns$$$
 
 $$$ech-private-link-azure-service-aliases$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-traffic-filtering-vnet.md](/raw-migrated-files/cloud/cloud/ec-traffic-filtering-vnet.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-vnet.md](/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-vnet.md)

--- a/deploy-manage/security/fips-140-2.md
+++ b/deploy-manage/security/fips-140-2.md
@@ -38,3 +38,8 @@ $$$java-security-provider$$$
 $$$keystore-fips-password$$$
 
 $$$verify-security-provider$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/fips-140-compliance.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/fips-140-compliance.md)
+* [/raw-migrated-files/kibana/kibana/xpack-security-fips-140-2.md](/raw-migrated-files/kibana/kibana/xpack-security-fips-140-2.md)

--- a/deploy-manage/security/gcp-private-service-connect-traffic-filters.md
+++ b/deploy-manage/security/gcp-private-service-connect-traffic-filters.md
@@ -37,3 +37,8 @@ $$$ech-psc-associate-traffic-filter-psc-rule-set$$$
 $$$ech-psc-create-traffic-filter-psc-rule-set$$$
 
 $$$ech-psc-remove-association-psc-rule-set$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-traffic-filtering-psc.md](/raw-migrated-files/cloud/cloud/ec-traffic-filtering-psc.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-psc.md](/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-psc.md)

--- a/deploy-manage/security/ip-traffic-filtering.md
+++ b/deploy-manage/security/ip-traffic-filtering.md
@@ -32,3 +32,10 @@ $$$ece-remove-association-traffic-filter-ip-rule-set$$$
 $$$ech-associate-traffic-filter-ip-rule-set$$$
 
 $$$ech-remove-association-traffic-filter-ip-rule-set$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-traffic-filtering-ip.md](/raw-migrated-files/cloud/cloud-enterprise/ece-traffic-filtering-ip.md)
+* [/raw-migrated-files/cloud/cloud/ec-traffic-filtering-ip.md](/raw-migrated-files/cloud/cloud/ec-traffic-filtering-ip.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-ip.md](/raw-migrated-files/cloud/cloud-heroku/ech-traffic-filtering-ip.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/ip-filtering.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/ip-filtering.md)

--- a/deploy-manage/security/manage-traffic-filtering-through-api.md
+++ b/deploy-manage/security/manage-traffic-filtering-through-api.md
@@ -46,3 +46,8 @@ $$$ece-delete-rule-set-association-with-a-deployment$$$
 $$$ece-ip-traffic-filters-ingress-rule-set$$$
 
 $$$ece-update-a-traffic-filter-rule-set$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-traffic-filtering-through-the-api.md](/raw-migrated-files/cloud/cloud-enterprise/ece-traffic-filtering-through-the-api.md)
+* [/raw-migrated-files/cloud/cloud/ec-traffic-filtering-through-the-api.md](/raw-migrated-files/cloud/cloud/ec-traffic-filtering-through-the-api.md)

--- a/deploy-manage/security/secure-cluster-communications.md
+++ b/deploy-manage/security/secure-cluster-communications.md
@@ -23,3 +23,9 @@ mapped_urls:
 $$$generate-certificates$$$
 
 $$$encrypt-internode-communication$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-security.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-security.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/security-basic-setup.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/security-basic-setup.md)
+* [/raw-migrated-files/kibana/kibana/elasticsearch-mutual-tls.md](/raw-migrated-files/kibana/kibana/elasticsearch-mutual-tls.md)

--- a/deploy-manage/security/secure-cluster-communications.md
+++ b/deploy-manage/security/secure-cluster-communications.md
@@ -26,6 +26,8 @@ $$$encrypt-internode-communication$$$
 
 **This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
 
-* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-security.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-security.md)
+% Doesn't exist
+% * [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-security.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-security.md)
+
 * [/raw-migrated-files/elasticsearch/elasticsearch-reference/security-basic-setup.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/security-basic-setup.md)
 * [/raw-migrated-files/kibana/kibana/elasticsearch-mutual-tls.md](/raw-migrated-files/kibana/kibana/elasticsearch-mutual-tls.md)

--- a/deploy-manage/security/secure-http-communications.md
+++ b/deploy-manage/security/secure-http-communications.md
@@ -52,3 +52,10 @@ $$$k8s-setting-up-your-own-certificate$$$
 $$$k8s-static-ip-custom-domain$$$
 
 $$$k8s-disable-tls$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/security-basic-setup-https.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/security-basic-setup-https.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-tls-certificates.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-tls-certificates.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-custom-http-certificate.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-custom-http-certificate.md)
+* [/raw-migrated-files/kibana/kibana/Security-production-considerations.md](/raw-migrated-files/kibana/kibana/Security-production-considerations.md)

--- a/deploy-manage/security/secure-settings.md
+++ b/deploy-manage/security/secure-settings.md
@@ -36,3 +36,13 @@ $$$ec-add-secret-values$$$
 $$$change-password$$$
 
 $$$creating-keystore$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-configuring-keystore.md](/raw-migrated-files/cloud/cloud-enterprise/ece-configuring-keystore.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-restful-api-examples-configuring-keystore.md](/raw-migrated-files/cloud/cloud-enterprise/ece-restful-api-examples-configuring-keystore.md)
+* [/raw-migrated-files/cloud/cloud/ec-configuring-keystore.md](/raw-migrated-files/cloud/cloud/ec-configuring-keystore.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-configuring-keystore.md](/raw-migrated-files/cloud/cloud-heroku/ech-configuring-keystore.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-es-secure-settings.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-es-secure-settings.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/secure-settings.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/secure-settings.md)
+* [/raw-migrated-files/kibana/kibana/secure-settings.md](/raw-migrated-files/kibana/kibana/secure-settings.md)

--- a/deploy-manage/security/secure-your-cluster-deployment.md
+++ b/deploy-manage/security/secure-your-cluster-deployment.md
@@ -38,3 +38,9 @@ $$$install-stack-demo-secure-second-node$$$
 $$$install-stack-demo-secure-transport$$$
 
 $$$install-stack-demo-secure-view-data$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/es-security-principles.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/es-security-principles.md)
+* [/raw-migrated-files/kibana/kibana/using-kibana-with-security.md](/raw-migrated-files/kibana/kibana/using-kibana-with-security.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/install-stack-demo-secure.md](/raw-migrated-files/stack-docs/elastic-stack/install-stack-demo-secure.md)

--- a/deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
+++ b/deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
@@ -33,3 +33,9 @@ $$$restore-entire-cluster$$$
 $$$restore-index-data-stream$$$
 
 $$$troubleshoot-restore$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/snapshots-restore-snapshot.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/snapshots-restore-snapshot.md)
+* [/raw-migrated-files/cloud/cloud/ec-restore-across-clusters.md](/raw-migrated-files/cloud/cloud/ec-restore-across-clusters.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-restore-across-clusters.md](/raw-migrated-files/cloud/cloud-enterprise/ece-restore-across-clusters.md)

--- a/deploy-manage/upgrade/deployment-or-cluster.md
+++ b/deploy-manage/upgrade/deployment-or-cluster.md
@@ -58,3 +58,18 @@ $$$prepare-to-upgrade-8x$$$
 $$$rolling-upgrades$$$
 
 $$$upgrading-reindex$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/kibana/kibana/upgrade.md](/raw-migrated-files/kibana/kibana/upgrade.md)
+* [/raw-migrated-files/kibana/kibana/upgrade-migrations-rolling-back.md](/raw-migrated-files/kibana/kibana/upgrade-migrations-rolling-back.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/upgrading-elastic-stack.md](/raw-migrated-files/stack-docs/elastic-stack/upgrading-elastic-stack.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/upgrading-elasticsearch.md](/raw-migrated-files/stack-docs/elastic-stack/upgrading-elasticsearch.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/upgrading-kibana.md](/raw-migrated-files/stack-docs/elastic-stack/upgrading-kibana.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-upgrade-deployment.md](/raw-migrated-files/cloud/cloud-enterprise/ece-upgrade-deployment.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-upgrade-deployment.md](/raw-migrated-files/cloud/cloud-heroku/ech-upgrade-deployment.md)
+* [/raw-migrated-files/cloud/cloud/ec-upgrade-deployment.md](/raw-migrated-files/cloud/cloud/ec-upgrade-deployment.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/upgrade-elastic-stack-for-elastic-cloud.md](/raw-migrated-files/stack-docs/elastic-stack/upgrade-elastic-stack-for-elastic-cloud.md)
+* [/raw-migrated-files/stack-docs/elastic-stack/upgrading-elastic-stack-on-prem.md](/raw-migrated-files/stack-docs/elastic-stack/upgrading-elastic-stack-on-prem.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-upgrading-stack.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-upgrading-stack.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-orchestration.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-orchestration.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
@@ -27,3 +27,9 @@ $$$tls-active-directory$$$
 
 $$$ad-user-metadata$$$
 
+
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/active-directory-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/active-directory-realm.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-ad.md](/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-ad.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md
@@ -20,3 +20,8 @@ $$$built-in-roles$$$
 $$$built-in-roles-kibana-admin$$$
 
 $$$built-in-roles-remote-monitoring-agent$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/built-in-roles.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/built-in-roles.md)
+* [/raw-migrated-files/kibana/kibana/xpack-security-authorization.md](/raw-migrated-files/kibana/kibana/xpack-security-authorization.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
@@ -31,3 +31,13 @@ mapped_urls:
 $$$set-built-in-user-passwords$$$
 
 $$$bootstrap-elastic-passwords$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/built-in-users.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/built-in-users.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-password-reset-elastic.md](/raw-migrated-files/cloud/cloud-enterprise/ece-password-reset-elastic.md)
+* [/raw-migrated-files/cloud/cloud/ec-password-reset.md](/raw-migrated-files/cloud/cloud/ec-password-reset.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-password-reset.md](/raw-migrated-files/cloud/cloud-heroku/ech-password-reset.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-rotate-credentials.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-rotate-credentials.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/change-passwords-native-users.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/change-passwords-native-users.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
@@ -22,3 +22,9 @@ mapped_urls:
 $$$multiple-roles-dls-fls$$$
 
 $$$templating-role-query$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/document-level-security.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/document-level-security.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/field-level-security.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/field-level-security.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/field-and-document-access-control.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/field-and-document-access-control.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
@@ -39,3 +39,11 @@ $$$roles-indices-priv$$$
 $$$roles-management-ui$$$
 
 $$$roles-management-api$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/defining-roles.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/defining-roles.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/defining-roles.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/defining-roles.md)
+* [/raw-migrated-files/kibana/kibana/tutorial-secure-access-to-kibana.md](/raw-migrated-files/kibana/kibana/tutorial-secure-access-to-kibana.md)
+* [/raw-migrated-files/kibana/kibana/kibana-role-management.md](/raw-migrated-files/kibana/kibana/kibana-role-management.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
@@ -17,3 +17,8 @@ mapped_urls:
 %      Notes: file realm content
 
 $$$file-realm-configuration$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/file-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/file-realm.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
@@ -22,3 +22,10 @@ mapped_urls:
 % Internal links rely on the following IDs being on this page (e.g. as a heading ID, paragraph ID, etc):
 
 $$$jwt-realm-runas$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/cloud/cloud/ec-securing-clusters-JWT.md](/raw-migrated-files/cloud/cloud/ec-securing-clusters-JWT.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-JWT.md](/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-JWT.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-securing-clusters-JWT.md](/raw-migrated-files/cloud/cloud-heroku/ech-securing-clusters-JWT.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/jwt-auth-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/jwt-auth-realm.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
@@ -24,3 +24,8 @@ $$$tls-ldap$$$
 $$$mapping-roles-ldap$$$
 
 $$$ldap-user-metadata$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/ldap-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/ldap-realm.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-ldap.md](/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-ldap.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
@@ -26,3 +26,9 @@ $$$ldap-role-mapping$$$
 $$$mapping-roles-api$$$
 
 $$$mapping-roles-rule-field$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/mapping-roles.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/mapping-roles.md)
+* [/raw-migrated-files/kibana/kibana/role-mappings.md](/raw-migrated-files/kibana/kibana/role-mappings.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/role-mapping-resources.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/role-mapping-resources.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
@@ -25,3 +25,10 @@ mapped_urls:
 $$$k8s-default-elastic-user$$$
 
 $$$managing-native-users$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/native-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/native-realm.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-users-and-roles.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/change-passwords-native-users.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/change-passwords-native-users.md)
+* [/raw-migrated-files/kibana/kibana/tutorial-secure-access-to-kibana.md](/raw-migrated-files/kibana/kibana/tutorial-secure-access-to-kibana.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
@@ -67,3 +67,12 @@ $$$oidc-role-mappings$$$
 $$$oidc-user-metadata$$$
 
 $$$oidc-user-properties$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/oidc-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/oidc-realm.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/oidc-guide.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/oidc-guide.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-secure-clusters-oidc.md](/raw-migrated-files/cloud/cloud-enterprise/ece-secure-clusters-oidc.md)
+* [/raw-migrated-files/cloud/cloud/ec-secure-clusters-oidc.md](/raw-migrated-files/cloud/cloud/ec-secure-clusters-oidc.md)
+* [/raw-migrated-files/cloud/cloud/ec-securing-clusters-oidc-op.md](/raw-migrated-files/cloud/cloud/ec-securing-clusters-oidc-op.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-secure-clusters-oidc.md](/raw-migrated-files/cloud/cloud-heroku/ech-secure-clusters-oidc.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
@@ -69,3 +69,17 @@ $$$saml-elasticsearch-authentication$$$
 $$$saml-no-kibana-sp-init-sso$$$
 
 $$$req-authn-context$$$
+
+**This page is a work in progress.** The documentation team is working to combine content pulled from the following pages:
+
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/saml-realm.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/saml-realm.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece_sign_outgoing_saml_message.md](/raw-migrated-files/cloud/cloud-enterprise/ece_sign_outgoing_saml_message.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece_optional_settings.md](/raw-migrated-files/cloud/cloud-enterprise/ece_optional_settings.md)
+* [/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-SAML.md](/raw-migrated-files/cloud/cloud-enterprise/ece-securing-clusters-SAML.md)
+* [/raw-migrated-files/cloud/cloud/ec-securing-clusters-SAML.md](/raw-migrated-files/cloud/cloud/ec-securing-clusters-SAML.md)
+* [/raw-migrated-files/cloud/cloud/ec-sign-outgoing-saml-message.md](/raw-migrated-files/cloud/cloud/ec-sign-outgoing-saml-message.md)
+* [/raw-migrated-files/cloud/cloud/ec-securing-clusters-saml-azure.md](/raw-migrated-files/cloud/cloud/ec-securing-clusters-saml-azure.md)
+* [/raw-migrated-files/cloud/cloud-heroku/ech-securing-clusters-SAML.md](/raw-migrated-files/cloud/cloud-heroku/ech-securing-clusters-SAML.md)
+* [/raw-migrated-files/cloud/cloud-heroku/echsign-outgoing-saml-message.md](/raw-migrated-files/cloud/cloud-heroku/echsign-outgoing-saml-message.md)
+* [/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-saml-authentication.md](/raw-migrated-files/cloud-on-k8s/cloud-on-k8s/k8s-saml-authentication.md)
+* [/raw-migrated-files/elasticsearch/elasticsearch-reference/saml-guide-stack.md](/raw-migrated-files/elasticsearch/elasticsearch-reference/saml-guide-stack.md)


### PR DESCRIPTION
The logic I used to identify the pages in https://github.com/elastic/docs-content/pull/488 didn't account for pages that include code comments AND IDs (like this `$$$some-id$$$`). 