### PR TITLE
more applies_to cleanup

### DIFF
--- a/deploy-manage/license.md
+++ b/deploy-manage/license.md
@@ -2,8 +2,8 @@
 applies_to:
   deployment:
     ece:
-    ech:
     ess:
+    eck:
     self:
   serverless:
 ---

--- a/deploy-manage/monitor.md
+++ b/deploy-manage/monitor.md
@@ -24,7 +24,7 @@ Depending on your deployment type and context, you have several options for moni
 
 ```{applies_to}
 deployment:
-  ech:
+  ess:
 ```
 
 :::{include} /deploy-manage/monitor/_snippets/autoops.md
@@ -34,7 +34,7 @@ deployment:
 
 ```{applies_to}
 deployment:
-  ech:
+  ess:
   ece:
   eck:
   self:
@@ -53,7 +53,7 @@ In {{ece}} and {{ech}}, Elastic manages the installation and configuration of th
 ```{applies_to}
 deployment:
   ece:
-  ech:
+  ess:
 ```
 
 {{ece}} and {{ech}} provide out of the box tools for monitoring the health of your deployment and resolving health issues when they arise: 


### PR DESCRIPTION
`ech` is not a valid `applies_to` value but I accidentally used it. replacing with `ess`

issue re: linting for these is [here](https://github.com/elastic/docs-builder/issues/610)
issue re: accepting `ech` is [here](https://github.com/elastic/docs-builder/issues/563)

thanks for the catch @stefnestor 