### PR TITLE
[cross-repo links] Add ID that cross-repo links depends on

### DIFF
--- a/deploy-manage/deploy/kibana-reporting-configuration.md
+++ b/deploy-manage/deploy/kibana-reporting-configuration.md
@@ -21,6 +21,8 @@ mapped_urls:
 
 $$$reporting-chromium-sandbox$$$
 
+$$$grant-user-access$$$
+
 ⚠️ **This page is a work in progress.** ⚠️
 
 The documentation team is working to combine content pulled from the following pages:


### PR DESCRIPTION
Add another ID that cross-repo links depends on like we did in https://github.com/elastic/docs-content/pull/495. 