### PR TITLE
Add missing cluster privilege to risk scoring

### DIFF
--- a/solutions/security/advanced-entity-analytics/entity-risk-scoring-requirements.md
+++ b/solutions/security/advanced-entity-analytics/entity-risk-scoring-requirements.md
@@ -31,6 +31,7 @@ To turn on the risk scoring engine, you need the following:
 
 - `manage_index_templates`
 - `manage_transform`
+- `manage_ingest_pipelines`
 
 #### Index
 


### PR DESCRIPTION
## Summary 

This PR adds the "manage_ingest_pipeline" privilege to the risk scoring cluster privilege requirements. As per [this](https://github.com/orgs/elastic/projects/668/views/56?sliceBy%5Bvalue%5D=CAWilson94&pane=issue&itemId=99856919&issue=elastic%7Csecurity-team%7C12010)requirement, since an ingest pipelines has now been added to the risk engine.