### PR TITLE
Lock Podman major version

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/configure-host-rhel-cloud.md
+++ b/deploy-manage/deploy/cloud-enterprise/configure-host-rhel-cloud.md
@@ -72,16 +72,24 @@ Verify that required traffic is allowed. Check the [Networking prerequisites](ec
 
 4. Install podman:
 
-    * For RHEL 8 and Rocky Linux, install version `4.*`.
+    * Install the latest available version `4.*` using dnf.
 
         ```sh
         sudo dnf install podman-4.* podman-remote-4.*
         ```
 
-    * For RHEL 9, install the latest available version `4.*` using dnf.
+    * To prevent automatic Podman major version updates, configure the Podman version to be locked while still allowing minor and patch updates.
 
         ```sh
-        sudo dnf install podman-4.* podman-remote-4.*
+        ## Install versionlock
+        sudo dnf install 'dnf-command(versionlock)'
+
+        ## Lock major version
+        sudo dnf versionlock add --raw 'podman-4.*'
+        sudo dnf versionlock add --raw 'podman-remote-4.*'
+
+        ## Verify that podman-4.* and podman-remote-4.* appear in the output
+        sudo dnf versionlock list
         ```
 
 5. [This step is for RHEL 9 and Rocky Linux 9 only] Switch the network stack from Netavark to CNI:

--- a/deploy-manage/deploy/cloud-enterprise/configure-host-rhel-onprem.md
+++ b/deploy-manage/deploy/cloud-enterprise/configure-host-rhel-onprem.md
@@ -70,16 +70,24 @@ Verify that required traffic is allowed.
 
 4. Install podman:
 
-    * For RHEL 8 and Rocky Linux, install version `4.*`.
+    * Install the latest available version `4.*` using dnf.
 
         ```sh
         sudo dnf install podman-4.* podman-remote-4.*
         ```
 
-    * For RHEL 9, install the latest available version `4.*` using dnf.
+    * To prevent automatic Podman major version updates, configure the Podman version to be locked while still allowing minor and patch updates.
 
         ```sh
-        sudo dnf install podman-4.* podman-remote-4.*
+        ## Install versionlock
+        sudo dnf install 'dnf-command(versionlock)'
+
+        ## Lock major version
+        sudo dnf versionlock add --raw 'podman-4.*'
+        sudo dnf versionlock add --raw 'podman-remote-4.*'
+
+        ## Verify that podman-4.* and podman-remote-4.* appear in the output
+        sudo dnf versionlock list
         ```
 
 5. [This step is for RHEL 9 and Rocky Linux 9 only] Switch the network stack from Netavark to CNI:

--- a/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
+++ b/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
@@ -111,16 +111,24 @@ Otherwise, when the file content changes, the corresponding user is mentioned as
 
 4. Install podman:
 
-    * For RHEL 8 and Rocky Linux, install version `4.*`.
+    * Install the latest available version `4.*` using dnf.
 
         ```sh
         sudo dnf install podman-4.* podman-remote-4.*
         ```
 
-    * For RHEL 9, install the latest available version `4.*` using dnf.
+    * To prevent automatic Podman major version updates, configure the Podman version to be locked while still allowing minor and patch updates.
 
         ```sh
-        sudo dnf install podman-4.* podman-remote-4.*
+        ## Install versionlock
+        sudo dnf install 'dnf-command(versionlock)'
+
+        ## Lock major version
+        sudo dnf versionlock add --raw 'podman-4.*'
+        sudo dnf versionlock add --raw 'podman-remote-4.*'
+
+        ## Verify that podman-4.* and podman-remote-4.* appear in the output
+        sudo dnf versionlock list
         ```
 
 5. [This step is for RHEL 9 and Rocky Linux 9 only] Switch the network stack from Netavark to CNI:


### PR DESCRIPTION
## Summary

To prevent automatic Podman major version updates, configure the Podman version to be locked while still allowing minor and patch updates.

## Changes

<img width="733" alt="1" src="https://github.com/user-attachments/assets/05f20d98-7c95-427b-9ba5-94482a98d4f7" />

<img width="727" alt="2" src="https://github.com/user-attachments/assets/08687c29-5203-4fbc-b39b-1c2476c3354a" />

<img width="774" alt="3" src="https://github.com/user-attachments/assets/764cf1e4-3119-4652-8418-225c8096e1b0" />
