### PR TITLE
[AutoOps] Update the supported AutoOps regions

### DIFF
--- a/deploy-manage/monitor/autoops/ec-autoops-regions.md
+++ b/deploy-manage/monitor/autoops/ec-autoops-regions.md
@@ -16,6 +16,7 @@ AutoOps is currently available in the following regions:
 | AWS | us-east-1 | US East (N. Virginia) |  |
 | AWS | us-west-2 | Oregon |  |
 | AWS | eu-west-1 | Ireland |  |
+| AWS | ap-southeast-1 |  Singapore | |
 
 ::::{note} 
 Currently, a limited number of AWS regions are available. More regions for AWS, Azure and GCP will be added in the future. Also, AutoOps is currently not available for GovCloud customers.


### PR DESCRIPTION
This PR adds Singapore to the supported [AutoOps regions](https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/deploy-manage/monitor/autoops/ec-autoops-regions). 


Relates to https://github.com/elastic/docs-content/issues/571