### PR TITLE
Add applies tags to Troubleshoot > Kibana

### DIFF
--- a/troubleshoot/kibana.md
+++ b/troubleshoot/kibana.md
@@ -1,5 +1,8 @@
 ---
 navigation_title: "Kibana"
+applies_to:
+  stack: all
+  serverless: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-troubleshooting.html
 ---

--- a/troubleshoot/kibana/access.md
+++ b/troubleshoot/kibana/access.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Server status"
+applies_to:
+  stack: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/access.html#status
 ---

--- a/troubleshoot/kibana/alerts.md
+++ b/troubleshoot/kibana/alerts.md
@@ -1,5 +1,8 @@
 ---
 navigation_title: "Alerts"
+applies_to:
+  stack: all
+  serverless: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/alerting-troubleshooting.html
 ---

--- a/troubleshoot/kibana/capturing-diagnostics.md
+++ b/troubleshoot/kibana/capturing-diagnostics.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Diagnostics"
+applies_to:
+  stack: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-diagnostic.html
 ---

--- a/troubleshoot/kibana/capturing-diagnostics.md
+++ b/troubleshoot/kibana/capturing-diagnostics.md
@@ -1,7 +1,11 @@
 ---
 navigation_title: "Diagnostics"
 applies_to:
-  stack: all
+  deployment:
+    ess: all
+    ece: all
+    self: all
+    eck: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-diagnostic.html
 ---

--- a/troubleshoot/kibana/error-server-not-ready.md
+++ b/troubleshoot/kibana/error-server-not-ready.md
@@ -1,7 +1,11 @@
 ---
 navigation_title: "Error: Server not ready"
 applies_to:
-  stack: all
+  deployment:
+    ess: all
+    ece: all
+    self: all
+    eck: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/access.html#not-ready
 ---

--- a/troubleshoot/kibana/error-server-not-ready.md
+++ b/troubleshoot/kibana/error-server-not-ready.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Error: Server not ready"
+applies_to:
+  stack: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/access.html#not-ready
 ---

--- a/troubleshoot/kibana/graph.md
+++ b/troubleshoot/kibana/graph.md
@@ -1,5 +1,8 @@
 ---
 navigation_title: "Graph"
+applies_to:
+  stack: all
+  serverless: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/graph-troubleshooting.html
 ---

--- a/troubleshoot/kibana/maps.md
+++ b/troubleshoot/kibana/maps.md
@@ -1,5 +1,8 @@
 ---
 navigation_title: "Maps"
+applies_to:
+  stack: all
+  serverless: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/maps-troubleshooting.html
 ---

--- a/troubleshoot/kibana/migration-failures.md
+++ b/troubleshoot/kibana/migration-failures.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Migration and upgrades"
+applies_to:
+  stack: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/resolve-migrations-failures.html
 ---

--- a/troubleshoot/kibana/migration-failures.md
+++ b/troubleshoot/kibana/migration-failures.md
@@ -1,7 +1,11 @@
 ---
 navigation_title: "Migration and upgrades"
 applies_to:
-  stack: all
+  deployment:
+    ess: all
+    ece: all
+    self: all
+    eck: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/resolve-migrations-failures.html
 ---

--- a/troubleshoot/kibana/monitoring.md
+++ b/troubleshoot/kibana/monitoring.md
@@ -1,5 +1,8 @@
 ---
 navigation_title: "Monitoring"
+applies_to:
+  deployment:
+    self: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/monitor-troubleshooting.html
 ---

--- a/troubleshoot/kibana/reporting.md
+++ b/troubleshoot/kibana/reporting.md
@@ -1,5 +1,8 @@
 ---
 navigation_title: "Reporting"
+applies_to:
+  stack: all
+  serverless: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/reporting-troubleshooting.html
 ---

--- a/troubleshoot/kibana/task-manager.md
+++ b/troubleshoot/kibana/task-manager.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Task Manager"
+applies_to:
+  stack: preview
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/task-manager-troubleshooting.html
 ---

--- a/troubleshoot/kibana/trace-elasticsearch-query-to-the-origin-in-kibana.md
+++ b/troubleshoot/kibana/trace-elasticsearch-query-to-the-origin-in-kibana.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Trace {{es}} query"
+applies_to:
+  stack: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-troubleshooting-trace-query.html
 ---

--- a/troubleshoot/kibana/trace-elasticsearch-query-to-the-origin-in-kibana.md
+++ b/troubleshoot/kibana/trace-elasticsearch-query-to-the-origin-in-kibana.md
@@ -1,7 +1,11 @@
 ---
 navigation_title: "Trace {{es}} query"
 applies_to:
-  stack: all
+  deployment:
+    ess: all
+    ece: all
+    self: all
+    eck: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-troubleshooting-trace-query.html
 ---

--- a/troubleshoot/kibana/using-kibana-server-logs.md
+++ b/troubleshoot/kibana/using-kibana-server-logs.md
@@ -1,7 +1,11 @@
 ---
 navigation_title: "Server logs"
 applies_to:
-  stack: all
+  deployment:
+    ess: all
+    ece: all
+    self: all
+    eck: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-troubleshooting-kibana-server-logs.html
 ---

--- a/troubleshoot/kibana/using-kibana-server-logs.md
+++ b/troubleshoot/kibana/using-kibana-server-logs.md
@@ -1,5 +1,7 @@
 ---
 navigation_title: "Server logs"
+applies_to:
+  stack: all
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-troubleshooting-kibana-server-logs.html
 ---


### PR DESCRIPTION
Adds `applies_to` tags to the **Troubleshoot > Kibana** section.

Preview: [Kibana](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/910/troubleshoot/kibana)

