### PR TITLE
Update ECK upgrade doc to include a tip

### DIFF
--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
@@ -9,6 +9,7 @@ This page provides instructions on how to upgrade the ECK operator.
 
 For upgrades of Elastic Stack applications like Elasticsearch or Kibana, check [Upgrade the Elastic Stack version](../deployment-or-cluster.md).
 
+TIP: ECK 2.x can upgrade to ECK 3.0.0 directly, without having to go to ECK 2.x latest minor version - 2.16
 
 ## Before you upgrade to ECK 3.0.0 [k8s-ga-upgrade]
 


### PR DESCRIPTION
Based on an internal sync that I had with @pebrc recently, I'd like to add a tip to the ECK upgrade doc that,
- ECK 2.x can upgrade to ECK 3.0.0 directly, without having to go to ECK 2.x latest minor version - 2.16

Please beg with me that I don't have experience posting doc PRs in this new repo and this is my first time 🙏 

Things I am unsure and I'd appreciate if anyone could help me with:
- How to preview
- How to add things like `TIP`, `NOTE`, `WARN`, like what we do for normal cloud docs - https://www.elastic.co/guide/en/cloud/current/index.html
- How to use variables to represent product, e.g. `ECK` and product version, e.g. `2.16` or `3.0`.

Thanks!