### PR TITLE
Update Fleet & Agent 'Upgrade' page, Take 2

### DIFF
--- a/reference/ingestion-tools/fleet/upgrade-elastic-agent.md
+++ b/reference/ingestion-tools/fleet/upgrade-elastic-agent.md
@@ -226,13 +226,13 @@ For installation steps refer to [Install {{fleet}}-managed {{agent}}s](/referenc
 1. Download the {{agent}} Debian install package for the release that you want to upgrade to:
 
     ```bash
-    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-beta1-amd64.deb
+    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{{stack-version}}-amd64.deb
     ```
 
 2. Upgrade {{agent}} to the target release:
 
     ```bash
-    sudo dpkg -i elastic-agent-9.0.0-beta1-amd64.deb
+    sudo dpkg -i elastic-agent-{{stack-version}}-amd64.deb
     ```
 
 3. Confirm in {{fleet}} that the agent has been upgraded to the target version. Note that the **Upgrade agent** option in the **Actions** menu next to the agent will be disabled since [fleet]-managed upgrades are not supported for this package type.
@@ -243,13 +243,13 @@ For installation steps refer to [Install {{fleet}}-managed {{agent}}s](/referenc
 1. Download the {{agent}} RPM install package for the release that you want to upgrade to:
 
     ```bash
-    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-9.0.0-beta1-x86_64.rpm
+    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{{stack-version}}-x86_64.rpm
     ```
 
 2. Upgrade {{agent}} to the target release:
 
     ```bash
-    sudo rpm -U elastic-agent-9.0.0-beta1-x86_64.rpm
+    sudo rpm -U elastic-agent-{{stack-version}}-x86_64.rpm
     ```
 
-3. Confirm in {{fleet}} that the agent has been upgraded to the target version. Note that the **Upgrade agent** option in the **Actions** menu next to the agent will be disabled since [fleet]-managed upgrades are not supported for this package type.
+3. Confirm in {{fleet}} that the agent has been upgraded to the target version. Note that the **Upgrade agent** option in the **Actions** menu next to the agent will be disabled since {{fleet}}-managed upgrades are not supported for this package type.


### PR DESCRIPTION
Redo of https://github.com/elastic/docs-content/pull/773

This updates the Elastic Agent upgrade steps for 9.0. It seems the only change required is to set the hard-coded versions to use the new `{{stack-version}}` variable.

The screen captures all show 8.x versions, but I think that makes sense for now since we don't have 9.x versions to upgrade to.

See: [Preview page](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/808/reference/ingestion-tools/fleet/upgrade-elastic-agent)
Closes: https://github.com/elastic/ingest-docs/issues/1730