### PR TITLE
Fix links for Console

### DIFF
--- a/explore-analyze/query-filter/tools/console.md
+++ b/explore-analyze/query-filter/tools/console.md
@@ -6,6 +6,7 @@ navigation_title: Console
 mapped_urls:
   - https://www.elastic.co/guide/en/kibana/current/console-kibana.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-api-console.html
+  - https://www.elastic.co/guide/en/serverless/current/devtools-run-api-requests-in-the-console.html
 ---
 
 # Run API requests with Console [console-kibana]

--- a/solutions/search/querying-for-search.md
+++ b/solutions/search/querying-for-search.md
@@ -26,7 +26,7 @@ Once you know which [search approaches](search-approaches.md) you need to use, y
 These query languages are complementary, not mutually exclusive. You can use different query languages for different parts of your application, based on your specific needs. This flexibility allows you to gradually adopt newer interfaces as your requirements evolve.
 
 ::::{note} 
-You can use the [{{es}} REST APIs](https://www.elastic.co/docs/api/doc/elasticsearch) to search your data using any HTTP client, including the [{{es}} client libraries](site-or-app/clients.md), or directly in [Console](https://www.elastic.co/guide/en/serverless/current/devtools-run-api-requests-in-the-console.html). You can also run searches using [Discover](/explore-analyze/discover.md) in the UI.
+You can use the [{{es}} REST APIs](https://www.elastic.co/docs/api/doc/elasticsearch) to search your data using any HTTP client, including the [{{es}} client libraries](site-or-app/clients.md), or directly in [Console](/explore-analyze/query-filter/tools/console.md). You can also run searches using [Discover](/explore-analyze/discover.md) in the UI.
 ::::
 
 

--- a/solutions/search/serverless-elasticsearch-get-started.md
+++ b/solutions/search/serverless-elasticsearch-get-started.md
@@ -85,7 +85,7 @@ You won’t be able to view this API key again. If needed you'll need to generat
 
 The UI provides ready-to-use code examples for ingesting data via the REST API. Choose your preferred tool for making these requests:
 
-* [Console](https://www.elastic.co/guide/en/serverless/current/devtools-run-api-requests-in-the-console.html) in your project’s UI
+* [Console](/explore-analyze/query-filter/tools/console.md) in your project’s UI
 * Python
 * JavaScript
 * cURL


### PR DESCRIPTION
The Kibana doc link service currently links to https://www.elastic.co/guide/en/serverless/current/devtools-run-api-requests-in-the-console.html, which seems to be identical to https://www.elastic.co/guide/en/kibana/current/console-kibana.html.

This PR therefore adds the former URL to the list of mapped pages for https://docs-v3-preview.elastic.dev/elastic/docs-content/tree/main/explore-analyze/query-filter/tools/console and updates some other links to that page.