### PR TITLE
[explore and analyze] Fix external links

### DIFF
--- a/explore-analyze/alerts-cases/alerts/rule-action-variables.md
+++ b/explore-analyze/alerts-cases/alerts/rule-action-variables.md
@@ -8,7 +8,7 @@ mapped_pages:
 
 # Rule action variables [rule-action-variables]
 
-Alerting rules can use the [Mustache](https://mustache.github.io/mustache.5.md) template syntax (`{{variable name}}`) to pass values when the actions run.
+Alerting rules can use the [Mustache](https://mustache.github.io/mustache.5.html) template syntax (`{{variable name}}`) to pass values when the actions run.
 
 ## Common variables [common-rule-action-variables]
 

--- a/explore-analyze/machine-learning/data-frame-analytics/ml-trained-models.md
+++ b/explore-analyze/machine-learning/data-frame-analytics/ml-trained-models.md
@@ -115,4 +115,4 @@ If you also want to copy the {{dfanalytics-job}} to the new cluster, you can exp
 
 ## Importing an external model to the {{stack}} [import-external-model-to-es]
 
-It is possible to import a model to your {{es}} cluster even if the model is not trained by Elastic {{dfanalytics}}. Eland supports [importing models](asciidocalypse://docs/eland/docs/reference/machine-learning.md) directly through its APIs. Please refer to the latest [Eland documentation](https://eland.readthedocs.io/en/latest/index.md) for more information on supported model types and other details of using Eland to import models with.
+It is possible to import a model to your {{es}} cluster even if the model is not trained by Elastic {{dfanalytics}}. Eland supports [importing models](asciidocalypse://docs/eland/docs/reference/machine-learning.md) directly through its APIs. Please refer to the latest [Eland documentation](https://eland.readthedocs.io/en/latest/index.html) for more information on supported model types and other details of using Eland to import models with.

--- a/explore-analyze/query-filter/languages/sql-functions-datetime.md
+++ b/explore-analyze/query-filter/languages/sql-functions-datetime.md
@@ -530,7 +530,7 @@ DATE_FORMAT(
 
 **Output**: string
 
-**Description**: Returns the date/datetime/time as a string using the format specified in the 2nd argument. The formatting pattern is one of the specifiers used in the [MySQL DATE_FORMAT() function](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.md#function_date-format).
+**Description**: Returns the date/datetime/time as a string using the format specified in the 2nd argument. The formatting pattern is one of the specifiers used in the [MySQL DATE_FORMAT() function](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format).
 
 ::::{note} 
 If the 1st argument is of type `time`, then pattern specified by the 2nd argument cannot contain date related units (e.g. *dd*, *MM*, *yyyy*, etc.). If it contains such units an error is returned. Ranges for month and day specifiers (%c, %D, %d, %e, %m) start at one, unlike MySQL, where they start at zero, due to the fact that MySQL permits the storing of incomplete dates such as *2014-00-00*. Elasticsearch in this case returns an error.
@@ -578,7 +578,7 @@ DATE_PARSE(
 
 **Output**: date
 
-**Description**: Returns a date by parsing the 1st argument using the format specified in the 2nd argument. The parsing format pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.md).
+**Description**: Returns a date by parsing the 1st argument using the format specified in the 2nd argument. The parsing format pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.html).
 
 ::::{note} 
 If the parsing pattern does not contain all valid date units (e.g. *HH:mm:ss*, *dd-MM HH:mm:ss*, etc.) an error is returned as the function needs to return a value of `date` type which will contain date part.
@@ -627,7 +627,7 @@ DATETIME_FORMAT(
 
 **Output**: string
 
-**Description**: Returns the date/datetime/time as a string using the format specified in the 2nd argument. The formatting pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.md).
+**Description**: Returns the date/datetime/time as a string using the format specified in the 2nd argument. The formatting pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.html).
 
 ::::{note} 
 If the 1st argument is of type `time`, then pattern specified by the 2nd argument cannot contain date related units (e.g. *dd*, *MM*, *yyyy*, etc.). If it contains such units an error is returned.
@@ -675,7 +675,7 @@ DATETIME_PARSE(
 
 **Output**: datetime
 
-**Description**: Returns a datetime by parsing the 1st argument using the format specified in the 2nd argument. The parsing format pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.md).
+**Description**: Returns a datetime by parsing the 1st argument using the format specified in the 2nd argument. The parsing format pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.html).
 
 ::::{note} 
 If the parsing pattern contains only date or only time units (e.g. *dd/MM/yyyy*, *HH:mm:ss*, etc.) an error is returned as the function needs to return a value of `datetime` type which must contain both.
@@ -732,7 +732,7 @@ TIME_PARSE(
 
 **Output**: time
 
-**Description**: Returns a time by parsing the 1st argument using the format specified in the 2nd argument. The parsing format pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.md).
+**Description**: Returns a time by parsing the 1st argument using the format specified in the 2nd argument. The parsing format pattern used is the one from [`java.time.format.DateTimeFormatter`](https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/time/format/DateTimeFormatter.html).
 
 ::::{note} 
 If the parsing pattern contains only date units (e.g. *dd/MM/yyyy*) an error is returned as the function needs to return a value of `time` type which will contain only time.

--- a/explore-analyze/scripting/modules-scripting-expression.md
+++ b/explore-analyze/scripting/modules-scripting-expression.md
@@ -22,7 +22,7 @@ This allows for very fast execution, even faster than if you had written a `nati
 
 Expressions support a subset of javascript syntax: a single expression.
 
-See the [expressions module documentation](https://lucene.apache.org/core/10_0_0/expressions/index.md?org/apache/lucene/expressions/js/package-summary.md) for details on what operators and functions are available.
+See the [expressions module documentation](https://lucene.apache.org/core/10_0_0/expressions/index.html?org/apache/lucene/expressions/js/package-summary.md) for details on what operators and functions are available.
 
 Variables in `expression` scripts are available to access:
 

--- a/explore-analyze/visualize/custom-visualizations-with-vega.md
+++ b/explore-analyze/visualize/custom-visualizations-with-vega.md
@@ -271,7 +271,7 @@ In the **Vega-Lite** spec, add the `encoding` block:
 
 #### Extract the `time_buckets.buckets` inner array [_extract_the_time_buckets_buckets_inner_array]
 
-In {{kib}} 7.9 and later, use the **Vega-Lite** [flatten transformation](https://vega.github.io/vega-lite/docs/flatten.md) to extract the `time_buckets.buckets` inner array.
+In {{kib}} 7.9 and later, use the **Vega-Lite** [flatten transformation](https://vega.github.io/vega-lite/docs/flatten.html) to extract the `time_buckets.buckets` inner array.
 
 If you are using {{kib}} 7.8 and earlier, the flatten transformation is available only in **Vega**.
 
@@ -1160,10 +1160,10 @@ padding: {
 }
 ```
 
-To learn more, read about [Vega autosize](https://vega.github.io/vega/docs/specification/#autosize) and [Vega-Lite autosize](https://vega.github.io/vega-lite/docs/size.md).
+To learn more, read about [Vega autosize](https://vega.github.io/vega/docs/specification/#autosize) and [Vega-Lite autosize](https://vega.github.io/vega-lite/docs/size.html).
 
 ::::{note}
-Autosize in Vega-Lite has [several limitations](https://vega.github.io/vega-lite/docs/size.md#limitations) which can affect the height and width of your visualization, but these limitations do not exist in Vega. If you need full control, convert your spec to Vega using the [browser console](#vega-browser-debugging-console) `VEGA_DEBUG.vega_spec` output. To disable these warnings, you can [add extra options to your spec](#vega-additional-configuration-options).
+Autosize in Vega-Lite has [several limitations](https://vega.github.io/vega-lite/docs/size.html#limitations) which can affect the height and width of your visualization, but these limitations do not exist in Vega. If you need full control, convert your spec to Vega using the [browser console](#vega-browser-debugging-console) `VEGA_DEBUG.vega_spec` output. To disable these warnings, you can [add extra options to your spec](#vega-additional-configuration-options).
 ::::
 
 
@@ -1418,7 +1418,7 @@ The visualization automatically injects a `"projection"`, which you can use to c
 
 ##### Additional tooltip styling [vega-tooltip]
 
-{{kib}} has installed the [Vega tooltip plugin](https://vega.github.io/vega-lite/docs/tooltip.md), so tooltips can be defined in the ways documented there. Beyond that, {{kib}} also supports a configuration option for changing the tooltip position and padding:
+{{kib}} has installed the [Vega tooltip plugin](https://vega.github.io/vega-lite/docs/tooltip.html), so tooltips can be defined in the ways documented there. Beyond that, {{kib}} also supports a configuration option for changing the tooltip position and padding:
 
 ```js
 {
@@ -1558,7 +1558,7 @@ The [Vega Editor](https://vega.github.io/editor/) includes examples for Vega & V
 
 #### Vega-Lite resources [vega-lite-resources]
 
-* [Tutorials](https://vega.github.io/vega-lite/tutorials/getting_started.md)
+* [Tutorials](https://vega.github.io/vega-lite/tutorials/getting_started.html)
 * [Docs](https://vega.github.io/vega-lite/docs/)
 * [Examples](https://vega.github.io/vega-lite/examples/)
 

--- a/explore-analyze/visualize/maps/maps-clean-data.md
+++ b/explore-analyze/visualize/maps/maps-clean-data.md
@@ -13,7 +13,7 @@ Geospatial fields in {{es}} have certain restrictions that need to be addressed 
 
 ## Convert to GeoJSON or Shapefile [_convert_to_geojson_or_shapefile] 
 
-Use [ogr2ogr](https://gdal.org/programs/ogr2ogr.md) (part of the [GDAL/OGR](https://gdal.org) suite) to convert datasets into a GeoJSON or Esri Shapefile. For example, use the following commands to convert a GPX file into JSON:
+Use [ogr2ogr](https://gdal.org/programs/ogr2ogr.html) (part of the [GDAL/OGR](https://gdal.org) suite) to convert datasets into a GeoJSON or Esri Shapefile. For example, use the following commands to convert a GPX file into JSON:
 
 ```sh
 # Example GPX file from https://www.topografix.com/gpx_sample_files.asp
@@ -33,7 +33,7 @@ $ ogr2ogr -f "GeoJSON" "routes.geo.json" "fells_loop.gpx" "routes"
 
 {{es}} only supports WGS84 Coordinate Reference System. Use `ogr2ogr` to convert from other coordinate systems to WGS84.
 
-On the following example, `ogr2ogr` transforms a shapefile from [NAD83](https://epsg.org/crs_4269/NAD83.md) to [WGS84](https://epsg.org/crs_4326/WGS-84.md). The input CRS is detected automatically thanks to the `.prj` sidecar file in the source dataset.
+On the following example, `ogr2ogr` transforms a shapefile from [NAD83](https://epsg.org/crs_4269/NAD83.html) to [WGS84](https://epsg.org/crs_4326/WGS-84.html). The input CRS is detected automatically thanks to the `.prj` sidecar file in the source dataset.
 
 ```sh
 # Example NAD83 file from https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_us_county_5m.zip
@@ -86,7 +86,7 @@ A dataset containing records with a very large amount of parts as the one from t
 
 Some machine generated datasets are stored with more decimals than are strictly necessary. For reference, the GeoJSON RFC 7946 [coordinate precision section](https://datatracker.ietf.org/doc/html/rfc7946#section-11.2) specifies six digits to be a common default to around 10 centimeters on the ground. The file uploader in the Maps application will automatically reduce the precision to 6 decimals but for big datasets it is better to do this before uploading.
 
-`ogr2ogr` generates GeoJSON files with 7 decimal degrees when requesting `RFC7946` compliant files but using the `COORDINATE_PRECISION` [GeoJSON layer creation option](https://gdal.org/drivers/vector/geojson.md#layer-creation-options) it can be downsized even more if that is OK for the usage of the data.
+`ogr2ogr` generates GeoJSON files with 7 decimal degrees when requesting `RFC7946` compliant files but using the `COORDINATE_PRECISION` [GeoJSON layer creation option](https://gdal.org/drivers/vector/geojson.html#layer-creation-options) it can be downsized even more if that is OK for the usage of the data.
 
 ```sh
 # Example NAD83 file from https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_us_county_5m.zip
@@ -171,7 +171,7 @@ $ du -h cb_2018_us_county_5m*.geo.json
 
 The Maps application expects valid GeoJSON or Shapefile datasets. Apart from the mentioned CRS requirement, geometries need to be valid. Both `ogr2ogr` and `mapshaper` have options to try to fix invalid geometries:
 
-* OGR [`-makevalid`](https://gdal.org/programs/ogr2ogr.md#cmdoption-ogr2ogr-makevalid) option
+* OGR [`-makevalid`](https://gdal.org/programs/ogr2ogr.html#cmdoption-ogr2ogr-makevalid) option
 * Mapshaper [`-clean`](https://github.com/mbloch/mapshaper/wiki/Command-Reference#-clean) command
 
 


### PR DESCRIPTION
In the migration tool, external URLs that contained `.html` were incorrectly modified to use `.md`.  

To (attempt) to fix these links:

1. I ran a script to find URLs that started with `http` (i.e. is not an internal or cross-repo link) and included `.md` somewhere in the URL.
2. Then I ran all the resulting URLs through an external link-checker.
    i. If I got a [`200` status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200) back, I didn't do anything to the link.
    ii. If I got a [`404` status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404) back, I swapped out the `.md` with `.html`.
3. I reran the link-checker to make sure all the updated links were now returning `200`.