### PR TITLE
Update outdated refs to the `prebuilt-jobs.md` file

### DIFF
--- a/solutions/security/advanced-entity-analytics/anomaly-detection.md
+++ b/solutions/security/advanced-entity-analytics/anomaly-detection.md
@@ -56,7 +56,7 @@ Or
 
 * You install one or more of the [Advanced Analytics integrations](/solutions/security/advanced-entity-analytics/behavioral-detection-use-cases.md#ml-integrations).
 
-[Prebuilt job reference](security-docs://reference/prebuilt-jobs.md) describes all available {{ml}} jobs and lists which ECS fields are required on your hosts when you are not using {{beats}} or the {{agent}} to ship your data. For information on tuning anomaly results to reduce the number of false positives, see [Optimizing anomaly results](/solutions/security/advanced-entity-analytics/optimizing-anomaly-results.md).
+[Prebuilt anomaly detection jobs](/reference/security/prebuilt-anomaly-detection-jobs.md) describes all available {{ml}} jobs and lists which ECS fields are required on your hosts when you are not using {{beats}} or the {{agent}} to ship your data. For information on tuning anomaly results to reduce the number of false positives, see [Optimizing anomaly results](/solutions/security/advanced-entity-analytics/optimizing-anomaly-results.md).
 
 ::::{note}
 Machine learning jobs look back and analyze two weeks of historical data prior to the time they are enabled. After jobs are enabled, they continuously analyze incoming data. When jobs are stopped and restarted within the two-week time frame, previously analyzed data is not processed again.

--- a/solutions/security/advanced-entity-analytics/behavioral-detection-use-cases.md
+++ b/solutions/security/advanced-entity-analytics/behavioral-detection-use-cases.md
@@ -32,5 +32,5 @@ Here’s a list of integrations for various behavioral detection use cases:
 * [Living off the Land Attack Detection](https://docs.elastic.co/en/integrations/problemchild)
 * [Network Beaconing Identification](https://docs.elastic.co/en/integrations/beaconing)
 
-To learn more about {{ml}} jobs enabled by these integrations, refer to the [Prebuilt jobs page](security-docs://reference/prebuilt-jobs.md).
+To learn more about {{ml}} jobs enabled by these integrations, refer to the [Prebuilt anomaly detection jobs page](/reference/security/prebuilt-anomaly-detection-jobs.md).
 

--- a/solutions/security/dashboards/entity-analytics-dashboard.md
+++ b/solutions/security/dashboards/entity-analytics-dashboard.md
@@ -128,7 +128,7 @@ Interact with the table to filter data and view more details:
 Anomaly detection jobs identify suspicious or irregular behavior patterns. The Anomalies table displays the total number of anomalies identified by these prebuilt {{ml}} jobs (named in the **Anomaly name** column).
 
 ::::{admonition} Requirements
-To display anomaly results, you must [install and run](/explore-analyze/machine-learning/anomaly-detection/ml-ad-run-jobs.md) one or more [prebuilt anomaly detection jobs](security-docs://reference/prebuilt-jobs.md). You cannot add custom anomaly detection jobs to the Entity Analytics dashboard.
+To display anomaly results, you must [install and run](/explore-analyze/machine-learning/anomaly-detection/ml-ad-run-jobs.md) one or more [prebuilt anomaly detection jobs](/reference/security/prebuilt-anomaly-detection-jobs.md). You cannot add custom anomaly detection jobs to the Entity Analytics dashboard.
 ::::
 
 


### PR DESCRIPTION
Updates lingering refs to the old `prebuilt-jobs.md` file. These refs now point to the new `prebuilt-anomaly-detection-jobs.md` file that was added in https://github.com/elastic/docs-content/pull/695.

Previews:
- [Anomaly detection](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/698/solutions/security/advanced-entity-analytics/anomaly-detection)
- [Behavioral detection use cases](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/698/solutions/security/advanced-entity-analytics/behavioral-detection-use-cases)
- [Entity Analytics dashboard](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/698/solutions/security/dashboards/entity-analytics-dashboard)