### PR TITLE
Introduce an Issue Report template to be used by docsv3.

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-report.yaml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yaml
@@ -1,0 +1,42 @@
+name: "Issue report"
+description: Report documentation issues such as inaccuracies, broken links, typos, or missing information.
+title: "[Issue]: "
+labels: ["Issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Hi 👋. Thanks for taking the time to fill out this issue report!
+        This form will create an issue that Elastic's docs team will triage and prioritize.
+        You can also open a PR instead.
+  - type: dropdown
+    attributes:
+      label: Type of issue
+      description: What type of issue are you reporting?
+      multiple: false
+      options:
+        - Not clear
+        - Missing information
+        - Could be improved
+        - I can't find what I'm looking for
+  - type: input
+    id: link
+    attributes:
+      label: What documentation page is affected
+      description: Include a link to the page where you're seeing the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: related
+    attributes:
+      label: What happened?
+      description: Describe the issue you're experiencing. Screenshots are valuable too!
+    validations:
+      required: true
+  - type: textarea
+    id: moreinfo
+    attributes:
+      label: Additional info
+      description: Anything else we should know?
+    validations:
+      required: false


### PR DESCRIPTION
As a part of the changes required for https://github.com/elastic/docs-builder/issues/748, this PR introduces a new template for issue reports to be consumed by a "`Report an issue`" link in the documentation.

The `link` input will be populated by default with the page the user came from.