### PR TITLE
[Fleet] Add tip for dynamic inputs

### DIFF
--- a/reference/ingestion-tools/fleet/install-elastic-agents.md
+++ b/reference/ingestion-tools/fleet/install-elastic-agents.md
@@ -64,7 +64,9 @@ If you are using {{agent}} with [{{serverless-full}}](/deploy-manage/deploy/elas
 
 ::::
 
-
+::::{admonition} Applying {{agent}} configurations dynamically
+When you set up {{agent}}, you might not yet have all input configuration details available. To solve this problem, the input configuration accepts variables and conditions that get evaluated at runtime using information from the running environment, allowing you to apply configurations dynamically. To learn more, refer to [Variables and conditions in input configurations](./dynamic-input-configuration.md).
+::::
 
 ## Resource requirements [elastic-agent-installation-resource-requirements]
 


### PR DESCRIPTION
This is a forward fit of https://github.com/elastic/ingest-docs/pull/1731 into the 9.0 docs. It updates the [Install Elastic Agents](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/785/reference/ingestion-tools/fleet/install-elastic-agents) page with the following note.

---

<img width="982" alt="Screenshot 2025-03-14 at 9 54 15 AM" src="https://github.com/user-attachments/assets/4b826957-6dab-4036-977b-2db4dc3c00d9" />
