### PR TITLE
[security] Add missing mapped pages

### DIFF
--- a/solutions/security/cloud/benchmarks.md
+++ b/solutions/security/cloud/benchmarks.md
@@ -2,6 +2,8 @@
 mapped_urls:
   - https://www.elastic.co/guide/en/security/current/cspm-benchmark-rules.html
   - https://www.elastic.co/guide/en/serverless/current/security-benchmark-rules.html
+  - https://www.elastic.co/guide/en/serverless/current/security-benchmark-rules-kspm.html
+  - https://www.elastic.co/guide/en/security/current/benchmark-rules.html
 ---
 
 # Benchmarks

--- a/solutions/security/cloud/cspm-frequently-asked-questions-faq.md
+++ b/solutions/security/cloud/cspm-frequently-asked-questions-faq.md
@@ -2,6 +2,8 @@
 mapped_urls:
   - https://www.elastic.co/guide/en/security/current/cspm-security-posture-faq.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-security-posture-faq.html
+  - https://www.elastic.co/guide/en/serverless/current/security-posture-faq.html
+  - https://www.elastic.co/guide/en/security/current/security-posture-faq.html
 ---
 
 # Frequently asked questions (FAQ)

--- a/solutions/security/dashboards/cloud-native-vulnerability-management-dashboard.md
+++ b/solutions/security/dashboards/cloud-native-vulnerability-management-dashboard.md
@@ -2,6 +2,8 @@
 mapped_urls:
   - https://www.elastic.co/guide/en/security/current/vuln-management-dashboard-dash.html
   - https://www.elastic.co/guide/en/serverless/current/security-vuln-management-dashboard-dash.html
+  - https://www.elastic.co/guide/en/serverless/current/_cloud_native_vulnerability_management_dashboard.html
+  - https://www.elastic.co/guide/en/security/current/vuln-management-dashboard.html
 ---
 
 # Cloud Native Vulnerability Management Dashboard

--- a/solutions/security/dashboards/cloud-security-posture-dashboard.md
+++ b/solutions/security/dashboards/cloud-security-posture-dashboard.md
@@ -2,6 +2,10 @@
 mapped_urls:
   - https://www.elastic.co/guide/en/security/current/cloud-posture-dashboard.html
   - https://www.elastic.co/guide/en/serverless/current/security-cloud-posture-dashboard-dash.html
+  - https://www.elastic.co/guide/en/serverless/current/security-cloud-posture-dashboard-dash-cspm.html
+  - https://www.elastic.co/guide/en/serverless/current/security-cloud-posture-dashboard-dash-kspm.html
+  - https://www.elastic.co/guide/en/security/current/cspm-posture-dashboard.html
+  - https://www.elastic.co/guide/en/security/current/cloud-nat-sec-posture-dashboard.html
 ---
 
 # Cloud Security Posture dashboard


### PR DESCRIPTION
Does it make sense to redirect the AsciiDoc URLs I added in this PR to the v3 files they were added to? I _think_ it might be that there are some AsciiDoc pages that are near duplicates, but I could be wrong about that. 