### PR TITLE
Clarify negative scores returned by Elastic Rerank

### DIFF
--- a/explore-analyze/machine-learning/nlp/ml-nlp-rerank.md
+++ b/explore-analyze/machine-learning/nlp/ml-nlp-rerank.md
@@ -51,6 +51,10 @@ Refer to this [Python notebook](https://github.com/elastic/elasticsearch-labs/bl
 
 ::::
 
+::::{note}
+The relevance scores produced during reranking depend on the text similarity model used and can include negative values.
+::::
+
 ### Create an inference endpoint [ml-nlp-rerank-deploy-steps]
 
 1. In {{kib}}, navigate to the **Dev Console**.

--- a/solutions/search/ranking/semantic-reranking.md
+++ b/solutions/search/ranking/semantic-reranking.md
@@ -102,8 +102,12 @@ To use semantic re-ranking in {{es}}, you need to:
 2. **Create a `rerank` endpoint using the [{{es}} Inference API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put)**. The Inference API creates an inference endpoint and configures your chosen machine learning model to perform the re-ranking task.
 3. **Define a `text_similarity_reranker` retriever in your search request**. The retriever syntax makes it simple to configure both the retrieval and re-ranking of search results in a single API call.
 
-::::{dropdown} Example search request with semantic reranker
+:::::{dropdown} Example search request with semantic reranker
 The following example shows a search request that uses a semantic reranker to reorder the top-k documents based on their semantic similarity to the query.
+
+::::{note}
+The relevance scores produced during reranking depend on the text similarity model used and can include negative values.
+::::
 
 ```console
 POST _search
@@ -128,7 +132,7 @@ POST _search
 }
 ```
 
-::::
+:::::
 
 
 

--- a/solutions/search/ranking/semantic-reranking.md
+++ b/solutions/search/ranking/semantic-reranking.md
@@ -122,8 +122,7 @@ POST _search
       "field": "text",
       "inference_id": "elastic-rerank",
       "inference_text": "How often does the moon hide the sun?",
-      "rank_window_size": 100,
-      "min_score": 0.5
+      "rank_window_size": 100
     }
   }
 }


### PR DESCRIPTION
- Added a note clarifying that relevance scores produced during reranking can include negative values.
- Removed "min_score": 0.5 from the example to avoid confusion, as users might incorrectly assume scores are always positive.
Based on https://github.com/elastic/search-docs-team/issues/234