### PR TITLE
Fix asciidoc-style link

### DIFF
--- a/solutions/observability/infra-and-hosts/universal-profiling.md
+++ b/solutions/observability/infra-and-hosts/universal-profiling.md
@@ -163,7 +163,7 @@ The functions view presents an ordered list of functions that Universal Profilin
 
 ## Filtering [profiling-filtering-intro]
 
-In all of the Universal Profiling views, the search bar accepts a filter in the {{kib}} Query Language (https://www.elastic.co/guide/en/kibana/current/kuery-query.html[KQL]).
+In all of the Universal Profiling views, the search bar accepts a filter in the {{kib}} Query Language [KQL](/explore-analyze/query-filter/languages/kql.md).
 
 Most notably, you may want to filter on:
 


### PR DESCRIPTION
A quick fix for a link that was still using old Asciidoc styling.