### PR TITLE
[solutions] Fix external links

### DIFF
--- a/solutions/observability/apps/create-custom-links.md
+++ b/solutions/observability/apps/create-custom-links.md
@@ -138,7 +138,7 @@ This link creates a new task on the Engineering board in Jira. It populates the 
 | Label | `Open a task in Jira` |
 | Link | `https://test-site-33.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10000&issuetype=10001&summary=Created+via+APM&description=Investigate+the+following+APM+trace%3A%0D%0A%0D%0Aservice.name%3A+{{service.name}}%0D%0Atransaction.id%3A+{{transaction.id}}%0D%0Acontainer.id%3A+{{container.id}}%0D%0Aurl.full%3A+{{url.full}}` |
 
-See the [Jira application administration knowledge base](https://confluence.atlassian.com/jirakb/how-to-create-issues-using-direct-html-links-in-jira-server-159474.md) for a full list of supported query parameters.
+See the [Jira application administration knowledge base](https://confluence.atlassian.com/jirakb/how-to-create-issues-using-direct-html-links-in-jira-server-159474.html) for a full list of supported query parameters.
 
 
 ### Dashboards [custom-links-examples-kib]

--- a/solutions/observability/apps/create-upload-source-maps-rum.md
+++ b/solutions/observability/apps/create-upload-source-maps-rum.md
@@ -58,7 +58,7 @@ It can also be any other unique string that indicates a specific version of your
 
 ## Generate a source map [apm-source-map-rum-generate]
 
-To be compatible with Elastic APM, source maps must follow the [source map revision 3 proposal spec](https://sourcemaps.info/spec.md).
+To be compatible with Elastic APM, source maps must follow the [source map revision 3 proposal spec](https://sourcemaps.info/spec.html).
 
 Source maps can be generated and configured in many different ways. For example, parcel automatically generates source maps by default. If you’re using webpack, some configuration may be needed to generate a source map:
 

--- a/solutions/observability/apps/monitoring-aws-lambda-functions.md
+++ b/solutions/observability/apps/monitoring-aws-lambda-functions.md
@@ -18,7 +18,7 @@ AWS Lambda uses a special execution model to provide a scalable, on-demand compu
 1. To avoid data loss, APM data collected by APM agents needs to be flushed before the execution environment of a lambda function is frozen.
 2. Flushing APM data must be fast so as not to impact the response times of lambda function requests.
 
-To accomplish the above, Elastic APM agents instrument AWS Lambda functions and dispatch APM data via an [AWS Lambda extension](https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.md).
+To accomplish the above, Elastic APM agents instrument AWS Lambda functions and dispatch APM data via an [AWS Lambda extension](https://docs.aws.amazon.com/lambda/latest/dg/using-extensions.html).
 
 Normally, during the execution of a Lambda function, there’s only a single language process running in the AWS Lambda execution environment. With an AWS Lambda extension, Lambda users run a *second* process alongside their main service/application process.
 

--- a/solutions/observability/apps/tutorial-monitor-java-application.md
+++ b/solutions/observability/apps/tutorial-monitor-java-application.md
@@ -917,7 +917,7 @@ You have now learned about parsing logs in either {{beats}} or {{es}}. What if w
 
 Writing out logs as plain text works and is easy to read for humans. However, first writing them out as plain text, parsing them using the `dissect` processors, and then creating a JSON again sounds tedious and burns unneeded CPU cycles.
 
-While log4j2 has a [JSONLayout](https://logging.apache.org/log4j/2.x/manual/layouts.md#JSONLayout), you can go further and use a Library called [ecs-logging-java](https://github.com/elastic/ecs-logging-java). The advantage of ECS logging is that it uses the [Elastic Common Schema](asciidocalypse://docs/ecs/docs/reference/index.md). ECS defines a standard set of fields used when storing event data in {{es}}, such as logs and metrics.
+While log4j2 has a [JSONLayout](https://logging.apache.org/log4j/2.x/manual/layouts.html#JSONLayout), you can go further and use a Library called [ecs-logging-java](https://github.com/elastic/ecs-logging-java). The advantage of ECS logging is that it uses the [Elastic Common Schema](asciidocalypse://docs/ecs/docs/reference/index.md). ECS defines a standard set of fields used when storing event data in {{es}}, such as logs and metrics.
 
 1. Instead of writing our logging standard, use an existing one. Let’s add the logging dependency to our Javalin application.
 
@@ -1561,7 +1561,7 @@ A programmatic setup allows you to attach the agent via a line of java in your s
 
     This looks much better, having differences between endpoints.
 
-4. Add another endpoint to see the power of transactions, which polls another HTTP service. You may have heard of [wttr.in](https://wttr.in/), a service to poll weather information from. Let’s implement a proxy HTTP method that forwards the request to that endpoint. Let’s use [Apache HTTP client](https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.md), one of the most typical HTTP clients out there.
+4. Add another endpoint to see the power of transactions, which polls another HTTP service. You may have heard of [wttr.in](https://wttr.in/), a service to poll weather information from. Let’s implement a proxy HTTP method that forwards the request to that endpoint. Let’s use [Apache HTTP client](https://hc.apache.org/httpcomponents-client-4.5.x/quickstart.html), one of the most typical HTTP clients out there.
 
     ```gradle
     implementation 'org.apache.httpcomponents:fluent-hc:4.5.12'

--- a/solutions/observability/cicd.md
+++ b/solutions/observability/cicd.md
@@ -370,7 +370,7 @@ To learn more, see the [integration of Maven builds with Elastic {{observability
 
 The Ansible OpenTelemetry plugin integration provides visibility into all your Ansible playbooks. The plugin generates traces for each run and performance metrics to help you understand which Ansible tasks or roles are run the most, how often they fail, and how long they take to complete.
 
-You can configure your Ansible playbooks with the [Ansible OpenTelemetry callback plugin](https://docs.ansible.com/ansible/latest/collections/community/general/opentelemetry_callback.md). It’s required to install the OpenTelemetry python libraries and configure the callback as stated in the [examples](https://docs.ansible.com/ansible/latest/collections/community/general/opentelemetry_callback.md#examples) section.
+You can configure your Ansible playbooks with the [Ansible OpenTelemetry callback plugin](https://docs.ansible.com/ansible/latest/collections/community/general/opentelemetry_callback.html). It’s required to install the OpenTelemetry python libraries and configure the callback as stated in the [examples](https://docs.ansible.com/ansible/latest/collections/community/general/opentelemetry_callback.html#examples) section.
 
 The context propagation from the Jenkins job or pipeline is passed to the Ansible run. Therefore, everything that happens in the CI is also shown in the traces.
 
@@ -492,7 +492,7 @@ pytest --otel-session-name='My_Test_cases'
 
 ### Concourse CI [ci-cd-concourse-ci]
 
-To configure Concourse CI to send traces, refer to the [tracing](https://concourse-ci.org/tracing.md) docs. In the Concourse configuration, you just need to define `CONCOURSE_TRACING_OTLP_ADDRESS` and `CONCOURSE_TRACING_OTLP_HEADERS`.
+To configure Concourse CI to send traces, refer to the [tracing](https://concourse-ci.org/tracing.html) docs. In the Concourse configuration, you just need to define `CONCOURSE_TRACING_OTLP_ADDRESS` and `CONCOURSE_TRACING_OTLP_HEADERS`.
 
 ```bash
 CONCOURSE_TRACING_OTLP_ADDRESS=elastic-apm-server.example.com:8200

--- a/solutions/observability/cloud/monitor-amazon-cloud-compute-ec2.md
+++ b/solutions/observability/cloud/monitor-amazon-cloud-compute-ec2.md
@@ -15,7 +15,7 @@ Amazon EC2 instances can be run in various locations. The location is composed o
 
 Like most AWS services, Amazon EC2 sends its metrics to Amazon CloudWatch. The Elastic [Amazon EC2 integration](https://docs.elastic.co/en/integrations/aws/ec2) collects metrics from Amazon CloudWatch using {{agent}}.
 
-CloudWatch, by default, uses basic monitoring that publishes metrics at five-minute intervals. You can enable detailed monitoring to increase that resolution to one-minute, at an additional cost. To learn how to enable detailed monitoring, refer to the [Amazon EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.md).
+CloudWatch, by default, uses basic monitoring that publishes metrics at five-minute intervals. You can enable detailed monitoring to increase that resolution to one-minute, at an additional cost. To learn how to enable detailed monitoring, refer to the [Amazon EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html).
 
 CloudWatch does not expose metrics related to EC2 instance memory. You can install {{agent}} on the EC2 instances to collect detailed system metrics.
 
@@ -159,7 +159,7 @@ Here are the key status check metrics you should monitor and what to look for:
 
 
 `aws.ec2.metrics.StatusCheckFailed_Instance.avg`
-:   This check monitors the software and network configuration of the instance. Problems that can cause instance status checks to fail may include: incorrect networking or startup configuration, exhausted memory, corrupted file system, incompatible kernel, and so on. When an instance status check fails, you typically must address the problem yourself. You may need to reboot the instance or make instance configuration changes. To troubleshoot instances with failed status checks, refer to the [Amazon EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstances.md).
+:   This check monitors the software and network configuration of the instance. Problems that can cause instance status checks to fail may include: incorrect networking or startup configuration, exhausted memory, corrupted file system, incompatible kernel, and so on. When an instance status check fails, you typically must address the problem yourself. You may need to reboot the instance or make instance configuration changes. To troubleshoot instances with failed status checks, refer to the [Amazon EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstances.html).
 
     This check returns 0 (passed) if an instance passes the system status check or 1 (failed) if it fails.
 

--- a/solutions/observability/cloud/monitor-amazon-kinesis-data-streams.md
+++ b/solutions/observability/cloud/monitor-amazon-kinesis-data-streams.md
@@ -19,7 +19,7 @@ By default, Kinesis Data Streams sends stream-level (basic level) metrics to Clo
 aws kinesis enable-enhanced-monitoring --stream-name samplestream --shard-level-metrics ALL
 ```
 
-For more details, refer to the [EnableEnhancedMonitoring](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_EnableEnhancedMonitoring.md) documentation.
+For more details, refer to the [EnableEnhancedMonitoring](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_EnableEnhancedMonitoring.html) documentation.
 
 
 ## Get started [get-started-kinesis]

--- a/solutions/observability/cloud/monitor-amazon-simple-storage-service-s3.md
+++ b/solutions/observability/cloud/monitor-amazon-simple-storage-service-s3.md
@@ -21,7 +21,7 @@ With the Amazon S3 integration, you can collect these S3 metrics from CloudWatch
 
 ## Get started [get-started-s3]
 
-If you plan to collect request metrics, enable them for the S3 buckets you want to monitor. To learn how, refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/configure-request-metrics-bucket.md).
+If you plan to collect request metrics, enable them for the S3 buckets you want to monitor. To learn how, refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/configure-request-metrics-bucket.html).
 
 To collect S3 metrics, you typically need to install the Elastic [Amazon S3 integration](https://docs.elastic.co/en/integrations/aws/s3) and deploy an {{agent}} locally or on an EC2 instance.
 

--- a/solutions/observability/cloud/monitor-amazon-web-services-aws-with-amazon-data-firehose.md
+++ b/solutions/observability/cloud/monitor-amazon-web-services-aws-with-amazon-data-firehose.md
@@ -66,13 +66,13 @@ From the **Destination settings** panel, specify the following settings:
 
 ## Step 4: Send data to the Firehose delivery stream [firehose-step-four]
 
-You can configure a variety of log sources to send data to Firehose streams directly for example VPC flow logs. Some services don’t support publishing logs directly to Firehose but they do support publishing logs to CloudWatch logs, such as CloudTrail and Lambda. Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.md) for more information.
+You can configure a variety of log sources to send data to Firehose streams directly for example VPC flow logs. Some services don’t support publishing logs directly to Firehose but they do support publishing logs to CloudWatch logs, such as CloudTrail and Lambda. Refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html) for more information.
 
 For example, a typical workflow for sending CloudTrail logs to Firehose would be the following:
 
-* Publish CloudTrail logs to a Cloudwatch log group. Refer to the AWS documentation [about publishing CloudTrail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/monitor-cloudtrail-log-files-with-cloudwatch-logs.md).
-* Create a subscription filter in the CloudWatch log group to the Firehose stream. Refer to the AWS documentation [about using subscription filters](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.md#FirehoseExample).
+* Publish CloudTrail logs to a Cloudwatch log group. Refer to the AWS documentation [about publishing CloudTrail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/monitor-cloudtrail-log-files-with-cloudwatch-logs.html).
+* Create a subscription filter in the CloudWatch log group to the Firehose stream. Refer to the AWS documentation [about using subscription filters](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html#FirehoseExample).
 
-We also added support for sending CloudWatch monitoring metrics to Elastic using Firehose. For example, you can configure metrics ingestion by creating a metric stream through CloudWatch. You can select an existing Firehose stream by choosing the option **Custom setup with Firehose**. For more information, refer to the AWS documentation [about the custom setup with Firehose](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-setup-datalake.md).
+We also added support for sending CloudWatch monitoring metrics to Elastic using Firehose. For example, you can configure metrics ingestion by creating a metric stream through CloudWatch. You can select an existing Firehose stream by choosing the option **Custom setup with Firehose**. For more information, refer to the AWS documentation [about the custom setup with Firehose](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-setup-datalake.html).
 
 For more information on Amazon Data Firehose, you can also check the [Amazon Data Firehose Integrations documentation](https://docs.elastic.co/integrations/awsfirehose).

--- a/solutions/observability/cloud/monitor-amazon-web-services-aws-with-beats.md
+++ b/solutions/observability/cloud/monitor-amazon-web-services-aws-with-beats.md
@@ -30,7 +30,7 @@ Create an [{{ech}}](https://cloud.elastic.co/registration?page=docs&placement=do
 With this tutorial, we assume that your logs and your infrastructure data are already shipped to CloudWatch. We are going to show you how you can stream your data from CloudWatch to {{es}}. If you don’t know how to put your AWS logs and infrastructure data in CloudWatch, Amazon provides a lot of documentation around this specific topic:
 
 * Collect your logs and infrastructure data from specific [AWS services](https://www.youtube.com/watch?v=vAnIhIwE5hY)
-* Export your logs [to an S3 bucket](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.md)
+* Export your logs [to an S3 bucket](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.html)
 
 
 ## Step 1:  Create an S3 Bucket [aws-step-one]
@@ -269,7 +269,7 @@ Edit the `modules.d/aws.yml` file with the following configurations.
 ```
 
 1. Enables the `ec2` fileset.
-2. This is the AWS profile defined following the [AWS standard](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.md).
+2. This is the AWS profile defined following the [AWS standard](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 3. Add the URL to the queue containing notifications around the bucket containing the EC2 logs
 
 
@@ -293,7 +293,7 @@ Make sure that the AWS user used to collect the logs from S3 has at least the fo
 }
 ```
 
-You can now upload your logs to the S3 bucket. If you are using CloudWatch, make sure to edit the policy of your bucket as shown in [step 3 of the AWS user guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.md). This will help you avoid permissions issues.
+You can now upload your logs to the S3 bucket. If you are using CloudWatch, make sure to edit the policy of your bucket as shown in [step 3 of the AWS user guide](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasksConsole.html). This will help you avoid permissions issues.
 
 Start {{filebeat}} to collect the logs.
 
@@ -344,7 +344,7 @@ Copy the URL of the queue you created. Edit the `modules.d/aws.yml`file with the
 ```
 
 1. Enables the `ec2` fileset.
-2. This is the AWS profile defined following the [AWS standard](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.md).
+2. This is the AWS profile defined following the [AWS standard](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 3. Add the URL to the queue containing notifications around the bucket containing the EC2 logs
 4. Add the URL to the queue containing notifications around the bucket containing the S3 access logs
 
@@ -532,7 +532,7 @@ To collect metrics from your AWS infrastructure, we’ll use the [{{metricbeat}}
     1. Defines the module that is going to be used.
     2. Defines the period at which the metrics are going to be collected
     3. Defines the metricset that is going to be used.
-    4. This is the AWS profile defined following the [AWS standard](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.md).
+    4. This is the AWS profile defined following the [AWS standard](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 
 
 Make sure that the AWS user used to collect the metrics from CloudWatch has at least the following permissions attached to it:

--- a/solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-agent.md
+++ b/solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-agent.md
@@ -35,15 +35,15 @@ Create an [{{ech}}](https://cloud.elastic.co/registration?page=docs&placement=do
 
 In this tutorial, we assume that:
 
-* Your VPC flow logs are already exported to an S3 bucket. To learn how, refer to the AWS documentation about [publishing flow logs to an S3 bucket](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.md).
-* You have EC2 instances in your AWS account. By default, Amazon EC2 sends metric data to CloudWatch. If you don’t have an EC2 instance in your account, refer to the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.md) to learn how to launch, connect to, and use a Linux instance.
+* Your VPC flow logs are already exported to an S3 bucket. To learn how, refer to the AWS documentation about [publishing flow logs to an S3 bucket](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html).
+* You have EC2 instances in your AWS account. By default, Amazon EC2 sends metric data to CloudWatch. If you don’t have an EC2 instance in your account, refer to the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html) to learn how to launch, connect to, and use a Linux instance.
 
 
 ## Step 1: Create a queue and notifications for VPC flow logs [aws-elastic-agent-set-up-sqs-queue-and-notifications]
 
 In this step, you create an Amazon Simple Queue Service (SQS) queue and configure the S3 bucket containing your VPC flow logs to send a message to the SQS queue whenever new logs are present in the S3 bucket.
 
-You should already have an S3 bucket that contains exported VPC flow logs. If you don’t, create one now. To learn how, refer to [publishing flow logs to an S3 bucket](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.md).
+You should already have an S3 bucket that contains exported VPC flow logs. If you don’t, create one now. To learn how, refer to [publishing flow logs to an S3 bucket](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html).
 
 ::::{note}
 **Why is an SQS queue needed?**

--- a/solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-serverless-forwarder.md
+++ b/solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-serverless-forwarder.md
@@ -33,7 +33,7 @@ Create an [{{ech}}](https://cloud.elastic.co/registration?page=docs&placement=do
 2. Specify the AWS region in which you want it deployed.
 3. Enter the bucket name.
 
-For more details, refer to the Amazon documentation on how to [Create your first S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.md).
+For more details, refer to the Amazon documentation on how to [Create your first S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html).
 
 
 ## Step 2: Enable AWS VPC flow logs to be sent to your S3 bucket [esf-step-two]
@@ -44,7 +44,7 @@ For more details, refer to the Amazon documentation on how to [Create your first
 4. For **Destination**, select **Send to an S3 bucket**.
 5. For **S3 bucket ARN**, enter the name of the S3 bucket you created in the previous step.
 
-For more details, refer to the Amazon documentation on how to [Create a flow log that publishes to Amazon S3](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.md).
+For more details, refer to the Amazon documentation on how to [Create a flow log that publishes to Amazon S3](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html).
 
 
 ## Step 3: Create an SQS queue and notifications for VPC flow logs [esf-step-three]
@@ -87,7 +87,7 @@ The Amazon Simple Queue Service (SQS) event notification on Amazon S3 serves as 
 
 3. Go to the properties of the S3 bucket containing the VPC flow logs and enable event notification.
 
-For more details, refer to the AWS documentation on how to [Configure a bucket for notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.md).
+For more details, refer to the AWS documentation on how to [Configure a bucket for notifications](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html).
 
 
 ## Step 4: Install the Elastic AWS integration [esf-step-four]

--- a/solutions/observability/cloud/monitor-aws-network-firewall-logs.md
+++ b/solutions/observability/cloud/monitor-aws-network-firewall-logs.md
@@ -47,7 +47,7 @@ AWS PrivateLink is not supported. Make sure the deployment is on AWS, because th
 
 You can either use an existing AWS Network Firewall, or create a new one for testing purposes.
 
-Creating a Network Firewall is not trivial and is beyond the scope of this guide. For more information, check the AWS documentation on the [Getting started with AWS Network Firewall](https://docs.aws.amazon.com/network-firewall/latest/developerguide/getting-started.md) guide.
+Creating a Network Firewall is not trivial and is beyond the scope of this guide. For more information, check the AWS documentation on the [Getting started with AWS Network Firewall](https://docs.aws.amazon.com/network-firewall/latest/developerguide/getting-started.html) guide.
 
 
 ## Step 3: Create a stream in Amazon Data Firehose [firehose-firewall-step-three]

--- a/solutions/observability/cloud/monitor-cloudtrail-logs.md
+++ b/solutions/observability/cloud/monitor-cloudtrail-logs.md
@@ -125,7 +125,7 @@ The Amazon Data Firehose delivery stream is ready to send logs to your Elastic C
 
 1. Visit the log group with the CloudTrail events.
 
-    Open the log group where the CloudTrail service is sending the events. You must forward these events to an Elastic stack using the Amazon Data Firehose delivery stream. CloudWatch log group offers a [subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.md) that allows you to choose log events from the log group and forward them to other services like Amazon Kinesis stream, an Amazon Data Firehose stream, or AWS Lambda.
+    Open the log group where the CloudTrail service is sending the events. You must forward these events to an Elastic stack using the Amazon Data Firehose delivery stream. CloudWatch log group offers a [subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html) that allows you to choose log events from the log group and forward them to other services like Amazon Kinesis stream, an Amazon Data Firehose stream, or AWS Lambda.
 
 2. Create a subscription filter for Amazon Data Firehose by following these steps.
 

--- a/solutions/observability/cloud/monitor-cloudwatch-logs.md
+++ b/solutions/observability/cloud/monitor-cloudwatch-logs.md
@@ -141,7 +141,7 @@ To send log events from CloudWatch to Firehose, open the log group where the Lam
 
 **Create a subscription filter for Amazon Data Firehose**
 
-The [subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.md) allows you to pick log events from the log group and forward them to other services, such as an Amazon Kinesis stream, an Amazon Data Firehose stream, or AWS Lambda.
+The [subscription filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html) allows you to pick log events from the log group and forward them to other services, such as an Amazon Kinesis stream, an Amazon Data Firehose stream, or AWS Lambda.
 
 1. On the log group page, select **Subscription filters** and click the **Create Amazon Data Firehose subscription filter** button.
 

--- a/solutions/observability/get-started/quickstart-monitor-hosts-with-opentelemetry.md
+++ b/solutions/observability/get-started/quickstart-monitor-hosts-with-opentelemetry.md
@@ -50,7 +50,7 @@ In this quickstart guide, you’ll learn how to monitor your hosts using the Ela
 
 ## Limitations [_limitations]
 
-Refer to [Elastic OpenTelemetry Collector limitations](https://github.com/elastic/opentelemetry/blob/main/docs/collector-limitations.md) for known limitations when using the EDOT Collector.
+Refer to [Elastic OpenTelemetry Collector limitations](https://github.com/elastic/opentelemetry/blob/main/docs/EDOT-collector/edot-collector-limitations.md) for known limitations when using the EDOT Collector.
 
 
 ## Collect your data [_collect_your_data]

--- a/solutions/observability/infra-and-hosts/add-symbols-for-native-frames.md
+++ b/solutions/observability/infra-and-hosts/add-symbols-for-native-frames.md
@@ -35,7 +35,7 @@ You also need to copy the **Symbols** endpoint from the deployment overview page
 
 ## Custom C, C++, Go and Rust applications [profiling-symbols-c]
 
-C/C++ applications must be built with debug symbols (`-g`) for symbolization to work. Rust applications must be built with [`debug = 1`](https://doc.rust-lang.org/cargo/reference/profiles.md#debug) (or higher). Go binaries will not require any special compiler flags and come with debug information by default. The debug info doesn’t have to be deployed to production, but it does have to be present temporarily to push it to the Elastic cluster.
+C/C++ applications must be built with debug symbols (`-g`) for symbolization to work. Rust applications must be built with [`debug = 1`](https://doc.rust-lang.org/cargo/reference/profiles.html#debug) (or higher). Go binaries will not require any special compiler flags and come with debug information by default. The debug info doesn’t have to be deployed to production, but it does have to be present temporarily to push it to the Elastic cluster.
 
 If you don’t mind deploying your applications with debug symbols, run:
 

--- a/solutions/observability/observability-ai-assistant.md
+++ b/solutions/observability/observability-ai-assistant.md
@@ -81,7 +81,7 @@ To set up the AI Assistant:
 
     * [OpenAI API keys](https://platform.openai.com/docs/api-reference)
     * [Azure OpenAI Service API keys](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference)
-    * [Amazon Bedrock authentication keys and secrets](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.md)
+    * [Amazon Bedrock authentication keys and secrets](https://docs.aws.amazon.com/bedrock/latest/userguide/security-iam.html)
     * [Google Gemini service account keys](https://cloud.google.com/iam/docs/keys-list-get)
 
 2. Create a connector for your AI provider. Refer to the connector documentation to learn how:

--- a/solutions/search/inference-api/amazon-bedrock-inference-integration.md
+++ b/solutions/search/inference-api/amazon-bedrock-inference-integration.md
@@ -86,10 +86,10 @@ You need to provide the access and secret keys only once, during the {{infer}} m
 
 
 `model`
-:   (Required, string) The base model ID or an ARN to a custom model based on a foundational model. The base model IDs can be found in the [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.md) documentation. Note that the model ID must be available for the provider chosen, and your IAM user must have access to the model.
+:   (Required, string) The base model ID or an ARN to a custom model based on a foundational model. The base model IDs can be found in the [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html) documentation. Note that the model ID must be available for the provider chosen, and your IAM user must have access to the model.
 
 `region`
-:   (Required, string) The region that your model or ARN is deployed in. The list of available regions per model can be found in the [Model support by AWS region](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.md) documentation.
+:   (Required, string) The region that your model or ARN is deployed in. The list of available regions per model can be found in the [Model support by AWS region](https://docs.aws.amazon.com/bedrock/latest/userguide/models-regions.html) documentation.
 
 `rate_limit`
 :   (Optional, object) By default, the `amazonbedrock` service sets the number of requests allowed per minute to `240`. This helps to minimize the number of rate limit errors returned from Amazon Bedrock. To modify this, set the `requests_per_minute` setting of this object in your service settings:
@@ -124,7 +124,7 @@ You need to provide the access and secret keys only once, during the {{infer}} m
 
 The following example shows how to create an {{infer}} endpoint called `amazon_bedrock_embeddings` to perform a `text_embedding` task type.
 
-Choose chat completion and embeddings models that you have access to from the [Amazon Bedrock base models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.md).
+Choose chat completion and embeddings models that you have access to from the [Amazon Bedrock base models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
 
 ```console
 PUT _inference/text_embedding/amazon_bedrock_embeddings

--- a/solutions/search/ranking/learning-to-rank-ltr.md
+++ b/solutions/search/ranking/learning-to-rank-ltr.md
@@ -90,7 +90,7 @@ The LTR space is evolving rapidly and many approaches and model types are being 
 
 Note that {{es}} supports model inference but the training process itself must happen outside of {{es}}, using a GBDT model. Among the most popular LTR models used today, [LambdaMART](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/MSR-TR-2010-82.pdf) provides strong ranking performance with low inference latencies. It relies on GBDT models and is therefore a perfect fit for LTR in {{es}}.
 
-[XGBoost](https://xgboost.readthedocs.io/en/stable/) is a well known library that provides an [implementation](https://xgboost.readthedocs.io/en/stable/tutorials/learning_to_rank.md) of LambdaMART, making it a popular choice for LTR. We offer helpers in [eland](https://eland.readthedocs.io/) to facilitate the integration of a trained [XBGRanker](https://xgboost.readthedocs.io/en/stable/python/python_api.md#xgboost.XGBRanker) model as your LTR model in {{es}}.
+[XGBoost](https://xgboost.readthedocs.io/en/stable/) is a well known library that provides an [implementation](https://xgboost.readthedocs.io/en/stable/tutorials/learning_to_rank.html) of LambdaMART, making it a popular choice for LTR. We offer helpers in [eland](https://eland.readthedocs.io/) to facilitate the integration of a trained [XBGRanker](https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.XGBRanker) model as your LTR model in {{es}}.
 
 ::::{tip}
 Learn more about training in [Train and deploy a LTR model](learning-to-rank-model-training.md), or check out our [interactive LTR notebook](https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/search/08-learning-to-rank.ipynb) available in the `elasticsearch-labs` repo.

--- a/solutions/search/ranking/learning-to-rank-model-training.md
+++ b/solutions/search/ranking/learning-to-rank-model-training.md
@@ -146,11 +146,11 @@ This method will serialize the trained model and the Learning To Rank configurat
 
 The following types of models are currently supported for LTR with {{es}}:
 
-* [`DecisionTreeRegressor`](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.md)
-* [`RandomForestRegressor`](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.md)
-* [`LGBMRegressor`](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.md)
-* [`XGBRanker`](https://xgboost.readthedocs.io/en/stable/python/python_api.md#xgboost.XGBRanker)
-* [`XGBRegressor`](https://xgboost.readthedocs.io/en/stable/python/python_api.md#xgboost.XGBRegressor)
+* [`DecisionTreeRegressor`](https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeRegressor.html)
+* [`RandomForestRegressor`](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestRegressor.html)
+* [`LGBMRegressor`](https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.LGBMRegressor.html)
+* [`XGBRanker`](https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.XGBRanker)
+* [`XGBRegressor`](https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.XGBRegressor)
 
 More model types will be supported in the future.
 

--- a/solutions/search/search-templates.md
+++ b/solutions/search/search-templates.md
@@ -21,7 +21,7 @@ To create or update a search template, use the [create stored script API](https:
 
 The request’s `source` supports the same parameters as the [search API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search)'s request body.`source` also accepts [Mustache](https://mustache.github.io/) variables, from an open source project [mustache.java](https://github.com/spullara/mustache.java).
 
-Typically [Mustache](https://mustache.github.io/) variables are enclosed in double curly brackets: `{{my-var}}`. When you run a templated search, {{es}} replaces these variables with values from `params`. To learn more about mustache syntax - see [Mustache.js manual](http://mustache.github.io/mustache.5.md) Search templates must use a `lang` of `mustache`.
+Typically [Mustache](https://mustache.github.io/) variables are enclosed in double curly brackets: `{{my-var}}`. When you run a templated search, {{es}} replaces these variables with values from `params`. To learn more about mustache syntax - see [Mustache.js manual](http://mustache.github.io/mustache.5.html) Search templates must use a `lang` of `mustache`.
 
 The following request creates a search template with an `id` of `my-search-template`.
 

--- a/solutions/search/semantic-search/semantic-search-inference.md
+++ b/solutions/search/semantic-search/semantic-search-inference.md
@@ -25,7 +25,7 @@ The following examples use the:
 * models available through [Azure AI Studio](https://ai.azure.com/explore/models?selectedTask=embeddings) or [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models)
 * `text-embedding-004` model for [Google Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api)
 * `mistral-embed` model for [Mistral](https://docs.mistral.ai/getting-started/models/)
-* `amazon.titan-embed-text-v1` model for [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.md)
+* `amazon.titan-embed-text-v1` model for [Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html)
 * `ops-text-embedding-zh-001` model for [AlibabaCloud AI](https://help.aliyun.com/zh/open-search/search-platform/developer-reference/text-embedding-api-details)
 
 You can use any Cohere and OpenAI models, they are all supported by the {{infer}} API. For a list of recommended models available on HuggingFace, refer to [the supported model list](../inference-api/huggingface-inference-integration.md#inference-example-hugging-face-supported-models).
@@ -561,7 +561,7 @@ PUT amazon-bedrock-embeddings
 
 1. The name of the field to contain the generated tokens. It must be referenced in the {{infer}} pipeline configuration in the next step.
 2. The field to contain the tokens is a `dense_vector` field.
-3. The output dimensions of the model. This value may be different depending on the underlying model used. See the [Amazon Titan model](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-multiemb-models.md) or the [Cohere Embeddings model](https://docs.cohere.com/reference/embed) documentation.
+3. The output dimensions of the model. This value may be different depending on the underlying model used. See the [Amazon Titan model](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-multiemb-models.html) or the [Cohere Embeddings model](https://docs.cohere.com/reference/embed) documentation.
 4. For Amazon Bedrock embeddings, the `dot_product` function should be used to calculate similarity for Amazon titan models, or `cosine` for Cohere models.
 5. The name of the field from which to create the dense vector representation. In this example, the name of the field is `content`. It must be referenced in the {{infer}} pipeline configuration in the next step.
 6. The field type which is text in this example.

--- a/solutions/security/ai/connect-to-amazon-bedrock.md
+++ b/solutions/security/ai/connect-to-amazon-bedrock.md
@@ -174,7 +174,7 @@ Finally, configure the connector in {{kib}}:
 
 
 ::::{important}
-If you’re using [provisioned throughput](https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.md), your ARN becomes the model ID, and the connector settings **URL** value must be [encoded](https://www.urlencoder.org/) to work. For example, if the non-encoded ARN is `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`, the encoded ARN would be `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`.
+If you’re using [provisioned throughput](https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html), your ARN becomes the model ID, and the connector settings **URL** value must be [encoded](https://www.urlencoder.org/) to work. For example, if the non-encoded ARN is `arn:aws:bedrock:us-east-2:123456789102:provisioned-model/3Ztr7hbzmkrqy1`, the encoded ARN would be `arn%3Aaws%3Abedrock%3Aus-east-2%3A123456789102%3Aprovisioned-model%2F3Ztr7hbzmkrqy1`.
 ::::
 
 

--- a/solutions/security/cloud/get-started-with-cnvm.md
+++ b/solutions/security/cloud/get-started-with-cnvm.md
@@ -32,7 +32,7 @@ CNVM currently only supports AWS EC2 Linux workloads.
 
 ## Set up CNVM for AWS [vuln-management-setup]
 
-To set up the CNVM integration for AWS, install the integration on a new {{agent}} policy, sign into the AWS account you want to scan, and run the [CloudFormation](https://docs.aws.amazon.com/cloudformation/index.md) template.
+To set up the CNVM integration for AWS, install the integration on a new {{agent}} policy, sign into the AWS account you want to scan, and run the [CloudFormation](https://docs.aws.amazon.com/cloudformation/index.html) template.
 
 ::::{important}
 Do not add the integration to an existing {{agent}} policy. It should always be added to a new policy since it should not run on VMs with existing workloads. For more information, refer to [How CNVM works](/solutions/security/cloud/cloud-native-vulnerability-management.md#vuln-management-overview-how-it-works).

--- a/solutions/security/cloud/get-started-with-cspm-for-aws.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-aws.md
@@ -69,7 +69,7 @@ Agentless deployment does not work if you are using [Traffic filtering](/deploy-
 
 ### Set up cloud account access [cspm-set-up-cloud-access-section]
 
-The CSPM integration requires access to AWS’s built-in [`SecurityAudit` IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.md#jf_security-auditor) in order to discover and evaluate resources in your cloud account. There are several ways to provide access.
+The CSPM integration requires access to AWS’s built-in [`SecurityAudit` IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_security-auditor) in order to discover and evaluate resources in your cloud account. There are several ways to provide access.
 
 For most use cases, the simplest option is to use AWS CloudFormation to automatically provision the necessary resources and permissions in your AWS account. This method, as well as several manual options, are described below.
 
@@ -217,7 +217,7 @@ When deploying to an organization using any of the authentication methods below,
 * [IAM role Amazon Resource Name (ARN)](/solutions/security/cloud/get-started-with-cspm-for-aws.md#cspm-use-iam-arn)
 
 ::::{important}
-Whichever method you use to authenticate, make sure AWS’s built-in [`SecurityAudit` IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.md#jf_security-auditor) is attached.
+Whichever method you use to authenticate, make sure AWS’s built-in [`SecurityAudit` IAM policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_security-auditor) is attached.
 ::::
 
 
@@ -229,7 +229,7 @@ If you are deploying to an AWS organization instead of an AWS account, you shoul
 ::::
 
 
-Follow AWS’s [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.md) documentation to create an IAM role using the IAM console, which automatically generates an instance profile.
+Follow AWS’s [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) documentation to create an IAM role using the IAM console, which automatically generates an instance profile.
 
 1. Create an IAM role:
 
@@ -273,7 +273,7 @@ Make sure to deploy the CSPM integration to this EC2 instance. When completing s
 
 Access keys are long-term credentials for an IAM user or AWS account root user. To use access keys as credentials, you must provide the `Access key ID` and the `Secret Access Key`. After you provide credentials, [finish manual setup](/solutions/security/cloud/get-started-with-cspm-for-aws.md#cspm-finish-manual).
 
-For more details, refer to [Access Keys and Secret Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.md).
+For more details, refer to [Access Keys and Secret Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html).
 
 ::::{important}
 You must select **Programmatic access** when creating the IAM user.
@@ -288,7 +288,7 @@ You can configure temporary security credentials in AWS to last for a specified 
 Because temporary security credentials are short term, once they expire, you will need to generate new ones and manually update the integration’s configuration to continue collecting cloud posture data. Update the credentials before they expire to avoid data loss.
 
 ::::{note}
-IAM users with multi-factor authentication (MFA) enabled need to submit an MFA code when calling `GetSessionToken`. For more details, refer to AWS’s [Temporary Security Credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.md) documentation.
+IAM users with multi-factor authentication (MFA) enabled need to submit an MFA code when calling `GetSessionToken`. For more details, refer to AWS’s [Temporary Security Credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) documentation.
 ::::
 
 
@@ -309,7 +309,7 @@ After you provide credentials, [finish manual setup](/solutions/security/cloud/g
 
 #### Option 4 - Shared credentials file [cspm-use-a-shared-credentials-file]
 
-If you use different AWS credentials for different tools or applications, you can use profiles to define multiple access keys in the same configuration file. For more details, refer to AWS' [Shared Credentials Files](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.md) documentation.
+If you use different AWS credentials for different tools or applications, you can use profiles to define multiple access keys in the same configuration file. For more details, refer to AWS' [Shared Credentials Files](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html) documentation.
 
 Instead of providing the `Access key ID` and `Secret Access Key` to the integration, provide the information required to locate the access keys within the shared credentials file:
 

--- a/solutions/security/cloud/get-started-with-kspm.md
+++ b/solutions/security/cloud/get-started-with-kspm.md
@@ -128,7 +128,7 @@ If you are using the AWS visual editor to create and modify your IAM Policies, y
 
 #### Option 1 - [Recommended] Use Kubernetes Service Account to assume IAM role [kspm-use-irsa]
 
-Follow AWS’s [EKS Best Practices](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#iam-roles-for-service-accounts-irsa) documentation to use the [IAM Role to Kubernetes Service-Account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.md) (IRSA) feature to get temporary credentials and scoped permissions.
+Follow AWS’s [EKS Best Practices](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#iam-roles-for-service-accounts-irsa) documentation to use the [IAM Role to Kubernetes Service-Account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) feature to get temporary credentials and scoped permissions.
 
 ::::{important}
 During setup, do not fill in any option in the "Setup Access" section. Click **Save and continue**.
@@ -138,7 +138,7 @@ During setup, do not fill in any option in the "Setup Access" section. Click **S
 
 #### Option 2 - Use default instance role [kspm-use-instance-role]
 
-Follow AWS’s [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.md) documentation to create an IAM role using the IAM console, which automatically generates an instance profile.
+Follow AWS’s [IAM roles for Amazon EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) documentation to create an IAM role using the IAM console, which automatically generates an instance profile.
 
 ::::{important}
 During setup, do not fill in any option in the "Setup Access" section. Click **Save and continue**.
@@ -150,7 +150,7 @@ During setup, do not fill in any option in the "Setup Access" section. Click **S
 
 Access keys are long-term credentials for an IAM user or AWS account root user. To use access keys as credentials, you must provide the `Access key ID` and the `Secret Access Key`.
 
-For more details, refer to AWS' [Access Keys and Secret Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.md) documentation.
+For more details, refer to AWS' [Access Keys and Secret Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) documentation.
 
 ::::{important}
 You must select "Programmatic access" when creating the IAM user.
@@ -165,7 +165,7 @@ You can configure temporary security credentials in AWS to last for a specified 
 Because temporary security credentials are short term, once they expire, you will need to generate new ones and manually update the integration’s configuration to continue collecting cloud posture data. Update the credentials before they expire to avoid data loss.
 
 ::::{note}
-IAM users with multi-factor authentication (MFA) enabled need to submit an MFA code when calling `GetSessionToken`. For more details, refer to AWS' [Temporary Security Credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.md) documentation.
+IAM users with multi-factor authentication (MFA) enabled need to submit an MFA code when calling `GetSessionToken`. For more details, refer to AWS' [Temporary Security Credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) documentation.
 ::::
 
 
@@ -184,7 +184,7 @@ The output from this command includes the following fields, which you should pro
 
 #### Option 5 - Use a shared credentials file [kspm-use-a-shared-credentials-file]
 
-If you use different AWS credentials for different tools or applications, you can use profiles to define multiple access keys in the same configuration file. For more details, refer to AWS' [Shared Credentials Files](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.md) documentation.
+If you use different AWS credentials for different tools or applications, you can use profiles to define multiple access keys in the same configuration file. For more details, refer to AWS' [Shared Credentials Files](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html) documentation.
 
 Instead of providing the `Access key ID` and `Secret Access Key` to the integration, provide the information required to locate the access keys within the shared credentials file:
 
@@ -203,7 +203,7 @@ If you don’t provide values for all configuration fields, the integration will
 
 An IAM role Amazon Resource Name (ARN) is an IAM identity that you can create in your AWS account. You define the role’s permissions. Roles do not have standard long-term credentials such as passwords or access keys. Instead, when you assume a role, it provides temporary security credentials for your session. An IAM role’s ARN can be used to specify which AWS IAM role to use to generate temporary credentials.
 
-For more details, refer to AWS' [AssumeRole API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.md) documentation. Follow AWS' instructions to [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.md), and define the IAM role’s permissions using the JSON permissions policy above.
+For more details, refer to AWS' [AssumeRole API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) documentation. Follow AWS' instructions to [create an IAM user](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html), and define the IAM role’s permissions using the JSON permissions policy above.
 
 To use an IAM role’s ARN, you need to provide either a [credential profile](/solutions/security/cloud/get-started-with-kspm.md#kspm-use-a-shared-credentials-file) or [access keys](/solutions/security/cloud/get-started-with-kspm.md#kspm-use-keys-directly) along with the `ARN role`. The `ARN Role` value specifies which AWS IAM role to use for generating temporary credentials.
 

--- a/solutions/security/configure-elastic-defend/configure-offline-endpoints-air-gapped-environments.md
+++ b/solutions/security/configure-elastic-defend/configure-offline-endpoints-air-gapped-environments.md
@@ -45,7 +45,7 @@ docker run -v "$PWD"/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 80:80 nginx
 ```
 
 ::::{important}
-This example script is not appropriate for production environments. We recommend configuring the Nginx server to use [TLS](http://nginx.org/en/docs/http/configuring_https_servers.md) according to your IT policies. Refer to [Nginx documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/) for more information on downloading and configuring Nginx.
+This example script is not appropriate for production environments. We recommend configuring the Nginx server to use [TLS](http://nginx.org/en/docs/http/configuring_https_servers.html) according to your IT policies. Refer to [Nginx documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/) for more information on downloading and configuring Nginx.
 ::::
 
 
@@ -71,7 +71,7 @@ docker run -p 80:80 -v "$PWD"/httpd.conf:/usr/local/apache2/conf/httpd.conf http
 ```
 
 ::::{important}
-This example script is not appropriate for production environments. We recommend configuring httpd to use [TLS](https://httpd.apache.org/docs/trunk/ssl/ssl_howto.md) according to your IT policies. Refer to [Apache documentation](https://httpd.apache.org) for more information on downloading and configuring Apache httpd.
+This example script is not appropriate for production environments. We recommend configuring httpd to use [TLS](https://httpd.apache.org/docs/trunk/ssl/ssl_howto.html) according to your IT policies. Refer to [Apache documentation](https://httpd.apache.org) for more information on downloading and configuring Apache httpd.
 ::::
 
 
@@ -133,7 +133,7 @@ docker run -v "$PWD"/nginx.conf:/etc/nginx/conf.d/default.conf:ro -v "$PWD"/stat
 ```
 
 ::::{important}
-This example script is not appropriate for production environments. We recommend configuring the Nginx server to use [TLS](http://nginx.org/en/docs/http/configuring_https_servers.md) according to your IT policies. Refer to [Nginx documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/) for more information on downloading and configuring Nginx.
+This example script is not appropriate for production environments. We recommend configuring the Nginx server to use [TLS](http://nginx.org/en/docs/http/configuring_https_servers.html) according to your IT policies. Refer to [Nginx documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/) for more information on downloading and configuring Nginx.
 ::::
 
 
@@ -153,7 +153,7 @@ docker run -p 80:80 -v "$PWD/static":/usr/local/apache2/htdocs/ -v "$PWD"/my-htt
 ```
 
 ::::{important}
-This example script is not appropriate for production environments. We recommend configuring httpd to use [TLS](https://httpd.apache.org/docs/trunk/ssl/ssl_howto.md) according to your IT policies. Refer to [Apache documentation](https://httpd.apache.org) for more information on downloading and configuring Apache httpd.
+This example script is not appropriate for production environments. We recommend configuring httpd to use [TLS](https://httpd.apache.org/docs/trunk/ssl/ssl_howto.html) according to your IT policies. Refer to [Apache documentation](https://httpd.apache.org) for more information on downloading and configuring Apache httpd.
 ::::
 
 


### PR DESCRIPTION
In the migration tool, external URLs that contained `.html` were incorrectly modified to use `.md`.  

To (attempt) to fix these links:

1. I ran a script to find URLs that started with `http` (i.e. is not an internal or cross-repo link) and included `.md` somewhere in the URL.
2. Then I ran all the resulting URLs through an external link-checker.
    i. If I got a [`200` status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200) back, I didn't do anything to the link.
    ii. If I got a [`404` status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404) back, I swapped out the `.md` with `.html`.
3. I reran the link-checker to make sure all the updated links were now returning `200`.