### PR TITLE
Handle `index.html` AsciiDoc links

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise.md
+++ b/deploy-manage/deploy/cloud-enterprise.md
@@ -1,5 +1,6 @@
 ---
 mapped_urls:
+  - https://www.elastic.co/guide/en/cloud-enterprise/current/index.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/Elastic-Cloud-Enterprise-overview.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-administering-ece.html
 ---

--- a/deploy-manage/deploy/cloud-enterprise/ece-regional-deployment-aliases.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-regional-deployment-aliases.md
@@ -99,5 +99,5 @@ While the `TransportClient` is deprecated, your custom endpoint aliases still wo
     ```
 
 
-For more information on configuring the `TransportClient`, see [Configure the Java Transport Client](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html).
+For more information on configuring the `TransportClient`, see [Configure the Java Transport Client](asciidocalypse://docs/elasticsearch-java/docs/reference/elasticsearch/elasticsearch-client-java-api-client/index.md).
 

--- a/deploy-manage/deploy/cloud-on-k8s.md
+++ b/deploy-manage/deploy/cloud-on-k8s.md
@@ -2,6 +2,7 @@
 applies:
   eck: all
 mapped_urls:
+  - https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-topics.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-supported.html

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-openshift-agent.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-openshift-agent.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 # Grant host access permission to Elastic Agent [k8s-openshift-agent]
 
-Deploying Elastic Agent on Openshift may require additional permissions depending on the type of [integration](https://www.elastic.co/guide/en/fleet/current/index.html) Elastic Agent is supposed to run. In any case, Elastic Agent uses a [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume as its data directory on OpenShift to maintain a stable identity. Therefore, the Service Account used for Elastic Agent needs permissions to use hostPath volumes.
+Deploying Elastic Agent on Openshift may require additional permissions depending on the type of [integration](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/index.md) Elastic Agent is supposed to run. In any case, Elastic Agent uses a [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume as its data directory on OpenShift to maintain a stable identity. Therefore, the Service Account used for Elastic Agent needs permissions to use hostPath volumes.
 
 The following example assumes that Elastic Agent is deployed in the Namespace `elastic` with the ServiceAccount `elastic-agent`. You can replace these values according to your environment.
 

--- a/deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md
+++ b/deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md
@@ -20,7 +20,7 @@ There are two ways to add plugins to a deployment in Elasticsearch Service:
 
 Custom plugins can include the official {{es}} plugins not provided with Elasticsearch Service, any of the community-sourced plugins, or [plugins that you write yourself](asciidocalypse://docs/elasticsearch/docs/extend/create-elasticsearch-plugins/index.md). Uploading custom plugins is available only to Gold, Platinum, and Enterprise subscriptions. For more information, check [Upload custom plugins and bundles](upload-custom-plugins-bundles.md).
 
-To learn more about the official and community-sourced plugins, refer to [{{es}} Plugins and Integrations](https://www.elastic.co/guide/en/elasticsearch/plugins/current/index.html).
+To learn more about the official and community-sourced plugins, refer to [{{es}} Plugins and Integrations](asciidocalypse://docs/elasticsearch/docs/reference/elasticsearch-plugins/index.md).
 
 For a detailed guide with examples of using the Elasticsearch Service API to create, get information about, update, and delete extensions and plugins, check [Managing plugins and extensions through the API](manage-plugins-extensions-through-api.md).
 

--- a/deploy-manage/deploy/elastic-cloud/cloud-hosted.md
+++ b/deploy-manage/deploy/elastic-cloud/cloud-hosted.md
@@ -1,5 +1,6 @@
 ---
 mapped_urls:
+  - https://www.elastic.co/guide/en/cloud/current/index.html
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html
   - https://www.elastic.co/guide/en/cloud/current/ec-prepare-production.html
   - https://www.elastic.co/guide/en/cloud/current/ec-faq-getting-started.html

--- a/deploy-manage/deploy/elastic-cloud/ech-getting-started.md
+++ b/deploy-manage/deploy/elastic-cloud/ech-getting-started.md
@@ -1,6 +1,7 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-getting-started.html
+  - https://www.elastic.co/guide/en/cloud-heroku/current/index.html
 ---
 
 # Introducing Elasticsearch Add-On for Heroku [ech-getting-started]

--- a/deploy-manage/deploy/elastic-cloud/serverless.md
+++ b/deploy-manage/deploy/elastic-cloud/serverless.md
@@ -1,5 +1,6 @@
 ---
 mapped_urls:
+  - https://www.elastic.co/guide/en/serverless/current/index.html
   - https://www.elastic.co/guide/en/serverless/current/intro.html
   - https://www.elastic.co/guide/en/serverless/current/general-serverless-status.html
 ---

--- a/deploy-manage/deploy/self-managed/plugins.md
+++ b/deploy-manage/deploy/self-managed/plugins.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 Plugins are a way to enhance the basic Elasticsearch functionality in a custom manner. They range from adding custom mapping types, custom analyzers (in a more built in fashion), custom script engines, custom discovery and more.
 
-For information about selecting and installing plugins, see [{{es}} Plugins and Integrations](https://www.elastic.co/guide/en/elasticsearch/plugins/current/index.html).
+For information about selecting and installing plugins, see [{{es}} Plugins and Integrations](asciidocalypse://docs/elasticsearch/docs/reference/elasticsearch-plugins/index.md).
 
 For information about developing your own plugin, see [Help for plugin authors](asciidocalypse://docs/elasticsearch/docs/extend/create-elasticsearch-plugins/index.md).
 

--- a/deploy-manage/index.md
+++ b/deploy-manage/index.md
@@ -6,6 +6,7 @@ mapped_urls:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/scalability.html
   - https://www.elastic.co/guide/en/cloud/current/ec-faq-technical.html
   - https://www.elastic.co/guide/en/elastic-stack/current/overview.html
+  - https://www.elastic.co/guide/en/elastic-stack/current/index.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-administering-deployments.html
   - https://www.elastic.co/guide/en/kibana/current/management.html
 ---

--- a/deploy-manage/reference-architectures.md
+++ b/deploy-manage/reference-architectures.md
@@ -1,6 +1,7 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/reference-architectures/current/reference-architectures-overview.html
+  - https://www.elastic.co/guide/en/reference-architectures/current/index.html
 applies:
   stack: all
   hosted: all
@@ -14,14 +15,14 @@ Elasticsearch reference architectures are blueprints for deploying Elasticsearch
 
 These architectures are designed by architects and engineers to provide standardized, proven solutions that help you to follow best practices when deploying {{es}}.
 
-::::{tip} 
+::::{tip}
 These architectures are specific to deploying Elastic on {{ech}}, {{eck}}, {{ece}}, or deploying a self-managed instance. If you are using {{serverless-full}}, your {{es}} clusters are autoscaled and fully managed by Elastic. To learn about all of the deployment options, refer to the [Deploy and manage overview](/deploy-manage/index.md).
 ::::
 
 
 These reference architectures are recommendations and should be adapted to fit your specific environment and needs. Each solution can vary based on the unique requirements and conditions of your deployment. In these architectures we discuss about how to deploy cluster components. For information about designing ingest architectures to feed content into your cluster, refer to [Ingest architectures](../manage-data/ingest/ingest-reference-architectures.md).
 
-## Architectures [reference-architectures-time-series] 
+## Architectures [reference-architectures-time-series]
 
 |     |     |
 | --- | --- |

--- a/explore-analyze/machine-learning/anomaly-detection/ml-getting-started.md
+++ b/explore-analyze/machine-learning/anomaly-detection/ml-getting-started.md
@@ -17,7 +17,7 @@ Ready to take {{anomaly-detect}} for a test drive? Follow this tutorial to:
 
 At the end of this tutorial, you should have a good idea of what {{ml}} is and will hopefully be inspired to use it to detect anomalies in your own data.
 
-Need more context? Check out the [{{es}} introduction](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html) to learn the lingo and understand the basics of how {{es}} works.
+Need more context? Check out the [{{es}} introduction](/get-started/index.md) to learn the lingo and understand the basics of how {{es}} works.
 
 ## Try it out [get-started-prereqs]
 

--- a/get-started/index.md
+++ b/get-started/index.md
@@ -1,6 +1,9 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro-what-is-es.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html
+  - https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html
+  - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/index.html
 ---
 
 # Get started [elasticsearch-intro-what-is-es]

--- a/get-started/the-stack.md
+++ b/get-started/the-stack.md
@@ -64,7 +64,7 @@ $$$stack-components-logstash$$$
 $$$stack-components-elasticsearch$$$
 
 {{es}}
-:   {{es}} is the distributed search and analytics engine at the heart of the {{stack}}. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, {{es}} can efficiently store and index it in a way that supports fast searches. {{es}} provides a REST API that enables you to store data in {{es}} and retrieve it. The REST API also provides access to {{es}}'s search and analytics capabilities. [Learn more about {{es}}](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html).
+:   {{es}} is the distributed search and analytics engine at the heart of the {{stack}}. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, {{es}} can efficiently store and index it in a way that supports fast searches. {{es}} provides a REST API that enables you to store data in {{es}} and retrieve it. The REST API also provides access to {{es}}'s search and analytics capabilities. [Learn more about {{es}}](/get-started/index.md).
 
 
 ### Consume [_consume]

--- a/get-started/the-stack.md
+++ b/get-started/the-stack.md
@@ -2,6 +2,7 @@
 mapped_urls:
   - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/stack-components.html
   - https://www.elastic.co/guide/en/kibana/current/introduction.html
+  - https://www.elastic.co/guide/en/kibana/current/index.html
   - https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html
 ---
 

--- a/manage-data/ingest/transform-enrich/ingest-pipelines.md
+++ b/manage-data/ingest/transform-enrich/ingest-pipelines.md
@@ -246,7 +246,7 @@ output.elasticsearch:
 
 ## Pipelines for {{fleet}} and {{agent}} [pipelines-for-fleet-elastic-agent]
 
-{{agent}} integrations ship with default ingest pipelines that preprocess and enrich data before indexing. [{{fleet}}](https://www.elastic.co/guide/en/fleet/current/index.html) applies these pipelines using [index templates](../../data-store/templates.md) that include [pipeline index settings](ingest-pipelines.md#set-default-pipeline). {{es}} matches these templates to your {{fleet}} data streams based on the [stream’s naming scheme](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/data-streams.md#data-streams-naming-scheme).
+{{agent}} integrations ship with default ingest pipelines that preprocess and enrich data before indexing. [{{fleet}}](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/index.md) applies these pipelines using [index templates](../../data-store/templates.md) that include [pipeline index settings](ingest-pipelines.md#set-default-pipeline). {{es}} matches these templates to your {{fleet}} data streams based on the [stream’s naming scheme](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/data-streams.md#data-streams-naming-scheme).
 
 Each default integration pipeline calls a nonexistent, unversioned `*@custom` ingest pipeline. If unaltered, this pipeline call has no effect on your data. However, you can modify this call to create custom pipelines for integrations that persist across upgrades. Refer to [Tutorial: Transform data with custom ingest pipelines](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/data-streams-pipeline-tutorial.md) to learn more.
 

--- a/raw-migrated-files/cloud/cloud-heroku/ech-adding-plugins.md
+++ b/raw-migrated-files/cloud/cloud-heroku/ech-adding-plugins.md
@@ -15,7 +15,7 @@ There are two ways to add plugins to a deployment in Elasticsearch Add-On for He
 
 Custom plugins can include the official {{es}} plugins not provided with Elasticsearch Add-On for Heroku, any of the community-sourced plugins, or [plugins that you write yourself](asciidocalypse://docs/elasticsearch/docs/extend/create-elasticsearch-plugins/index.md). Uploading custom plugins is available only to Gold, Platinum, and Enterprise subscriptions. For more information, check [Upload custom plugins and bundles](../../../deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md).
 
-To learn more about the official and community-sourced plugins, refer to [{{es}} Plugins and Integrations](https://www.elastic.co/guide/en/elasticsearch/plugins/current/index.html).
+To learn more about the official and community-sourced plugins, refer to [{{es}} Plugins and Integrations](asciidocalypse://docs/elasticsearch/docs/reference/elasticsearch-plugins/index.md).
 
 Plugins are not supported for {{kib}}. To learn more, check [Restrictions for {{es}} and {{kib}} plugins](../../../deploy-manage/deploy/elastic-cloud/ech-restrictions.md#ech-restrictions-plugins).
 

--- a/raw-migrated-files/observability-docs/observability/observability-get-started.md
+++ b/raw-migrated-files/observability-docs/observability/observability-get-started.md
@@ -68,5 +68,5 @@ Ready to dig into more features of Elastic Observability? See these guides:
 
 ## Related content [_related_content]
 
-* [Starting with the {{es}} Platform and its Solutions](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/index.html) for new users
+* [Starting with the {{es}} Platform and its Solutions](/get-started/index.md) for new users
 * [Adding data to {{es}}](../../../manage-data/ingest.md) for other ways to ingest data

--- a/raw-migrated-files/stack-docs/elastic-stack/overview.md
+++ b/raw-migrated-files/stack-docs/elastic-stack/overview.md
@@ -4,10 +4,10 @@ The products in the [{{stack}}](https://www.elastic.co/products) are designed to
 
 * [Beats master](asciidocalypse://docs/beats/docs/reference/ingestion-tools/index.md)
 * [APM master](https://www.elastic.co/guide/en/apm/guide/current/index.html)
-* [Elasticsearch master](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)
-* [Elasticsearch Hadoop master](https://www.elastic.co/guide/en/elasticsearch/hadoop/current/index.html)
-* [Kibana master](https://www.elastic.co/guide/en/kibana/current/index.html)
-* [Logstash master](https://www.elastic.co/guide/en/logstash/current/index.html)
+* [Elasticsearch master](/get-started/index.md)
+* [Elasticsearch Hadoop master](asciidocalypse://docs/elasticsearch-hadoop/docs/reference/ingestion-tools/elasticsearch-hadoop/preface.md)
+* [Kibana master](/get-started/the-stack.md)
+* [Logstash master](asciidocalypse://docs/logstash/docs/reference/ingestion-tools/logstash/index.md)
 
 This guide provides information about installing and upgrading when you are using more than one {{stack}} product. It specifies the recommended order of installation and the steps you need to take to prepare for a stack upgrade.
 

--- a/solutions/observability/apps/configure-real-user-monitoring-rum.md
+++ b/solutions/observability/apps/configure-real-user-monitoring-rum.md
@@ -17,7 +17,7 @@ Most options in this section are supported by all APM Server deployment methods.
 ::::
 
 
-The [Real User Monitoring (RUM) agent](https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html) captures user interactions with clients such as web browsers. These interactions are sent as events to the APM Server. Because the RUM agent runs on the client side, the connection between agent and server is unauthenticated. As a security precaution, RUM is therefore disabled by default.
+The [Real User Monitoring (RUM) agent](asciidocalypse://docs/apm-agent-rum-js/docs/reference/ingestion-tools/apm-agent-rum-js/index.md) captures user interactions with clients such as web browsers. These interactions are sent as events to the APM Server. Because the RUM agent runs on the client side, the connection between agent and server is unauthenticated. As a security precaution, RUM is therefore disabled by default.
 
 :::::::{tab-set}
 

--- a/solutions/observability/apps/tutorial-monitor-java-application.md
+++ b/solutions/observability/apps/tutorial-monitor-java-application.md
@@ -15,7 +15,7 @@ You’ll learn how to:
 * Create a sample Java application.
 * Ingest logs using {{filebeat}} and view your logs in {{kib}}.
 * Ingest metrics using the [Metricbeat Prometheus Module](asciidocalypse://docs/beats/docs/reference/ingestion-tools/beats-metricbeat/metricbeat-module-prometheus.md) and view your metrics in {{kib}}.
-* Instrument your application using the [Elastic APM Java agent](https://www.elastic.co/guide/en/apm/agent/java/current/index.html).
+* Instrument your application using the [Elastic APM Java agent](asciidocalypse://docs/apm-agent-java/docs/reference/ingestion-tools/apm-agent-java/index.md).
 * Monitor your services using {{heartbeat}} and view your uptime data in {{kib}}.
 
 
@@ -917,7 +917,7 @@ You have now learned about parsing logs in either {{beats}} or {{es}}. What if w
 
 Writing out logs as plain text works and is easy to read for humans. However, first writing them out as plain text, parsing them using the `dissect` processors, and then creating a JSON again sounds tedious and burns unneeded CPU cycles.
 
-While log4j2 has a [JSONLayout](https://logging.apache.org/log4j/2.x/manual/layouts.md#JSONLayout), you can go further and use a Library called [ecs-logging-java](https://github.com/elastic/ecs-logging-java). The advantage of ECS logging is that it uses the [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html). ECS defines a standard set of fields used when storing event data in {{es}}, such as logs and metrics.
+While log4j2 has a [JSONLayout](https://logging.apache.org/log4j/2.x/manual/layouts.md#JSONLayout), you can go further and use a Library called [ecs-logging-java](https://github.com/elastic/ecs-logging-java). The advantage of ECS logging is that it uses the [Elastic Common Schema](asciidocalypse://docs/ecs/docs/reference/ecs/index.md). ECS defines a standard set of fields used when storing event data in {{es}}, such as logs and metrics.
 
 1. Instead of writing our logging standard, use an existing one. Let’s add the logging dependency to our Javalin application.
 

--- a/solutions/observability/cloud/monitor-amazon-cloud-compute-ec2.md
+++ b/solutions/observability/cloud/monitor-amazon-cloud-compute-ec2.md
@@ -51,7 +51,7 @@ Expand the **quick guide** to learn how, or skip to the next section if your dat
 
 9. When incoming data is confirmed—​after a minute or two—​click **View assets** to access the dashboards.
 
-For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](https://www.elastic.co/guide/en/fleet/current/index.html).
+For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/index.md).
 
 ::::
 

--- a/solutions/observability/cloud/monitor-amazon-kinesis-data-streams.md
+++ b/solutions/observability/cloud/monitor-amazon-kinesis-data-streams.md
@@ -53,7 +53,7 @@ Expand the **quick guide** to learn how, or skip to the next section if your dat
 
 9. When incoming data is confirmed—​after a minute or two—​click **View assets** to access the dashboards.
 
-For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](https://www.elastic.co/guide/en/fleet/current/index.html).
+For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/index.md).
 
 ::::
 

--- a/solutions/observability/cloud/monitor-amazon-simple-queue-service-sqs.md
+++ b/solutions/observability/cloud/monitor-amazon-simple-queue-service-sqs.md
@@ -49,7 +49,7 @@ Expand the **quick guide** to learn how, or skip to the next section if your dat
 
 9. When incoming data is confirmed—​after a minute or two—​click **View assets** to access the dashboards.
 
-For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](https://www.elastic.co/guide/en/fleet/current/index.html).
+For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/index.md).
 
 ::::
 

--- a/solutions/observability/cloud/monitor-amazon-simple-storage-service-s3.md
+++ b/solutions/observability/cloud/monitor-amazon-simple-storage-service-s3.md
@@ -52,7 +52,7 @@ Expand the **quick guide** to learn how, or skip to the next section if your dat
 
 9. When incoming data is confirmed—​after a minute or two—​click **View assets** to access the dashboards.
 
-For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](https://www.elastic.co/guide/en/fleet/current/index.html).
+For more information {{agent}} and integrations, refer to the [{{fleet}} and {{agent}} documentation](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/index.md).
 
 ::::
 

--- a/solutions/observability/get-started.md
+++ b/solutions/observability/get-started.md
@@ -2,6 +2,7 @@
 mapped_urls:
   - https://www.elastic.co/guide/en/serverless/current/observability-get-started.html
   - https://www.elastic.co/guide/en/observability/current/observability-get-started.html
+  - https://www.elastic.co/guide/en/observability/current/index.html
 ---
 
 # Get started

--- a/solutions/search/site-or-app/search-ui.md
+++ b/solutions/search/site-or-app/search-ui.md
@@ -2,6 +2,7 @@
 navigation_title: "Search UI"
 mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/overview.html
+  - https://www.elastic.co/guide/en/search-ui/current/index.html
 applies:
   stack:
   serverless:

--- a/solutions/security.md
+++ b/solutions/security.md
@@ -1,6 +1,7 @@
 ---
 navigation_title: "Security"
 mapped_urls:
+  - https://www.elastic.co/guide/en/security/current/index.html
   - https://www.elastic.co/guide/en/security/current/es-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-overview.html
 ---
@@ -17,7 +18,7 @@ mapped_urls:
 * Integrations for collecting data from various sources
 
 
-## Learn more [siem-integration] 
+## Learn more [siem-integration]
 
 * [Get started](security/get-started.md): Learn about system requirements, workspaces, configuration, and data ingestion.
 * [{{elastic-sec}} UI overview](security/get-started/elastic-security-ui.md): Navigate {{elastic-sec}}'s various tools and interfaces.
@@ -30,7 +31,7 @@ mapped_urls:
 * [{{elastic-sec}} fields and object schemas](asciidocalypse://docs/docs-content/docs/reference/security/fields-and-object-schemas/index.md): Learn how to structure data for use with {{elastic-sec}}.
 
 
-## {{es}} and {{kib}} [elastic-search-and-kibana] 
+## {{es}} and {{kib}} [elastic-search-and-kibana]
 
 {{elastic-sec}} uses {{es}} for data storage, management, and search, and {{kib}} is its main user interface. Learn more:
 
@@ -38,7 +39,7 @@ mapped_urls:
 * [{{kib}}](https://www.elastic.co/products/kibana): An open-source analytics and visualization platform designed to work with {{es}} and {{elastic-sec}}. {{kib}} allows you to search, view, analyze and visualize data stored in {{es}} indices.
 
 
-### {{elastic-endpoint}} self-protection [self-protection] 
+### {{elastic-endpoint}} self-protection [self-protection]
 
 For information about {{elastic-endpoint}}'s tamper-protection features, refer to [{{elastic-endpoint}} self-protection](security/manage-elastic-defend/elastic-endpoint-self-protection-features.md).
 

--- a/troubleshoot/ingest/fleet/frequently-asked-questions.md
+++ b/troubleshoot/ingest/fleet/frequently-asked-questions.md
@@ -129,7 +129,7 @@ By default, {{kib}} requires an internet connection to download integration pack
 
 ## Does {{agent}} download anything from the Internet? [does-agent-download-anything-from-internet]
 
-* In version 7.10 and later, a fully capable artifact can be installed with no connection to the Elastic download site. However, if it is in use, the {{elastic-defend}} process is instructed to attempt to download newer released versions of the integration-specific artifacts it uses. Some of those are, for example, the malware model, trusted applications artifact, exceptions list artifact, and others. {{elastic-endpoint}} will continue to protect the host even if it’s unable to download updates. However, it won’t receive updates to protections until {{agent}} is upgraded to a new version. For more information, refer to the [{{elastic-sec}} documentation](https://www.elastic.co/guide/en/security/current/index.html).
+* In version 7.10 and later, a fully capable artifact can be installed with no connection to the Elastic download site. However, if it is in use, the {{elastic-defend}} process is instructed to attempt to download newer released versions of the integration-specific artifacts it uses. Some of those are, for example, the malware model, trusted applications artifact, exceptions list artifact, and others. {{elastic-endpoint}} will continue to protect the host even if it’s unable to download updates. However, it won’t receive updates to protections until {{agent}} is upgraded to a new version. For more information, refer to the [{{elastic-sec}} documentation](/solutions/security.md).
 * {{agent}} requires internet access to download artifacts for binary upgrades. In air-gapped environments, you can host your own artifact registry. For more information, refer to [Air-gapped environments](asciidocalypse://docs/docs-content/docs/reference/ingestion-tools/fleet/air-gapped.md).
 
 
@@ -142,7 +142,7 @@ For example, standalone {{beats}} use modules and require you to run a setup com
 
 ## What is the {{elastic-defend}} integration in {{fleet}}? [what-is-the-endpoint-package]
 
-The {{elastic-defend}} integration provides protection on your {{agent}} controlled host. The integration monitors your host for security-related events, allowing for investigation of security data through the {{security-app}} in {{kib}}. The {{elastic-defend}} integration is managed by {{agent}} in the same way as other integrations. Try it out! For more information, refer to the [{{elastic-sec}} documentation](https://www.elastic.co/guide/en/security/current/index.html).
+The {{elastic-defend}} integration provides protection on your {{agent}} controlled host. The integration monitors your host for security-related events, allowing for investigation of security data through the {{security-app}} in {{kib}}. The {{elastic-defend}} integration is managed by {{agent}} in the same way as other integrations. Try it out! For more information, refer to the [{{elastic-sec}} documentation](/solutions/security.md).
 
 
 ## How are communications secured between {{elastic-sec}} and {{agent}}? [how-are-security-to-agent-communications-secured]


### PR DESCRIPTION
Replace links to `index.html` paths in the AsciiDoc docs (for example, https://www.elastic.co/guide/en/beats/heartbeat/current/index.html).