### PR TITLE
Fixing inference-id and harmonizing model-id

### DIFF
--- a/explore-analyze/machine-learning/nlp/ml-nlp-elser.md
+++ b/explore-analyze/machine-learning/nlp/ml-nlp-elser.md
@@ -57,7 +57,7 @@ The easiest and recommended way to download and deploy ELSER is to use the [{{in
 2. Create an {{infer}} endpoint with the ELSER service by running the following API request:
 
 ```console
-PUT _inference/sparse_embedding/my-elser-model
+PUT _inference/sparse_embedding/my-elser-endpoint
     {
       "service": "elasticsearch",
       "service_settings": {
@@ -67,7 +67,7 @@ PUT _inference/sparse_embedding/my-elser-model
           "max_number_of_allocations": 10
         },
         "num_threads": 1,
-        "model_id": ".elser_model_2_linux-x86_64"
+        "model_id": ".elser_model_2"
       }
     }
 ```


### PR DESCRIPTION
Related issue: https://github.com/elastic/search-docs-team/issues/258

This PR changes the `inference-id` and `model-id` of the example API call for downloading ELSER to be in sync with the Semantic search with ELSER tutorial.