### PR TITLE
[Serverless] Standardize actions in Alerts KPI visualizations and update actions copy

### DIFF
--- a/solutions/security/detect-and-alert/manage-detection-alerts.md
+++ b/solutions/security/detect-and-alert/manage-detection-alerts.md
@@ -35,7 +35,7 @@ The Alerts page offers various ways for you to organize and triage detection ale
 * Use the date and time filter to define a specific time range. By default, this filter is set to search the last 24 hours.
 * Use the drop-down filter controls to filter alerts by up to four fields. By default, you can filter alerts by **Status**, **Severity**, **User**, and **Host**, and you can [edit the controls](/solutions/security/detect-and-alert/manage-detection-alerts.md#drop-down-filter-controls) to use other fields.
 * Visualize and group alerts by specific fields in the visualization section. Use the buttons on the left to select a view type (**Summary**, **Trend**, **Counts**, or **Treemap**), and use the menus on the right to select the ECS fields used for grouping alerts. Refer to [Visualize detection alerts](/solutions/security/detect-and-alert/visualize-detection-alerts.md) for more on each view type.
-* Hover over a value to display available [inline actions](/solutions/security/get-started/elastic-security-ui.md#inline-actions), such as **Filter In**, **Filter Out**, and **Add to timeline**. Click the expand icon for more options, including **Show top *x*** and **Copy to Clipboard**. The available options vary based on the type of data.
+* Hover over a value to display available [inline actions](/solutions/security/get-started/elastic-security-ui.md#inline-actions). Click the expand icon for more options, including **Show top *x*** and **Copy to Clipboard**. The available options vary based on the type of data.
 
     :::{image} /solutions/images/security-inline-actions-menu.png
     :alt: Inline additional actions menu


### PR DESCRIPTION
## Description

Fixes https://github.com/elastic/docs-content/issues/321.

The following UI changes were made to the Alerts page in 9.1 and Serverless:
- Inline actions for the visualizations of alerts were moved into the more actions menu to align the visualizations' design with Lens'.  
- Copy for the actions were tweaked to align them with Discover's. For example, **Filter In** was changed to **Filter for**.

## Preview

Since these modifications were so visually minor, I decided against updating screenshots of the Alerts tables. In the docs about using inline actions from the alerts page I removed examples that were only applicable to 9.0 and not Serverless. Those docs link off to our main docs on inline actions (which apply more broadly across the Security app), so the duplicate info isn't needed. 

[Manage detection alerts | View and filter detection alerts](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/961/solutions/security/detect-and-alert/manage-detection-alerts#detection-view-and-filter-alerts)