### PR TITLE
Fix symbol being used on mapped_pages front matter

### DIFF
--- a/reference/index.md
+++ b/reference/index.md
@@ -1,6 +1,6 @@
 ---
 mapped_pages:
-  • https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/api-reference.html
+  - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/api-reference.html
 ---
 
 # Reference [api-reference]


### PR DESCRIPTION
Hello!

While I was working on making use of the front matter to show the user there's a previous version available, I've found an incorrect character being used to define the mapped page.

This change fixes things here!