### PR TITLE
Update Fleet & Agent 'Upgrade' page

### DIFF
--- a/reference/ingestion-tools/fleet/upgrade-elastic-agent.md
+++ b/reference/ingestion-tools/fleet/upgrade-elastic-agent.md
@@ -226,13 +226,13 @@ For installation steps refer to [Install {{fleet}}-managed {{agent}}s](/referenc
 1. Download the {{agent}} Debian install package for the release that you want to upgrade to:
 
     ```bash
-    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-beta1-amd64.deb
+    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-amd64.deb
     ```
 
 2. Upgrade {{agent}} to the target release:
 
     ```bash
-    sudo dpkg -i elastic-agent-9.0.0-beta1-amd64.deb
+    sudo dpkg -i elastic-agent-9.0.0-amd64.deb
     ```
 
 3. Confirm in {{fleet}} that the agent has been upgraded to the target version. Note that the **Upgrade agent** option in the **Actions** menu next to the agent will be disabled since [fleet]-managed upgrades are not supported for this package type.
@@ -243,13 +243,13 @@ For installation steps refer to [Install {{fleet}}-managed {{agent}}s](/referenc
 1. Download the {{agent}} RPM install package for the release that you want to upgrade to:
 
     ```bash
-    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-beta1-x86_64.rpm
+    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-x86_64.rpm
     ```
 
 2. Upgrade {{agent}} to the target release:
 
     ```bash
-    sudo rpm -U elastic-agent-9.0.0-beta1-x86_64.rpm
+    sudo rpm -U elastic-agent-9.0.0-x86_64.rpm
     ```
 
-3. Confirm in {{fleet}} that the agent has been upgraded to the target version. Note that the **Upgrade agent** option in the **Actions** menu next to the agent will be disabled since [fleet]-managed upgrades are not supported for this package type.
+3. Confirm in {{fleet}} that the agent has been upgraded to the target version. Note that the **Upgrade agent** option in the **Actions** menu next to the agent will be disabled since {{fleet}}-managed upgrades are not supported for this package type.


### PR DESCRIPTION
This makes just a few super small updates the Elastic Agent "Upgrade" steps for 9.0.

See: [preview page](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/773/reference/ingestion-tools/fleet/upgrade-elastic-agent)

I don't think there's anything more that we need for this page for 9.0, but @cmacknz please correct me if you think that's not right.

Note:
 - The screen captures all show 8.x versions, but I think that makes sense for now since we don't have 9.x versions to upgrade to.
 - The version numbers are hard-coded in the code blocks because we haven't settled on how version variables will be handled in the new system, but once we're decided on that I can fix these.

Closes: https://github.com/elastic/ingest-docs/issues/1730
