### PR TITLE
Use mapped_pages instead of mapped_urls

### DIFF
--- a/cloud-account/index.md
+++ b/cloud-account/index.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-account-user-settings.html
   - https://www.elastic.co/guide/en/serverless/current/general-user-profile.html
 applies:
@@ -23,7 +23,7 @@ Additionally, you can manage your organization membership, including joining or 
 
 Some options also let you set personal preferences and customize the interface, such as [using dark mode](dark-mode.md) in your projects and deployments.
 
-::::{tip} 
+::::{tip}
 This section focuses on the actions you can take as an individual user to manage your own account. It does not cover organization-wide settings, such as managing user permissions or configuring organization-level access controls, which are handled by the organization administrators.
 
 For information on organization and access management, refer to:

--- a/cloud-account/join-or-leave-an-organization.md
+++ b/cloud-account/join-or-leave-an-organization.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-invite-users.html
   - https://www.elastic.co/guide/en/serverless/current/general-manage-organization.html
 applies:
@@ -35,7 +35,7 @@ If you already belong to an organization, and you want to join a new one you wil
 
 Alternatively, for Elastic Cloud Hosted deployments, there's a possibility to migrate your deployments to the new organization through back up and restore operations. In such case:
 
-1. [Back up your deployments to any private repository](/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md) so that you can restore them to your new organization. 
+1. [Back up your deployments to any private repository](/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md) so that you can restore them to your new organization.
 2. Leave your current organization.
 3. Ask the administrator to invite you to the organization you want to join.
 4. Accept the invitation that you will get by email.

--- a/deploy-manage/autoscaling.md
+++ b/deploy-manage/autoscaling.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-autoscaling.html
 applies_to:
   deployment:
@@ -19,7 +19,7 @@ By default, {{serverless-full}} automatically scales your {{es}} resources based
 
 ## Cluster autoscaling
 
-::::{admonition} Indirect use only 
+::::{admonition} Indirect use only
 This feature is designed for indirect use by {{ech}}, {{ece}}, and {{eck}}. Direct use is not supported.
 ::::
 
@@ -42,7 +42,7 @@ Trained model autoscaling automatically adjusts the resources allocated to train
 Trained model autoscaling supports:
 * Scaling trained model deployments
 
-::::{note} 
+::::{note}
 Autoscaling is not supported on Debian 8.
 ::::
 

--- a/deploy-manage/autoscaling/autoscaling-deciders.md
+++ b/deploy-manage/autoscaling/autoscaling-deciders.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-deciders.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-reactive-storage-decider.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/autoscaling-proactive-storage-decider.html

--- a/deploy-manage/autoscaling/autoscaling-in-ece-and-ech.md
+++ b/deploy-manage/autoscaling/autoscaling-in-ece-and-ech.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-autoscaling.html
   - https://www.elastic.co/guide/en/cloud/current/ec-autoscaling.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-autoscaling.html
@@ -200,7 +200,7 @@ The example deployment has a hot data and content tier, warm data tier, cold dat
 
 To learn more about the {{ece}} API, see the [RESTful API](cloud://reference/cloud-enterprise/restful-api.md) documentation. For details on the {{ech}} API, check [RESTful API](cloud://reference/cloud-hosted/ec-api-restful.md).
 
-### Requirements [ec_requirements] 
+### Requirements [ec_requirements]
 
 Note the following requirements when you run this API request:
 
@@ -218,7 +218,7 @@ Note the following requirements when you run this API request:
     * On all other components autoscaling is not currently supported.
 * On {{ece}}, autoscaling is supported for custom deployment templates on version 2.12 and above. To learn more, refer to [Updating custom templates to support `node_roles` and autoscaling](../deploy/cloud-enterprise/ce-add-support-for-node-roles-autoscaling.md).
 
-$$$ece-autoscaling-api-example-requirements-table$$$ 
+$$$ece-autoscaling-api-example-requirements-table$$$
 
 |  | `size` | `autoscaling_min` | `autoscaling_max` |
 | --- | --- | --- | --- |
@@ -237,7 +237,7 @@ $$$ece-autoscaling-api-example-requirements-table$$$
 
 ### API request example [ec_api_request_example]
 
-::::{note} 
+::::{note}
 Although autoscaling can scale some tiers by CPU, the primary measurement of tier size is memory. Limits on tier size are in terms of memory.
 ::::
 

--- a/deploy-manage/autoscaling/trained-model-autoscaling.md
+++ b/deploy-manage/autoscaling/trained-model-autoscaling.md
@@ -1,13 +1,13 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/general-ml-nlp-auto-scale.html
   - https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-auto-scale.html
 applies_to:
-  deployment: 
+  deployment:
     ess:
     eck:
     ece:
-  serverless: 
+  serverless:
 ---
 
 # Trained model autoscaling
@@ -93,7 +93,7 @@ On {{serverless-short}}, VCUs for {{ml}} are based on the amount of vCPU and mem
 As a math formula, `VCUs = 8 * allocations * threads`, or `1` VCU for every `1GB` of memory consumed, whichever is greater.
 ::::
 
-If you use a self-managed cluster or ECK, vCPUs level ranges are derived from the `total_ml_processors` and `max_single_ml_node_processors` values. Use the [get {{ml}} info API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-info) to check these values. 
+If you use a self-managed cluster or ECK, vCPUs level ranges are derived from the `total_ml_processors` and `max_single_ml_node_processors` values. Use the [get {{ml}} info API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-info) to check these values.
 
 The following tables show you the number of allocations, threads, and vCPUs available in ECE and ECH when adaptive resources are enabled or disabled.
 

--- a/deploy-manage/cloud-organization/billing.md
+++ b/deploy-manage/cloud-organization/billing.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-billing.html
   - https://www.elastic.co/guide/en/serverless/current/general-manage-billing.html
   - https://www.elastic.co/guide/en/serverless/current/general-billing-stop-project.html

--- a/deploy-manage/cloud-organization/billing/billing-models.md
+++ b/deploy-manage/cloud-organization/billing/billing-models.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-billing-models.html
 applies_to:
   deployment:
@@ -17,7 +17,7 @@ You can be billed for {{ecloud}} using one of the following billing models:
 
 Regardless of your billing model, all {{ecloud}} usage is metered and billed in [Elastic Consumption Units (ECU)](/deploy-manage/cloud-organization/billing/ecu.md).
 
-## Monthly, billed by Elastic [ec-monthly-direct] 
+## Monthly, billed by Elastic [ec-monthly-direct]
 
 When you sign up for {{ecloud}} by [adding your credit card details](/deploy-manage/cloud-organization/billing/add-billing-details.md) in the {{ecloud}} Console, you are billed on a monthly basis.
 
@@ -27,7 +27,7 @@ All usage is expressed and charged in US dollars only.
 
 Refer to our [Billing FAQ](/deploy-manage/cloud-organization/billing/billing-faq.md) for more details about monthly invoicing.
 
-## Monthly, billed through a marketplace [ec-monthly-marketplace] 
+## Monthly, billed through a marketplace [ec-monthly-marketplace]
 
 You can sign up for {{ecloud}} [from a marketplace](/deploy-manage/deploy/elastic-cloud/subscribe-from-marketplace.md). In this case, all usage is reported hourly to the marketplace.
 
@@ -35,11 +35,11 @@ At the marketplace’s billing cycle, all usage is aggregated and charged as par
 
 {{ecloud}} usage appears as a single invoice line with the total amount charged. For a detailed breakdown of your usage, visit the [Usage page](/deploy-manage/cloud-organization/billing/monitor-analyze-usage.md) in the {{ecloud}} Console.
 
-::::{note} 
+::::{note}
 Marketplaces typically invoice you in arrears on the first of each month. There are exceptions, however, such as in the case of the [GCP billing cycle](https://cloud.google.com/billing/docs/how-to/billing-cycle).
 ::::
 
-## Prepaid consumption [ec-prepaid-consumption] 
+## Prepaid consumption [ec-prepaid-consumption]
 
 All new and renewing {{ecloud}} annual customers are automatically enrolled into the prepaid consumption billing model.
 
@@ -79,6 +79,6 @@ Based on these four key concepts, the prepaid consumption lifecycle is as follow
 
 ² Purchasing credits through early renewals, or through add-ons with different expiration dates will be available in the near future.
 
-::::{note} 
+::::{note}
 Existing annual+overages customers will be able to switch to prepaid consumption when they renew or sign a new contract. Existing manual burndown customers will be migrated gradually to prepaid consumption in the near future. Exceptions apply.
 ::::

--- a/deploy-manage/cloud-organization/billing/ecu.md
+++ b/deploy-manage/cloud-organization/billing/ecu.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-billing-ecu.html
 applies_to:
   deployment:
@@ -15,7 +15,7 @@ The nominal value of one Elastic Consumption Unit is $1.00. You can use our [{{e
 
 Your monthly usage statement is issued in ECU, though it also includes the currency equivalent of your consumption. The **Usage** page in the [{{ecloud}} Console](https://cloud.elastic.co?page=docs&placement=docs-body) also shows usage information in ECU.
 
-## Contractual information and quoting [ec_contractual_information_and_quoting] 
+## Contractual information and quoting [ec_contractual_information_and_quoting]
 
 When you sign a prepaid consumption contract, you are purchasing Elastic Consumption Units which can be used to cover your {{ecloud}} usage throughout your contract period.
 

--- a/deploy-manage/cloud-organization/billing/manage-subscription.md
+++ b/deploy-manage/cloud-organization/billing/manage-subscription.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/general-check-subscription.html
   - https://www.elastic.co/guide/en/cloud/current/ec-subscription-overview.html
   - https://www.elastic.co/guide/en/cloud/current/ec-select-subscription-level.html
@@ -13,14 +13,14 @@ applies_to:
 
 # Manage your subscription
 
-When you decide to add your credit card and become a paying customer, you can choose a subscription level. 
+When you decide to add your credit card and become a paying customer, you can choose a subscription level.
 
 Depending on whether you're using {{ech}} deployment or {{serverless-full}} projects, your subscription level might dictate what features you can access or what level of support you receive. On the following pricing pages, you can review additional details about what you get at each subscription level:
 
 * [{{ech}}](https://www.elastic.co/cloud/elasticsearch-service/pricing)
 * [{{serverless-full}}](https://www.elastic.co/pricing/serverless-search)
 
-You can find more details about your subscription in the [Billing overview page](https://cloud.elastic.co/billing/overview), in the **Subscription level** section. 
+You can find more details about your subscription in the [Billing overview page](https://cloud.elastic.co/billing/overview), in the **Subscription level** section.
 
 
 ## Change your subscription level [ec-select-subscription-level]

--- a/deploy-manage/cloud-organization/billing/monitor-analyze-usage.md
+++ b/deploy-manage/cloud-organization/billing/monitor-analyze-usage.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-account-usage.html
   - https://www.elastic.co/guide/en/serverless/current/general-monitor-usage.html
 applies_to:
@@ -27,6 +27,6 @@ To access your account usage:
 3. Select **Billing** under the user menu.
 4. Go to the **Usage** page.
 
-::::{important} 
+::::{important}
 The usage breakdown information visible on the **Usage** page is an estimate, and does not include prepaid credits, free allowances or any discounts. To get the exact amount you owe for a given month, check your invoices in the [billing history](/deploy-manage/cloud-organization/billing/view-billing-history.md).
 ::::

--- a/deploy-manage/cloud-organization/billing/view-billing-history.md
+++ b/deploy-manage/cloud-organization/billing/view-billing-history.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-billing-history.html
   - https://www.elastic.co/guide/en/serverless/current/general-billing-history.html
 applies_to:

--- a/deploy-manage/cloud-organization/service-status.md
+++ b/deploy-manage/cloud-organization/service-status.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-service-status.html
   - https://www.elastic.co/guide/en/cloud/current/ec_subscribe_to_individual_regionscomponents.html
   - https://www.elastic.co/guide/en/cloud/current/ec_service_status_api.html
@@ -19,7 +19,7 @@ applies_to:
 
 To check current and past service availability, go to to the [Cloud Status](https://cloud-status.elastic.co/) page. Services are separated into {{ech}} services and [Serverless services](https://status.elastic.co/?section=serverless).
 
-## Subscribe to updates [ec_subscribe_to_updates] 
+## Subscribe to updates [ec_subscribe_to_updates]
 
 Don’t want to check the service status page manually? You can get notified about changes to the service status automatically.
 
@@ -36,7 +36,7 @@ After you subscribe to updates, you are notified whenever a service status updat
 
 ## Subscribe to individual regions or components
 
-If you want to know about specific status updates, rather than all of them, you can adjust your preferences by using the following steps. These steps apply to both new signups and adjustments to an existing subscription. 
+If you want to know about specific status updates, rather than all of them, you can adjust your preferences by using the following steps. These steps apply to both new signups and adjustments to an existing subscription.
 
 Go to the [Cloud Status](https://cloud-status.elastic.co/) page and select **SUBSCRIBE TO UPDATES**. Enter your email address and click **SUBSCRIBE VIA EMAIL**. You will be brought to a page with a list of regions and components.
 

--- a/deploy-manage/deploy.md
+++ b/deploy-manage/deploy.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/intro.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro-deploy.html
   - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/get-elastic.html

--- a/deploy-manage/deploy/cloud-enterprise.md
+++ b/deploy-manage/deploy/cloud-enterprise.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/index.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/Elastic-Cloud-Enterprise-overview.html
 ---

--- a/deploy-manage/deploy/cloud-enterprise/air-gapped-install.md
+++ b/deploy-manage/deploy/cloud-enterprise/air-gapped-install.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-install-offline.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/create-deployment.md
+++ b/deploy-manage/deploy/cloud-enterprise/create-deployment.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-create-deployment.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/ece-integrations-server-api-example.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-integrations-server-api-example.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-integrations-server-api-example.html
 ---
 
@@ -13,14 +13,14 @@ This example demonstrates how to use the Elastic Cloud Enterprise RESTful API to
 For more information on how to manage Integrations Server from the UI, check [Manage your Integrations Server](manage-integrations-server.md)
 
 
-## Requirements [ece_requirements_4] 
+## Requirements [ece_requirements_4]
 
 Integrations Server can be enabled only on new deployments, starting with Elastic Stack version 8.0.
 
 It’s possible to enable Integrations Server on an existing deployment with version 8.0 only if [APM & Fleet Server](https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-apm-and-fleet.html) hasn’t been previously enabled on the deployment.
 
 
-## API request example [ece_api_request_example_2] 
+## API request example [ece_api_request_example_2]
 
 Run this example API request to create a deployment with Integrations Server:
 

--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm.md
@@ -3,7 +3,7 @@ navigation_title: APM user settings
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-apm-settings.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-elasticsearch.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-elasticsearch.md
@@ -3,7 +3,7 @@ navigation_title: Elasticsearch user settings
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-add-user-settings.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-enterprise.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-enterprise.md
@@ -3,7 +3,7 @@ navigation_title: Enterprise search user settings
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-enterprise-search-settings.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-kibana.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-kibana.md
@@ -3,7 +3,7 @@ navigation_title: Kibana user settings
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-kibana-settings.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md
@@ -3,7 +3,7 @@ navigation_title: Edit stack settings
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/editing-user-settings.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/generate-roles-tokens.md
+++ b/deploy-manage/deploy/cloud-enterprise/generate-roles-tokens.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-generate-roles-token.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-revoke-roles-token.html
 ---

--- a/deploy-manage/deploy/cloud-enterprise/manage-integrations-server.md
+++ b/deploy-manage/deploy/cloud-enterprise/manage-integrations-server.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-integrations-server.html
 ---
 

--- a/deploy-manage/deploy/cloud-enterprise/working-with-deployments.md
+++ b/deploy-manage/deploy/cloud-enterprise/working-with-deployments.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-stack-getting-started.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-administering-deployments.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-monitoring-deployments.html
@@ -44,7 +44,7 @@ From the deployment main page, you can quickly access the following configuratio
 
 * Select **{{es}} > snapshots** to associate a [snapshots repository](../../tools/snapshot-and-restore/cloud-enterprise.md#ece-manage-repositories-clusters) with the deployment.
 
-* Select **Monitoring > Logs and metrics** to set up [Stack monitoring](../../monitor/stack-monitoring/ece-ech-stack-monitoring.md) for your deployment, forwarding its logs and metrics to a dedicated monitoring deployment. 
+* Select **Monitoring > Logs and metrics** to set up [Stack monitoring](../../monitor/stack-monitoring/ece-ech-stack-monitoring.md) for your deployment, forwarding its logs and metrics to a dedicated monitoring deployment.
 
   ::::{note}
   In addition to the monitoring of clusters that is described here, don’t forget that {{ece}} also provides [monitoring information for your entire installation](../../../deploy-manage/monitor/orchestrators/ece-platform-monitoring.md).

--- a/deploy-manage/deploy/cloud-on-k8s.md
+++ b/deploy-manage/deploy/cloud-on-k8s.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     eck: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-advanced-topics.html

--- a/deploy-manage/deploy/cloud-on-k8s/accessing-services.md
+++ b/deploy-manage/deploy/cloud-on-k8s/accessing-services.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     eck: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-accessing-elastic-services.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-request-elasticsearch-endpoint.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-services.html

--- a/deploy-manage/deploy/cloud-on-k8s/air-gapped-install.md
+++ b/deploy-manage/deploy/cloud-on-k8s/air-gapped-install.md
@@ -3,7 +3,7 @@ navigation_title: Air-gapped environments
 applies_to:
   deployment:
     eck: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elastic-stack/current/air-gapped-install.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-air-gapped.html
 ---

--- a/deploy-manage/deploy/cloud-on-k8s/deploy-fips-compatible-version-of-eck.md
+++ b/deploy-manage/deploy/cloud-on-k8s/deploy-fips-compatible-version-of-eck.md
@@ -3,7 +3,7 @@ navigation_title: FIPS compatibility
 applies_to:
   deployment:
     eck: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-fips.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_installation.html
 ---

--- a/deploy-manage/deploy/cloud-on-k8s/install-using-yaml-manifest-quickstart.md
+++ b/deploy-manage/deploy/cloud-on-k8s/install-using-yaml-manifest-quickstart.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: YAML manifests
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-install-yaml-manifests.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-deploy-eck.html
 applies_to:
@@ -10,7 +10,7 @@ applies_to:
 
 # Install ECK using the YAML manifests [k8s-install-yaml-manifests]
 
-In this guide, you'll learn how to deploy ECK using Elastic-provided YAML manifests. This method is the quickest way to get started with ECK if you have full administrative access to the Kubernetes cluster. 
+In this guide, you'll learn how to deploy ECK using Elastic-provided YAML manifests. This method is the quickest way to get started with ECK if you have full administrative access to the Kubernetes cluster.
 
 To learn about other installation methods, refer to [](/deploy-manage/deploy/cloud-on-k8s/install.md).
 

--- a/deploy-manage/deploy/cloud-on-k8s/install.md
+++ b/deploy-manage/deploy/cloud-on-k8s/install.md
@@ -3,7 +3,7 @@ navigation_title: Install
 applies_to:
   deployment:
     eck: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-installing-eck.html
 ---
 

--- a/deploy-manage/deploy/elastic-cloud/access-kibana.md
+++ b/deploy-manage/deploy/elastic-cloud/access-kibana.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-access-kibana.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-access-kibana.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-enable-kibana2.html
@@ -37,7 +37,7 @@ To access Kibana:
 
 3. Under **Applications**, select the Kibana **Launch** link and wait for Kibana to open.
 
-    ::::{note} 
+    ::::{note}
     Both ports 443 and 9243 can be used to access Kibana. SSO only works with 9243 on older deployments, where you will see an option in the Cloud UI to migrate the default to port 443. In addition, any version upgrade will automatically migrate the default port to 443.
     ::::
 

--- a/deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md
+++ b/deploy-manage/deploy/elastic-cloud/add-plugins-extensions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-adding-plugins.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-adding-elastic-plugins.html
   - https://www.elastic.co/guide/en/cloud/current/ec-adding-plugins.html

--- a/deploy-manage/deploy/elastic-cloud/cloud-hosted.md
+++ b/deploy-manage/deploy/elastic-cloud/cloud-hosted.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/index.html
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started.html
   - https://www.elastic.co/guide/en/cloud/current/ec-faq-getting-started.html

--- a/deploy-manage/deploy/elastic-cloud/configure.md
+++ b/deploy-manage/deploy/elastic-cloud/configure.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-customize-deployment.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-configure-settings.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-configure.html
@@ -15,7 +15,7 @@ You might want to change the configuration of your deployment to:
 * Add features, such as machine learning or APM (application performance monitoring).
 * Increase or decrease capacity by changing the amount of reserved memory and storage for different parts of your deployment.
 
-    ::::{note} 
+    ::::{note}
     During the free trial, {{ech}} deployments are restricted to a limited size. You can increase the size of your deployments when your trial is converted to a paid subscription.
     ::::
 
@@ -30,7 +30,7 @@ We perform all of these changes by creating instances with the new configuration
 
 By doing it this way, we reduce the risk of making configuration changes. If any of the new instances have a problems, the old ones are still there, processing requests.
 
-::::{note} 
+::::{note}
 If you use a Platform-as-a-Service provider like Heroku, the administration console is slightly different and does not allow you to make changes that will affect the price. That must be done in the platform provider’s add-on system. You can still do things like change {{es}} version or plugins.
 ::::
 
@@ -51,13 +51,13 @@ To change your deployment:
 
 Review the changes to your configuration on the **Activity** page, with a tab for {{es}} and one for {{kib}}.
 
-::::{tip} 
+::::{tip}
 If you are creating a new deployment, select **Edit settings** to change the cloud provider, region, hardware profile, and stack version; or select **Advanced settings** for more complex configuration settings.
 ::::
 
 
 That’s it! If you haven’t already, [start exploring with {{kib}}](../../../deploy-manage/deploy/elastic-cloud/access-kibana.md), our visualization tool. If you’re not familiar with adding data yet, {{kib}} can show you how to index your data into {{es}}, or try our basic steps for working with [{{es}}](../../../manage-data/data-store/manage-data-from-the-command-line.md).
 
-::::{tip} 
+::::{tip}
 Some features are not available during the 14-day free trial. If a feature is greyed out, [add a credit card](../../../deploy-manage/cloud-organization/billing/add-billing-details.md) to unlock the feature.
 ::::

--- a/deploy-manage/deploy/elastic-cloud/create-an-organization.md
+++ b/deploy-manage/deploy/elastic-cloud/create-an-organization.md
@@ -4,7 +4,7 @@ applies_to:
     ess: ga
   serverless: ga
 navigation_title: Sign up
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-trial.html
   - https://www.elastic.co/guide/en/serverless/current/general-sign-up-trial.html
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-existing-email.html

--- a/deploy-manage/deploy/elastic-cloud/custom-endpoint-aliases.md
+++ b/deploy-manage/deploy/elastic-cloud/custom-endpoint-aliases.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-regional-deployment-aliases.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-regional-deployment-aliases.html
 ---
@@ -20,9 +20,9 @@ mapped_urls:
 Custom aliases for your deployment endpoints on {{ech}} allow you to have predictable, human-readable URLs that can be shared easily. An alias is unique to only one deployment within a region.
 
 
-## Create a custom endpoint alias for a deployment [ec-create-regional-deployment-alias] 
+## Create a custom endpoint alias for a deployment [ec-create-regional-deployment-alias]
 
-::::{note} 
+::::{note}
 New deployments are assigned a default alias derived from the deployment name. This alias can be modified later, if needed.
 ::::
 
@@ -33,14 +33,14 @@ To add an alias to an existing deployment:
 2. Under **Custom endpoint alias**, select **Edit**.
 3. Define a new alias. Make sure you choose something meaningful to you.
 
-    ::::{tip} 
+    ::::{tip}
     Make the alias as unique as possible to avoid collisions. Aliases might have been already claimed by other users for deployments in the region.
     ::::
 
 4. Select **Update alias**.
 
 
-## Remove a custom endpoint alias [ec-delete-regional-deployment-alias] 
+## Remove a custom endpoint alias [ec-delete-regional-deployment-alias]
 
 To remove an alias from your deployment, or if you want to re-assign an alias to another deployment, follow these steps:
 
@@ -49,23 +49,23 @@ To remove an alias from your deployment, or if you want to re-assign an alias to
 3. Remove the text from the **Custom endpoint alias** text box.
 4. Select **Update alias**.
 
-::::{note} 
+::::{note}
 After removing an alias, your organisation’s account will hold a claim on it for 30 days. After that period, other users can re-use this alias.
 ::::
 
 
 
-## Using the custom endpoint URL [ec-using-regional-deployment-alias] 
+## Using the custom endpoint URL [ec-using-regional-deployment-alias]
 
 To use your new custom endpoint URL to access your Elastic products, note that each has its own alias to use in place of the default application UUID. For example, if you configured the custom endpoint alias for your deployment to be `test-alias`, the corresponding alias for the Elasticsearch cluster in that deployment is `test-alias.es`.
 
-::::{note} 
+::::{note}
 You can get the application-specific custom endpoint alias by selecting **Copy endpoint** for that product. It should contain a subdomain for each application type, for example `es`, `kb`, `apm`, or `ent`.
 ::::
 
 
 
-### With the REST Client [ec-rest-regional-deployment-alias] 
+### With the REST Client [ec-rest-regional-deployment-alias]
 
 * As part of the host name:
 
@@ -77,7 +77,7 @@ You can get the application-specific custom endpoint alias by selecting **Copy e
 
 
 
-### With the `TransportClient` [ec-transport-regional-deployment-alias] 
+### With the `TransportClient` [ec-transport-regional-deployment-alias]
 
 While the `TransportClient` is deprecated, your custom endpoint aliases still work with it. Similar to the REST Client, there are two ways to use your custom endpoint alias with the `TransportClient`:
 
@@ -118,24 +118,24 @@ While the `TransportClient` is deprecated, your custom endpoint aliases still wo
 For more information on configuring the `TransportClient`, see
 
 
-## Create a custom domain with NGINX [ec-custom-domains-with-nginx] 
+## Create a custom domain with NGINX [ec-custom-domains-with-nginx]
 
 If you don’t get the level of domain customization you’re looking for by using the [custom endpoint aliases](../../../deploy-manage/deploy/elastic-cloud/custom-endpoint-aliases.md), you might consider creating a CNAME record that points to your Elastic Cloud endpoints. However, that can lead to some issues. Instead, setting up your own proxy could provide the desired level of customization.
 
-::::{important} 
+::::{important}
 The setup described in the following sections is not supported by Elastic, and if your proxy cannot connect to the endpoint, but curl can, we may not be able to help.
 ::::
 
 
 
-### Avoid creating CNAMEs [ec_avoid_creating_cnames] 
+### Avoid creating CNAMEs [ec_avoid_creating_cnames]
 
 To achieve a fully custom domain, you can add a CNAME that points to your Elastic Cloud endpoint. However, this will lead to invalid certificate errors, and moreover, may simply not work. Your Elastic Cloud endpoints already point to a proxy internal to Elastic Cloud, which may not resolve your configured CNAME in the desired way.
 
 So what to do, instead?
 
 
-### Setting up a proxy [ec_setting_up_a_proxy] 
+### Setting up a proxy [ec_setting_up_a_proxy]
 
 Here we’ll show you an example of proxying with NGINX, but this can be extrapolated to HAProxy or some other proxy server.
 
@@ -157,7 +157,7 @@ server {
 
 This should work for all of your applications, not just {{es}}. To set it up for {{kib}}, for example, you can select `Copy cluster ID` next to {{kib}} on your deployment’s main page to get the correct UUID.
 
-::::{note} 
+::::{note}
 Doing this for {{kib}} won't work with Cloud SSO.
 ::::
 

--- a/deploy-manage/deploy/elastic-cloud/edit-stack-settings.md
+++ b/deploy-manage/deploy/elastic-cloud/edit-stack-settings.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-add-user-settings.html
   - https://www.elastic.co/guide/en/cloud/current/ec-editing-user-settings.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-add-user-settings.html

--- a/deploy-manage/deploy/elastic-cloud/heroku.md
+++ b/deploy-manage/deploy/elastic-cloud/heroku.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-getting-started.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-about.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-getting-started-next-steps.html
@@ -36,7 +36,7 @@ For other restrictions that apply to all of {{ecloud}}, refer to [](/deploy-mana
 
 To get started with the {{es}} Add-on for Heroku, [install the add-on](/deploy-manage/deploy/elastic-cloud/heroku-getting-started-installing.md).
 
-After you install, you can access your deployment: 
+After you install, you can access your deployment:
 
 * [](/deploy-manage/deploy/elastic-cloud/heroku-getting-started-accessing.md): Access the {{ecloud}} Console for your {{es}} Add-On for Heroku deployment.
 * [](/deploy-manage/deploy/elastic-cloud/heroku-working-with-elasticsearch.md): Retrieve  the {{es}} endpoint address and send requests to {{es}}.
@@ -65,7 +65,7 @@ Find more information about {{ech}} on the following pages. This information is 
 
 After have provisioned your first deployment, you’re ready to index data into the deployment and explore the advanced capabilities of {{heroku}}.
 
-### Index data [ech-ingest-data] 
+### Index data [ech-ingest-data]
 
 There are several ways to ingest data into the deployment:
 
@@ -74,7 +74,7 @@ There are several ways to ingest data into the deployment:
 * Have existing {{es}} data? Consider your [migration options](../../../manage-data/migrate.md).
 
 
-### Increase security [ech-increase-security] 
+### Increase security [ech-increase-security]
 
 You might want to add more layers of security to your deployment, such as:
 
@@ -83,6 +83,6 @@ You might want to add more layers of security to your deployment, such as:
 * Create [traffic filters](../../security/traffic-filtering.md) and apply them to your deployments.
 * If needed, you can [reset](../../users-roles/cluster-or-deployment-auth/built-in-users.md) the `elastic` password.
 
-### Scale or adjust your deployment [echscale_or_adjust_your_deployment] 
+### Scale or adjust your deployment [echscale_or_adjust_your_deployment]
 
 You might find that you need a larger deployment for the workload, or [upgrade the {{es}} version](/deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ech.md) for the latest features. All of this can be done after provisioning by [changing your deployment configuration](/deploy-manage/deploy/elastic-cloud/manage-deployments.md).

--- a/deploy-manage/deploy/elastic-cloud/keep-track-of-deployment-activity.md
+++ b/deploy-manage/deploy/elastic-cloud/keep-track-of-deployment-activity.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-activity-page.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-activity-page.html
 ---

--- a/deploy-manage/deploy/elastic-cloud/project-settings.md
+++ b/deploy-manage/deploy/elastic-cloud/project-settings.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/project-and-management-settings.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-manage-project.html
 

--- a/deploy-manage/deploy/elastic-cloud/serverless.md
+++ b/deploy-manage/deploy/elastic-cloud/serverless.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/index.html
   - https://www.elastic.co/guide/en/serverless/current/intro.html
   - https://www.elastic.co/guide/en/serverless/current/general-serverless-status.html
@@ -49,8 +49,8 @@ Afterwards, you can:
 
 **Pay per usage:** Each serverless project type includes product-specific and usage-based pricing.
 
-**Data and performance control**. Control your project data and query performance against your project data. 
-  * **Data:** Choose the data you want to ingest and the method to ingest it. By default, data is stored indefinitely in your project, and you define the retention settings for your data streams. 
+**Data and performance control**. Control your project data and query performance against your project data.
+  * **Data:** Choose the data you want to ingest and the method to ingest it. By default, data is stored indefinitely in your project, and you define the retention settings for your data streams.
   * **Performance:** For granular control over costs and query performance against your project data, serverless projects come with a set of predefined settings you can edit.
 
 ## Monitor serverless status [general-serverless-status]

--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -3,7 +3,7 @@ applies_to:
   deployment:
     ess: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-http-apis.html
   - https://www.elastic.co/guide/en/tpec/current/index.html
 navigation_title: "Tools and APIs"
@@ -49,8 +49,8 @@ Refer to [{{es}} API conventions](elasticsearch://reference/elasticsearch/rest-a
 
 The following APIs are available for {{es-serverless}} users:
 
-- [{{es}} {{serverless-short}} APIs](https://www.elastic.co/docs/api/doc/elasticsearch-serverless): Use these APIs to index, manage, search, and analyze your data in {{es-serverless}}. 
-  
+- [{{es}} {{serverless-short}} APIs](https://www.elastic.co/docs/api/doc/elasticsearch-serverless): Use these APIs to index, manage, search, and analyze your data in {{es-serverless}}.
+
   Learn how to [connect to your {{es-serverless}} endpoint](/solutions/search/get-started.md).
 - [{{kib}} {{serverless-short}} APIs](https://www.elastic.co/docs/api/doc/serverless): Use these APIs to manage resources such as connectors, data views, and saved objects for your {{serverless-full}} project.
 ::::

--- a/deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md
+++ b/deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-custom-bundles.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-custom-bundles.html
 ---
@@ -25,7 +25,7 @@ The selected plugins/bundles are downloaded and provided when a node starts. Cha
 
 With great power comes great responsibility: your plugins can extend your deployment with new functionality, but also break it. Be careful. We obviously cannot guarantee that your custom code works.
 
-::::{important} 
+::::{important}
 You cannot edit or delete a custom extension after it has been used in a deployment. To remove it from your deployment, you can disable the extension and update your deployment configuration.
 ::::
 
@@ -48,7 +48,7 @@ Plugins
 
     {{es}} assumes that the uploaded ZIP file contains binaries. If it finds any source code, it fails with an error message, causing provisioning to fail. Make sure you upload binaries, and not source code.
 
-    ::::{note} 
+    ::::{note}
     Plugins larger than 5GB should have the plugin descriptor file at the top of the archive. This order can be achieved by specifying at time of creating the ZIP file:
 
     ```sh
@@ -119,7 +119,7 @@ You must upload your files before you can apply them to your cluster configurati
 
 After creating your extension, you can [enable them for existing {{es}} deployments](../../../deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md#ec-update-bundles) or enable them when creating new deployments.
 
-::::{note} 
+::::{note}
 Creating extensions larger than 200MB should be done through the extensions API.
 
 Refer to [Managing plugins and extensions through the API](../../../deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md) for more details.
@@ -178,7 +178,7 @@ To update an extension with a new file version,
 
 ## How to use the extensions API [ec-extension-api-usage-guide]
 
-::::{note} 
+::::{note}
 For a full set of examples, check [Managing plugins and extensions through the API](../../../deploy-manage/deploy/elastic-cloud/manage-plugins-extensions-through-api.md).
 ::::
 

--- a/deploy-manage/deploy/self-managed/air-gapped-install.md
+++ b/deploy-manage/deploy/self-managed/air-gapped-install.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elastic-stack/current/air-gapped-install.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-install-offline.html
 applies_to:

--- a/deploy-manage/deploy/self-managed/bootstrap-checks.md
+++ b/deploy-manage/deploy/self-managed/bootstrap-checks.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks-xpack.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks-heap-size.html

--- a/deploy-manage/deploy/self-managed/install-kibana.md
+++ b/deploy-manage/deploy/self-managed/install-kibana.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/setup.html
   - https://www.elastic.co/guide/en/kibana/current/install.html
 applies_to:
@@ -19,7 +19,7 @@ This section includes information on how to set up {{kib}} and get it running, i
 
 To quickly set up {{es}} and {{kib}} in Docker for local development or testing, jump to [](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md).
 
-## Supported platforms [supported-platforms] 
+## Supported platforms [supported-platforms]
 
 Packages of {{kib}} are provided for and tested against Linux, Darwin, and Windows. Because {{kib}} runs on Node.js, we include the necessary Node.js binaries for these platforms. Running {{kib}} against a separately maintained version of Node.js is not supported.
 
@@ -37,7 +37,7 @@ To support certain older Linux platforms (most notably CentOS7/RHEL7), {{kib}} f
 | `rpm` | The `rpm` package is suitable for installation on Red Hat, SLES, OpenSuSE and other RPM-based systems.  RPMs may be downloaded from the Elastic website or from our RPM repository. | [Install with RPM](/deploy-manage/deploy/self-managed/install-kibana-with-rpm.md) |
 | `docker` | Images are available for running {{kib}} as a Docker container. They may be downloaded from the Elastic Docker Registry. | [Running {{kib}} on Docker](/deploy-manage/deploy/self-managed/install-kibana-with-docker.md) |
 
-## {{es}} version [elasticsearch-version] 
+## {{es}} version [elasticsearch-version]
 
 :::{include} /deploy-manage/deploy/_snippets/stack-version-compatibility.md
 :::

--- a/deploy-manage/deploy/self-managed/installing-elasticsearch.md
+++ b/deploy-manage/deploy/self-managed/installing-elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html
   - https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html

--- a/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/index-level-shard-allocation.md
+++ b/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/index-level-shard-allocation.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-allocation.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/shard-allocation-filtering.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/recovery-prioritization.html

--- a/deploy-manage/index.md
+++ b/deploy-manage/index.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/setup.html
   - https://www.elastic.co/guide/en/cloud/current/ec-faq-technical.html
   - https://www.elastic.co/guide/en/elastic-stack/current/index.html
@@ -9,7 +9,7 @@ mapped_urls:
 
 # Deploy and manage
 
-To get started with Elastic, you need to choose a deployment method and deploy {{stack}} components. 
+To get started with Elastic, you need to choose a deployment method and deploy {{stack}} components.
 
 In this section, you'll learn about how to deploy and manage all aspects of your Elastic environment. You'll learn how to design resilient, highly available clusters and deployments, and how to maintain and scale your environment to grow with your use case.
 
@@ -23,9 +23,9 @@ To get started quickly, you can set up a [local development and testing environm
 
 Learn how to design and deploy a production-ready Elastic environment.
 
-* [](/deploy-manage/deploy.md): Understand your deployment options and choose the approach that best fits your needs. 
-  
-  If you already know how you want to deploy, you can jump to the documentation for your preferred deployment method: 
+* [](/deploy-manage/deploy.md): Understand your deployment options and choose the approach that best fits your needs.
+
+  If you already know how you want to deploy, you can jump to the documentation for your preferred deployment method:
   * [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md)
   * [{{ech}}](/deploy-manage/deploy/elastic-cloud/cloud-hosted.md)
   * [{{ece}}](/deploy-manage/deploy/cloud-enterprise.md)

--- a/deploy-manage/kibana-reporting-configuration.md
+++ b/deploy-manage/kibana-reporting-configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configure Kibana reporting
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/secure-reporting.html
 applies_to:
   deployment:

--- a/deploy-manage/maintenance/start-stop-routing-requests.md
+++ b/deploy-manage/maintenance/start-stop-routing-requests.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-maintenance-mode-routing.html
   - https://www.elastic.co/guide/en/cloud/current/ec-maintenance-mode-routing.html
 applies_to:

--- a/deploy-manage/maintenance/start-stop-services/restart-cloud-hosted-deployment.md
+++ b/deploy-manage/maintenance/start-stop-services/restart-cloud-hosted-deployment.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-restart-deployment.html
   - https://www.elastic.co/guide/en/cloud/current/ec-api-deployment-other.html
 applies_to:

--- a/deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
+++ b/deploy-manage/maintenance/start-stop-services/start-stop-elasticsearch.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/starting-elasticsearch.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/stopping-elasticsearch.html
 applies_to:
@@ -89,15 +89,15 @@ During the life of the {{es}} virtual machine, certain fatal errors could arise 
 
 When {{es}} detects that the virtual machine has encountered such a fatal error {{es}} will attempt to log the error and then will halt the virtual machine. When {{es}} initiates such a shutdown, it does not go through an orderly shutdown as described above. The {{es}} process will also return with a special status code indicating the nature of the error.
 
-| Status code | Error | 
+| Status code | Error |
 | --- | --- |
-| 1   | Unknown fatal error | 
-| 78  | Bootstrap check failure | 
+| 1   | Unknown fatal error |
+| 78  | Bootstrap check failure |
 | 124 | Serious I/O error |
 | 125 | Unknown virtual machine error |
-| 126 | Stack overflow error |  
-| 127 | Out of memory error | 
-| 128 | JVM internal error | 
+| 126 | Stack overflow error |
+| 127 | Out of memory error |
+| 128 | JVM internal error |
 | 134 | Segmentation fault |
 | 137 | Slain by kernel oom-killer |
 | 143 | User or kernel SIGTERM |

--- a/deploy-manage/manage-connectors.md
+++ b/deploy-manage/manage-connectors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/action-types.html
   - https://www.elastic.co/guide/en/serverless/current/action-connectors.html
 applies_to:

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/xpack-spaces.html
   - https://www.elastic.co/guide/en/serverless/current/spaces.html
 ---

--- a/deploy-manage/monitor.md
+++ b/deploy-manage/monitor.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html
   - https://www.elastic.co/guide/en/cloud/current/ec-monitoring.html
 applies_to:
@@ -56,7 +56,7 @@ deployment:
   ess:
 ```
 
-{{ece}} and {{ech}} provide out of the box tools for monitoring the health of your deployment and resolving health issues when they arise: 
+{{ece}} and {{ech}} provide out of the box tools for monitoring the health of your deployment and resolving health issues when they arise:
 
 * [Cluster health information](/deploy-manage/monitor/cloud-health-perf.md#ec-es-cluster-health), including [health warnings](/deploy-manage/monitor/cloud-health-perf.md#ec-es-health-warnings)
 * A [JVM memory pressure indicator](/deploy-manage/monitor/ec-memory-pressure.md)

--- a/deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md
+++ b/deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-saas-metrics-accessing.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-saas-metrics-accessing.html
 applies_to:
@@ -15,7 +15,7 @@ For advanced views or production monitoring, [enable logging and monitoring](/de
 
 :::{tip}
 For {{ece}} deployments, you can use [platform monitoring](/deploy-manage/monitor/orchestrators/ece-platform-monitoring.md) to access preconfigured performance metrics.
-::: 
+:::
 
 To access cluster performance metrics:
 

--- a/deploy-manage/monitor/cloud-health-perf.md
+++ b/deploy-manage/monitor/cloud-health-perf.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/monitor-elasticsearch-cluster.html
 navigation_title: "Cloud deployment health"
 applies_to:
@@ -37,7 +37,7 @@ The **Health** page provides the following information:
 
 * **Severity**: A critical issue impacts operations such as search and ingest and should be addressed as soon as possible. Warnings don’t impact the cluster immediately but might lead to more critical issues over time such as a corrupted repository might lead to no backups being available in the future. |
 * **Description**: For most issues, you can click the description to get more details page on the specific issue and on how to fix it.
-* **Affected capabilities**: Each of these areas might impact search, ingest, backups, or deployment management capabilities. 
+* **Affected capabilities**: Each of these areas might impact search, ingest, backups, or deployment management capabilities.
 
 You can also search and filter the table based on affected resources, such as indices, repositories, nodes, or SLM policies. Individual issues can be further expanded to get more details and guided troubleshooting.
 
@@ -74,9 +74,9 @@ deployment:
   ess:
 ```
 
-{{ech}} deployments offer an additional **Performance** page to get further information about your cluster performance. 
+{{ech}} deployments offer an additional **Performance** page to get further information about your cluster performance.
 
-If you observe issues on search and ingest operations in terms of increased latency or throughput for queries, these might not be directly reported on the **Health** page, unless they are related to shard health or master node availability. 
+If you observe issues on search and ingest operations in terms of increased latency or throughput for queries, these might not be directly reported on the **Health** page, unless they are related to shard health or master node availability.
 
 The **Performance** page and the out-of-the-box logs allow you to monitor your cluster performance, but for production applications we strongly recommend setting up a dedicated monitoring cluster. Refer to [Understanding deployment health](#ec-health-best-practices), for more guidelines on how to monitor you cluster performance.
 
@@ -84,7 +84,7 @@ The **Performance** page and the out-of-the-box logs allow you to monitor your c
 
 :::{tip}
 For {{ece}} deployments, you can use [platform monitoring](/deploy-manage/monitor/orchestrators/ece-platform-monitoring.md) to access preconfigured performance metrics.
-::: 
+:::
 
 ## JVM memory pressure indicator
 

--- a/deploy-manage/monitor/stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/monitoring-overview.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/how-monitoring-works.html
 applies_to:

--- a/deploy-manage/monitor/stack-monitoring/elasticsearch-monitoring-self-managed.md
+++ b/deploy-manage/monitor/stack-monitoring/elasticsearch-monitoring-self-managed.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Self-managed: {{es}}"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/monitoring-production.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-monitoring.html
 applies_to:
@@ -18,7 +18,7 @@ To use the {{monitor-features}} with the {{security-features}} enabled, you need
 
 ## Collection methods
 
-You can collect monitoring and logging data in the following ways: 
+You can collect monitoring and logging data in the following ways:
 
 * [Collect monitoring data with Elastic Agent](/deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-elastic-agent.md) (recommended)
 * [Collect monitoring data with Metricbeat](/deploy-manage/monitor/stack-monitoring/collecting-monitoring-data-with-metricbeat.md)
@@ -26,7 +26,7 @@ You can collect monitoring and logging data in the following ways:
 
 If you're building a production environment, then you should send monitoring data to a separate monitoring cluster so that historical data is available even when the nodes you are monitoring are not. To learn how to store monitoring data in a separate cluster, refer to [](/deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md).
 
-### Legacy collection methods 
+### Legacy collection methods
 
 You can also monitor your stack using legacy {{es}} monitoring features. This method is deprecated and should not be used. To learn more, refer to [](/deploy-manage/monitor/stack-monitoring/es-legacy-collection-methods.md).
 

--- a/deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md
+++ b/deploy-manage/monitor/stack-monitoring/es-self-monitoring-prod.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/monitoring-production.html
 applies_to:
   deployment:

--- a/deploy-manage/security.md
+++ b/deploy-manage/security.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment: all
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/security-files.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html
   - https://www.elastic.co/guide/en/kibana/current/xpack-security.html
@@ -32,7 +32,7 @@ deployment:
 serverless: all
 ```
 
-{{ecloud}} has built-in security. For example, HTTPS communications between {{ecloud}} and the internet, as well as inter-node communications, are secured automatically, and cluster data is encrypted at rest. 
+{{ecloud}} has built-in security. For example, HTTPS communications between {{ecloud}} and the internet, as well as inter-node communications, are secured automatically, and cluster data is encrypted at rest.
 
 In {{ech}}, you can augment these Security features in the following ways:
 * Configure [traffic filtering](/deploy-manage/security/traffic-filtering.md) to prevent unauthorized access to your deployments.
@@ -86,7 +86,7 @@ You can configure the following aspects of your Elastic cluster or deployment to
 
 :::{include} /deploy-manage/security/_snippets/cluster-data.md
 :::
- 
+
 ### User session security
 
 :::{include} /deploy-manage/security/_snippets/cluster-user-session.md
@@ -110,7 +110,7 @@ You can configure the following aspects of your Elastic cluster or deployment to
 
 The {{es}} security features enable you to secure your {{es}} cluster. However, for a complete security strategy, you must secure other applications in the {{stack}}, as well as communications between {{es}} and other {{stack}} components.
 
-[Review security topics for other {{stack}} components](/deploy-manage/security/secure-clients-integrations.md). 
+[Review security topics for other {{stack}} components](/deploy-manage/security/secure-clients-integrations.md).
 
 ## Securing clients and integrations
 

--- a/deploy-manage/security/aws-privatelink-traffic-filters.md
+++ b/deploy-manage/security/aws-privatelink-traffic-filters.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-vpc.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-traffic-filtering-vpc.html
 ---
@@ -22,13 +22,13 @@ Read more about [Traffic Filtering](/deploy-manage/security/traffic-filtering.md
 
 ## Considerations
 
-Before you begin, review  the following considerations: 
+Before you begin, review  the following considerations:
 
 ### PrivateLink filtering and regions
 
-AWS PrivateLink filtering is supported only for AWS regions. Elastic does not yet support cross-region AWS PrivateLink connections. Your PrivateLink endpoint needs to be in the same region as your target deployments. Additional details can be found in the [AWS VPCE Documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#vpce-interface-limitations). 
+AWS PrivateLink filtering is supported only for AWS regions. Elastic does not yet support cross-region AWS PrivateLink connections. Your PrivateLink endpoint needs to be in the same region as your target deployments. Additional details can be found in the [AWS VPCE Documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#vpce-interface-limitations).
 
-AWS interface VPC endpoints get created in availability zones (AZ). In some regions, our VPC endpoint *service* is not present in all the possible AZs that a region offers. You can only choose AZs that are common on both sides. As the *names* of AZs (for example `us-east-1a`) differ between AWS accounts, the following list of AWS regions shows the *ID* (e.g. `use1-az4`) of each available AZ for the service. 
+AWS interface VPC endpoints get created in availability zones (AZ). In some regions, our VPC endpoint *service* is not present in all the possible AZs that a region offers. You can only choose AZs that are common on both sides. As the *names* of AZs (for example `us-east-1a`) differ between AWS accounts, the following list of AWS regions shows the *ID* (e.g. `use1-az4`) of each available AZ for the service.
 
 Check [interface endpoint availability zone considerations](https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#vpce-interface-availability-zones) for more details.
 
@@ -153,11 +153,11 @@ The mapping will be different for your region. Our production VPC Service for `u
 3. Test the connection.
 
     Find out the endpoint of your deployment. You can do that by selecting **Copy endpoint** in the Cloud UI. It looks something like:
-    
+
     ```
     my-deployment-d53192.es.us-east-1.aws.found.io
     ```
-    
+
     where `my-deployment-d53192` is an alias, and `es` is the product you want to access within your deployment.
 
     To access your {{es}} cluster over PrivateLink:

--- a/deploy-manage/security/azure-private-link-traffic-filters.md
+++ b/deploy-manage/security/azure-private-link-traffic-filters.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-vnet.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-traffic-filtering-vnet.html
 ---
@@ -182,7 +182,7 @@ Let’s test the connection:
         ```
 
 3. You can test the Azure portal part of the setup with the following command (substitute the region and {{es}} ID with your cluster):
-   
+
     ```sh
     $ curl -v https://6b111580caaa4a9e84b18ec7c600155e.privatelink.eastus2.azure.elastic-cloud.com:9243
     ```

--- a/deploy-manage/security/ec-traffic-filtering-through-the-api.md
+++ b/deploy-manage/security/ec-traffic-filtering-through-the-api.md
@@ -1,9 +1,9 @@
 ---
 applies_to:
   deployment:
-    ess: 
+    ess:
     ece:
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-through-the-api.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-traffic-filtering-through-the-api.html
 ---
@@ -28,20 +28,20 @@ This example demonstrates how to use the {{ecloud}} RESTful API or {{ece}} RESTf
 
 Refer to [](traffic-filtering.md) to learn about the general concepts behind filtering access to your {{ech}} and {{ece}} deployments.
 
-To learn more about these endpoints, refer to the reference for your deployment type: 
+To learn more about these endpoints, refer to the reference for your deployment type:
 
 * [{{ecloud}} API](https://www.elastic.co/docs/api/doc/cloud/group/endpoint-deploymentstrafficfilter)
 * [{{ece}} API](https://www.elastic.co/docs/api/doc/cloud-enterprise/group/endpoint-deploymentstrafficfilter)
 
 
-## Create a traffic filter rule set [ec-create-a-traffic-filter-rule-set] 
+## Create a traffic filter rule set [ec-create-a-traffic-filter-rule-set]
 
 
-### IP traffic filter ingress rule set [ec-ip-traffic-filters-ingress-rule-set] 
+### IP traffic filter ingress rule set [ec-ip-traffic-filters-ingress-rule-set]
 ```{applies_to}
 deployment:
-  ess: 
-  ece: 
+  ess:
+  ece:
 ```
 
 Send a request like the following to create an IP traffic filter ingress rule set:
@@ -124,7 +124,7 @@ If the request is successful, a response containing a $RULESET_ID is returned. $
 ```
 
 
-### IP traffic filter egress rule set [ec-ip-traffic-filters-egress-rule-set] 
+### IP traffic filter egress rule set [ec-ip-traffic-filters-egress-rule-set]
 ```{applies_to}
 deployment:
   ess: beta
@@ -170,7 +170,7 @@ https://api.elastic-cloud.com/api/v1/deployments/traffic-filter/rulesets \
 :   This can be `udp`, `tcp`, or `all`.
 
 
-### AWS Privatelink traffic filters [ec-aws-privatelink-traffic-filters-rule-set] 
+### AWS Privatelink traffic filters [ec-aws-privatelink-traffic-filters-rule-set]
 ```{applies_to}
 deployment:
   ess:
@@ -202,7 +202,7 @@ https://api.elastic-cloud.com/api/v1/deployments/traffic-filter/rulesets \
 To find the value for `source` for type `vpce`, check [Find your VPC endpoint ID](aws-privatelink-traffic-filters.md#ec-find-your-endpoint). This setting is supported only in AWS regions.
 
 
-### Azure Private Link traffic filters [ec-azure-privatelink-traffic-filters-rule-set] 
+### Azure Private Link traffic filters [ec-azure-privatelink-traffic-filters-rule-set]
 ```{applies_to}
 deployment:
   ess:
@@ -267,11 +267,11 @@ https://api.elastic-cloud.com/api/v1/deployments/traffic-filter/rulesets \
 To find the value for `source` for type `gcp_private_service_connect_endpoint`, check [Find your Private Service Connect connection ID](gcp-private-service-connect-traffic-filters.md#ec-find-your-psc-connection-id). This setting is supported only in GCP regions.
 
 
-## Update a traffic filter rule set [ec-update-a-traffic-filter-rule-set] 
+## Update a traffic filter rule set [ec-update-a-traffic-filter-rule-set]
 ```{applies_to}
 deployment:
-  ess: 
-  ece: 
+  ess:
+  ece:
 ```
 
 Send a request like the following to update an IP traffic filter ingress rule set:
@@ -339,11 +339,11 @@ https://$COORDINATOR_HOST:12443/api/v1/deployments/traffic-filter/rulesets/$RULE
 ::::
 
 
-## Associate a rule set with a deployment [ec-associate-rule-set-with-a-deployment] 
+## Associate a rule set with a deployment [ec-associate-rule-set-with-a-deployment]
 ```{applies_to}
 deployment:
-  ess: 
-  ece: 
+  ess:
+  ece:
 ```
 
 Send a request like the following to associate a rule set with a deployment:
@@ -385,11 +385,11 @@ https://$COORDINATOR_HOST:12443/api/v1/deployments/traffic-filter/rulesets/$RULE
 ::::
 
 
-## Delete a rule set association with a deployment [ec-delete-rule-set-association-with-a-deployment] 
+## Delete a rule set association with a deployment [ec-delete-rule-set-association-with-a-deployment]
 ```{applies_to}
 deployment:
-  ess: 
-  ece: 
+  ess:
+  ece:
 ```
 
 Send a request like the following to delete a rule set association with a deployment:
@@ -421,11 +421,11 @@ https://$COORDINATOR_HOST:12443/api/v1/deployments/traffic-filter/rulesets/$RULE
 ::::
 
 
-## Delete a traffic filter rule set [ec-delete-a-rule-set] 
+## Delete a traffic filter rule set [ec-delete-a-rule-set]
 ```{applies_to}
 deployment:
-  ess: 
-  ece: 
+  ess:
+  ece:
 ```
 
 Send a request like the following to delete a traffic filter rule set:

--- a/deploy-manage/security/fips-140-2.md
+++ b/deploy-manage/security/fips-140-2.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     self: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/fips-140-compliance.html
   - https://www.elastic.co/guide/en/kibana/current/xpack-security-fips-140-2.html
 ---
@@ -29,8 +29,8 @@ $$$keystore-fips-password$$$
 
 $$$verify-security-provider$$$
 
-The Federal Information Processing Standard (FIPS) Publication 140-2, (FIPS PUB 140-2), titled "Security Requirements for Cryptographic Modules" is a U.S. government computer security standard used to approve cryptographic modules. 
-- [{{es}}](#fips-elasticsearch) offers a FIPS 140-2 compliant mode and as such can run in a FIPS 140-2 configured JVM. 
+The Federal Information Processing Standard (FIPS) Publication 140-2, (FIPS PUB 140-2), titled "Security Requirements for Cryptographic Modules" is a U.S. government computer security standard used to approve cryptographic modules.
+- [{{es}}](#fips-elasticsearch) offers a FIPS 140-2 compliant mode and as such can run in a FIPS 140-2 configured JVM.
 - [{{kib}}](#fips-kibana) offers a FIPS 140-2 compliant mode and as such can run in a Node.js environment configured with a FIPS 140-2 compliant OpenSSL3 provider.
 
 :::{note}
@@ -197,11 +197,11 @@ Due to the limitations that FIPS 140-2 compliance enforces, a small number of fe
 
 
 
-## {{kib}} [fips-kibana] 
+## {{kib}} [fips-kibana]
 
 To run {{kib}} in FIPS mode, you must have the appropriate [subscription](https://www.elastic.co/subscriptions).
 
-::::{important} 
+::::{important}
 The Node bundled with {{kib}} is not configured for FIPS 140-2. You must configure a FIPS 140-2 compliant OpenSSL3 provider. Consult the Node.js documentation to learn how to configure your environment.
 
 ::::

--- a/deploy-manage/security/gcp-private-service-connect-traffic-filters.md
+++ b/deploy-manage/security/gcp-private-service-connect-traffic-filters.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     ess: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-psc.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-traffic-filtering-psc.html
 ---

--- a/deploy-manage/security/install-stack-demo-secure.md
+++ b/deploy-manage/security/install-stack-demo-secure.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     self: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elastic-stack/current/install-stack-demo-secure.html
 ---
 

--- a/deploy-manage/security/ip-filtering-basic.md
+++ b/deploy-manage/security/ip-filtering-basic.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ip-filtering.html
 applies_to:
   deployment:

--- a/deploy-manage/security/secure-cluster-communications.md
+++ b/deploy-manage/security/secure-cluster-communications.md
@@ -1,11 +1,11 @@
 ---
-navigation_title: Manage TLS certificates 
+navigation_title: Manage TLS certificates
 applies_to:
   deployment:
     self:
     eck:
     ece:
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-security.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup.html
   - https://www.elastic.co/guide/en/kibana/current/elasticsearch-mutual-tls.html

--- a/deploy-manage/security/secure-http-communications.md
+++ b/deploy-manage/security/secure-http-communications.md
@@ -4,7 +4,7 @@ applies_to:
     eck:
     ece:
     self:
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/security-basic-setup-https.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-tls-certificates.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-custom-http-certificate.html
@@ -55,7 +55,7 @@ For self-managed deployments, you need to generate and configure certificates fo
 
 ### Prerequisites
 
-Complete all steps in: 
+Complete all steps in:
 
 - [Set up basic security](/deploy-manage/security/set-up-basic-security.md)
 - [](/deploy-manage/security/set-up-basic-security-plus-https.md)
@@ -381,7 +381,7 @@ Create a Kubernetes secret with:
 * `tls.crt`: The certificate.
 * `tls.key`: The private key to the first certificate in the certificate chain.
 
-::::{warning} 
+::::{warning}
 If your `tls.crt` is signed by an intermediate CA you may need both the Root CA and the intermediate CA combined within the `ca.crt` file depending on whether the Root CA is globally trusted.
 ::::
 

--- a/deploy-manage/security/secure-settings.md
+++ b/deploy-manage/security/secure-settings.md
@@ -5,7 +5,7 @@ applies_to:
     ece: ga
     eck: ga
     self: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configuring-keystore.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restful-api-examples-configuring-keystore.html
   - https://www.elastic.co/guide/en/cloud/current/ec-configuring-keystore.html
@@ -31,7 +31,7 @@ Some settings are sensitive, and relying on filesystem permissions to protect th
 - [Kubernetes secrets](k8s-secure-settings.md), if you are using {{eck}}.
 
 
-:::{important} 
+:::{important}
 Only some settings are designed to be read from the keystore. However, the keystore has no validation to block unsupported settings. Adding unsupported settings to the keystore causes [reload_secure_settings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-reload-secure-settings) to fail and if not addressed, {{es}} will fail to start. To check whether a setting is supported in the keystore, look for a "Secure" qualifier in the [setting reference](/reference/index.md).
 :::
 
@@ -207,7 +207,7 @@ curl -k -X PATCH -H "Authorization: ApiKey $ECE_API_KEY" https://$COORDINATOR_HO
 ```
 
 
-**Verify your credentials** 
+**Verify your credentials**
 
 If your credentials are invalid, an administrator can verify that they are correct by checking the `keystore` field in the cluster metadata.
 
@@ -273,13 +273,13 @@ deployment:
 
 Some settings are sensitive, and relying on filesystem permissions to protect their values is not sufficient. For this use case, {{kib}} provides a keystore, and the `kibana-keystore` tool to manage the settings in the keystore.
 
-::::{note} 
+::::{note}
 * Run all commands as the user who runs {{kib}}.
 * Any valid {{kib}} setting can be stored in the keystore securely. Unsupported, extraneous or invalid settings will cause {{kib}} to fail to start up.
 
 ::::
 
-### Create the keystore [creating-keystore] 
+### Create the keystore [creating-keystore]
 
 To create the `kibana.keystore`, use the `create` command:
 
@@ -292,7 +292,7 @@ The file `kibana.keystore` will be created in the `config` directory defined by 
 To create a password protected keystore use the `--password` flag.
 
 
-### List settings in the keystore [list-settings] 
+### List settings in the keystore [list-settings]
 
 A list of the settings in the keystore is available with the `list` command:
 
@@ -301,9 +301,9 @@ bin/kibana-keystore list
 ```
 
 
-### Add string settings [add-string-to-keystore] 
+### Add string settings [add-string-to-keystore]
 
-::::{note} 
+::::{note}
 Your input will be JSON-parsed to allow for object/array input configurations. To enforce string values, use "double quotes" around your input.
 ::::
 
@@ -329,7 +329,7 @@ cat /file/containing/setting/value | bin/kibana-keystore add the.setting.name.to
 ```
 
 
-### Remove settings [remove-settings] 
+### Remove settings [remove-settings]
 
 To remove a setting from the keystore, use the `remove` command:
 
@@ -338,7 +338,7 @@ bin/kibana-keystore remove the.setting.name.to.remove
 ```
 
 
-### Read settings [read-settings] 
+### Read settings [read-settings]
 
 To display the configured setting values, use the `show` command:
 
@@ -347,7 +347,7 @@ bin/kibana-keystore show setting.key
 ```
 
 
-### Change password [change-password] 
+### Change password [change-password]
 
 To change the password of the keystore, use the `passwd` command:
 
@@ -355,7 +355,7 @@ To change the password of the keystore, use the `passwd` command:
 bin/kibana-keystore passwd
 ```
 
-### Has password [has-password] 
+### Has password [has-password]
 
 To check if the keystore is password protected, use the `has-passwd` command. An exit code of 0 will be returned if the keystore is password protected, and the command will fail otherwise.
 

--- a/deploy-manage/security/traffic-filtering.md
+++ b/deploy-manage/security/traffic-filtering.md
@@ -1,13 +1,13 @@
 ---
 navigation_title: Traffic filtering
 applies_to:
-  deployment: 
+  deployment:
     ess: ga
     ece: ga
     eck: ga
     self: ga
   serverless: unavailable
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-traffic-filtering-deployment-configuration.html
   - https://www.elastic.co/guide/en/cloud/current/ec-traffic-filtering-deployment-configuration.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-traffic-filtering-deployment-configuration.html
@@ -27,11 +27,11 @@ This section covers traffic filtering at the deployment level. If you need the I
 You can also allow traffic to or from a [remote cluster](/deploy-manage/remote-clusters.md) for use with cross-cluster replication or search.
 ::::
 
-| Filter type | Description | Applicable deployment types | 
-| --- | --- | --- | 
-| [IP traffic filters](ip-traffic-filtering.md) | Filter traffic using IP addresses and Classless Inter-Domain Routing (CIDR) masks.<br><br>• [In ECH or ECE](/deploy-manage/security/ip-filtering-cloud.md)<br><br>• [In ECK or self-managed](/deploy-manage/security/ip-filtering-basic.md) | ECH, ECE, ECK, and self-managed clusters | 
+| Filter type | Description | Applicable deployment types |
+| --- | --- | --- |
+| [IP traffic filters](ip-traffic-filtering.md) | Filter traffic using IP addresses and Classless Inter-Domain Routing (CIDR) masks.<br><br>• [In ECH or ECE](/deploy-manage/security/ip-filtering-cloud.md)<br><br>• [In ECK or self-managed](/deploy-manage/security/ip-filtering-basic.md) | ECH, ECE, ECK, and self-managed clusters |
 | [Private link filters](/deploy-manage/security/private-link-traffic-filters.md) | Allow traffic between {{es}} and other resources hosted by the same cloud provider using private link services. Choose the relevant option for your region:<br><br>• AWS regions: [AWS PrivateLink](/deploy-manage/security/aws-privatelink-traffic-filters.md)<br><br>• Azure regions: [Azure Private Link](/deploy-manage/security/azure-private-link-traffic-filters.md)<br><br>• GCP regions: [GCP Private Service Connect](/deploy-manage/security/gcp-private-service-connect-traffic-filters.md) | {{ech}} only |
-| [Kubernetes network policies](/deploy-manage/security/k8s-network-policies.md) | Isolate pods by restricting incoming and outgoing network connections to a trusted set of sources and destinations. | {{eck}} only | 
+| [Kubernetes network policies](/deploy-manage/security/k8s-network-policies.md) | Isolate pods by restricting incoming and outgoing network connections to a trusted set of sources and destinations. | {{eck}} only |
 
 :::{include} _snippets/eck-traffic-filtering.md
 :::
@@ -39,16 +39,16 @@ You can also allow traffic to or from a [remote cluster](/deploy-manage/remote-c
 
 ## Traffic filter rules in ECE and ECH [traffic-filter-rules]
 ```{applies_to}
-  deployment: 
+  deployment:
     ess:
     ece:
 ```
 
 % could be refined further
 
-By default, in {{ece}} and {{ech}}, all your deployments are accessible over the public internet. In {{ece}}, this assumes that your orchestrator's proxies are accessible. 
+By default, in {{ece}} and {{ech}}, all your deployments are accessible over the public internet. In {{ece}}, this assumes that your orchestrator's proxies are accessible.
 
-Filtering *rules* are grouped into *rule sets*, which in turn are *associated* with one or more deployments to take effect. After you associate at least one traffic filter with a deployment, traffic that does not match any filtering rules for the deployment is denied. 
+Filtering *rules* are grouped into *rule sets*, which in turn are *associated* with one or more deployments to take effect. After you associate at least one traffic filter with a deployment, traffic that does not match any filtering rules for the deployment is denied.
 
 Traffic filters apply to external traffic only. Internal traffic is managed by ECE or ECH. For example, {{kib}} can connect to {{es}}, as well as internal services which manage the deployment. Other deployments can’t connect to deployments protected by traffic filters.
 
@@ -65,9 +65,9 @@ Rule sets work as follows:
 - Any traffic filter rule set assigned to a deployment overrides the default behavior of *allow all access over the public internet endpoint; deny all access over Private Link*. The implication is that if you make a mistake putting in the traffic source (for example, specified the wrong IP address) the deployment will be effectively locked down to any of your traffic. You can use the UI to adjust or remove the rule sets.
 
 :::{admonition} Rule limits
-In {{ech}}, you can have a maximum of 1024 rule sets per organization and 128 rules in each rule set. 
+In {{ech}}, you can have a maximum of 1024 rule sets per organization and 128 rules in each rule set.
 
-In {{ece}}, you can have a maximum of 512 rule sets per organization and 128 rules in each rule set. 
+In {{ece}}, you can have a maximum of 512 rule sets per organization and 128 rules in each rule set.
 :::
 
 ### Tips
@@ -88,7 +88,7 @@ On this page, you can view and remove existing filters and attach new filters.
 To identify which rule sets are automatically applied to new deployments in your account:
 
 1. Navigate to the traffic filters list:
-  
+
     ::::{tab-set}
     :group: ech-ece
 

--- a/deploy-manage/security/using-kibana-with-security.md
+++ b/deploy-manage/security/using-kibana-with-security.md
@@ -2,7 +2,7 @@
 applies_to:
   deployment:
     self: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/using-kibana-with-security.html
 ---
 

--- a/deploy-manage/tools/snapshot-and-restore.md
+++ b/deploy-manage/tools/snapshot-and-restore.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html
   - https://www.elastic.co/guide/en/cloud/current/ec-snapshot-restore.html
   - https://www.elastic.co/guide/en/cloud/current/ec-restoring-snapshots.html

--- a/deploy-manage/tools/snapshot-and-restore/access-isolation-for-found-snapshots-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/access-isolation-for-found-snapshots-repository.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-snapshot-repository-migration.html
 applies_to:
   deployment:
-    ess: 
+    ess:
 ---
 
 # Access isolation for the found-snapshots repository [ec-snapshot-repository-migration]

--- a/deploy-manage/tools/snapshot-and-restore/azure-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/azure-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-azure.html
 applies_to:
   deployment:

--- a/deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configure-azure-snapshotting.html
 applies_to:
   deployment:
-    ece: 
+    ece:
 ---
 
 # Azure Storage repository [ece-configure-azure-snapshotting]

--- a/deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md
+++ b/deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-repositories.html
 navigation_title: "Elastic Cloud Enterprise"
 applies_to:
   deployment:
-    ece: 
+    ece:
 ---
 
 # Manage snapshot repositories in Elastic Cloud Enterprise [ece-manage-repositories]
@@ -42,7 +42,7 @@ If you are installing ECE without internet access (commonly called an offline or
 
 The following guides provide instructions on adding a snapshot repository in ECE for all supported types:
 
-* [AWS S3](/deploy-manage/tools/snapshot-and-restore/ece-aws-custom-repository.md) 
+* [AWS S3](/deploy-manage/tools/snapshot-and-restore/ece-aws-custom-repository.md)
 * [Azure](/deploy-manage/tools/snapshot-and-restore/azure-storage-repository.md)
 * [Google Cloud Storage](/deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md)
 * [Minio](/deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md)

--- a/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+++ b/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-snapshots.html
 navigation_title: "Elastic Cloud on Kubernetes"
 applies_to:
   deployment:
-    eck: 
+    eck:
 ---
 
 # Manage snapshot repositories in Elastic Cloud on Kubernetes [k8s-snapshots]

--- a/deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-aws-custom-repository.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-custom-repository.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-aws-custom-repository.html

--- a/deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
+++ b/deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-azure-snapshotting.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-azure-snapshotting.html
 applies_to:
   deployment:
-    ess: 
+    ess:
 ---
 
 # Configure a snapshot repository using Azure Blob storage [ec-azure-snapshotting]

--- a/deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
+++ b/deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-gcs-snapshotting.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-gcs-snapshotting.html
 applies_to:
   deployment:
-    ess: 
+    ess:
 ---
 
 # Configure a snapshot repository using GCS [ec-gcs-snapshotting]

--- a/deploy-manage/tools/snapshot-and-restore/ece-restore-across-clusters.md
+++ b/deploy-manage/tools/snapshot-and-restore/ece-restore-across-clusters.md
@@ -1,18 +1,18 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-restore-across-clusters.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restore-across-clusters.html
 applies_to:
   deployment:
-    ess: 
-    ece: 
+    ess:
+    ece:
 ---
 
 # Restore a snapshot across clusters [ece-restore-across-clusters]
 
 Snapshots can be restored to either the same Elasticsearch cluster or to another cluster. If you are restoring all indices to another cluster, you can [clone](/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md) a cluster.
 
-::::{note} 
+::::{note}
 Users created using the X-Pack security features or using Shield are not included when you restore across clusters, only data from Elasticsearch indices is restored. If you do want to create a cloned cluster with the same users as your old cluster, you need to recreate the users manually on the new cluster.
 ::::
 
@@ -49,6 +49,6 @@ To restore built-in snapshots across clusters, there are two options:
 
 When restoring snapshots across clusters on {{ech}} or {{ece}}, the platform creates a new repository called `\_clone_{{clusterIdPrefix}}`, which persists until manually deleted. If the repository is still in use, for example by mounted searchable snapshots, it can’t be removed.
 
-::::{warning} 
+::::{warning}
 When restoring from a deployment that’s using searchable snapshots, refer to [Restore snapshots containing searchable snapshots indices across clusters](ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md).
 ::::

--- a/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md
+++ b/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.md
@@ -1,11 +1,11 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters.html
 applies_to:
   deployment:
-    ess: 
-    ece: 
+    ess:
+    ece:
 ---
 
 # Restore snapshots containing searchable snapshots indices across clusters [ece-restore-snapshots-containing-searchable-snapshots-indices-across-clusters]

--- a/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-existing-deployment.md
+++ b/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-existing-deployment.md
@@ -1,11 +1,11 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-restore-snapshots-into-existing-deployment.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restore-snapshots-into-existing-deployment.html
 applies_to:
   deployment:
-    ess: 
-    ece: 
+    ess:
+    ece:
 ---
 
 # Restore snapshot into an existing deployment [ece-restore-snapshots-into-existing-deployment]

--- a/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
+++ b/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
@@ -1,11 +1,11 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-restore-snapshots-into-new-deployment.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-restore-snapshots-into-new-deployment.html
 applies_to:
   deployment:
-    ess: 
-    ece: 
+    ess:
+    ece:
 ---
 
 # Restore snapshot into a new deployment [ece-restore-snapshots-into-new-deployment]

--- a/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
+++ b/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
@@ -1,11 +1,11 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-custom-repository.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-custom-repository.html
 navigation_title: "Elastic Cloud Hosted"
 applies_to:
   deployment:
-    ess: 
+    ess:
 ---
 
 # Manage snapshot repositories in Elastic Cloud Hosted
@@ -55,7 +55,7 @@ The `found-snapshots` repository is specific to each deployment. However, you ca
 
 ## Register a snapshot repository in Elastic Cloud Hosted [register-snapshot-repos-ech]
 
-In **Elastic Cloud Hosted**, snapshot repositories are automatically registered for you, but you can create additional repositories if needed.  
+In **Elastic Cloud Hosted**, snapshot repositories are automatically registered for you, but you can create additional repositories if needed.
 
 * {{kib}}'s **Snapshot and Restore** feature
 * {{es}}'s [snapshot repository management APIs](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-snapshot)

--- a/deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/google-cloud-storage-gcs-repository.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configure-gcp-snapshotting.html
 applies_to:
   deployment:
-    ece: 
+    ece:
 ---
 
 # Google Cloud Storage (GCS) repository [ece-configure-gcp-snapshotting]

--- a/deploy-manage/tools/snapshot-and-restore/google-cloud-storage-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/google-cloud-storage-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-gcs.html
 applies_to:
   deployment:

--- a/deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/minio-on-premise-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-configuring-minio.html
 applies_to:
   deployment:

--- a/deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-read-only-repository.html
 applies_to:
   deployment:

--- a/deploy-manage/tools/snapshot-and-restore/repository-isolation-on-aws-gcp.md
+++ b/deploy-manage/tools/snapshot-and-restore/repository-isolation-on-aws-gcp.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-snapshot-repository-aws-gcp-migration.html
 applies_to:
   deployment:
-    ess: 
+    ess:
 ---
 
 # Repository isolation on AWS and GCP [ec-snapshot-repository-aws-gcp-migration]

--- a/deploy-manage/tools/snapshot-and-restore/s3-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/s3-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-s3.html
 applies_to:
   deployment:

--- a/deploy-manage/tools/snapshot-and-restore/self-managed.md
+++ b/deploy-manage/tools/snapshot-and-restore/self-managed.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-register-repository.html
 navigation_title: "Self-managed"
 applies_to:

--- a/deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-filesystem-repository.html
 applies_to:
   deployment:

--- a/deploy-manage/tools/snapshot-and-restore/source-only-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/source-only-repository.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-source-only-repository.html
 applies_to:
   deployment:

--- a/deploy-manage/uninstall/delete-a-cloud-deployment.md
+++ b/deploy-manage/uninstall/delete-a-cloud-deployment.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-delete-deployment.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-delete-deployment.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-terminate-deployment.html
@@ -10,7 +10,7 @@ navigation_title: "Delete a cloud deployment"
 applies_to:
   deployment:
     ess:
-    ece: 
+    ece:
   serverless:
 ---
 
@@ -20,7 +20,7 @@ This page provides instructions for deleting several types of cloud deployments,
 
 ## {{ech}} [elastic-cloud-hosted]
 
-To delete an {{ech}} deployment: 
+To delete an {{ech}} deployment:
 
 1. Log in to the [{{ecloud}} Console](https://cloud.elastic.co?page=docs&placement=docs-body).
 2. On the deployment overview page, select **Actions**, then select **Delete deployment** and confirm the deletion.

--- a/deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
+++ b/deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   -  https://www.elastic.co/guide/en/cloud-enterprise/current/ece-uninstall.html
 applies_to:
   deployment:
-    ece: 
+    ece:
 ---
 
 # Uninstall {{ece}} [ece-uninstall]
@@ -35,7 +35,7 @@ You can remove {{ece}} by removing all containers on the host:
 
 If you plan to reinstall {{ece}} on the host, make sure you [delete the host](../maintenance/ece/delete-ece-hosts.md) from the Cloud UI first. Reinstallation can fail if the host is still associated with your old {{ece}} installation.
 
-::::{warning} 
+::::{warning}
 During installation, the system generates secrets that are placed into the `/mnt/data/elastic/bootstrap-state/bootstrap-secrets.json` secrets file, unless you passed in a different path with the `--host-storage-path` parameter. Keep the information in the `bootstrap-secrets.json` file secure by removing it from its default location and placing it into a secure storage location.
 ::::
 

--- a/deploy-manage/uninstall/uninstall-elastic-cloud-on-kubernetes.md
+++ b/deploy-manage/uninstall/uninstall-elastic-cloud-on-kubernetes.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   -  https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-uninstalling-eck.html
 applies_to:
   deployment:

--- a/deploy-manage/upgrade/deployment-or-cluster.md
+++ b/deploy-manage/upgrade/deployment-or-cluster.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/upgrade.html
   - https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html
   - https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elasticsearch.html
@@ -17,7 +17,7 @@ applies_to:
     eck:
     ess:
     ece:
-    self:  
+    self:
 ---
 
 # Upgrade your deployment or cluster [upgrade-deployment-cluster]

--- a/deploy-manage/upgrade/deployment-or-cluster/kibana-roll-back.md
+++ b/deploy-manage/upgrade/deployment-or-cluster/kibana-roll-back.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Roll back to a previous version"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/upgrade-migrations-rolling-back.html
 ---
 
@@ -8,7 +8,7 @@ mapped_urls:
 
 If you’ve followed [preparing for migration](/deploy-manage/upgrade/deployment-or-cluster/kibana.md#preventing-migration-failures) and [resolving migration failures](../../../troubleshoot/kibana/migration-failures.md), and {{kib}} is still unable to successfully upgrade, roll back {{kib}} until you identify and fix the root cause.
 
-::::{warning} 
+::::{warning}
 Before you roll back {{kib}}, ensure that the version you want to roll back to is compatible with your {{es}} cluster. If the version you want to roll back to is not compatible, you must also roll back {{es}}. Any changes made after an upgrade are lost when you roll back to a previous version.
 ::::
 
@@ -16,7 +16,7 @@ Before you roll back {{kib}}, ensure that the version you want to roll back to i
 To roll back after a failed upgrade migration, you must also roll back the {{kib}} feature state to be compatible with the previous {{kib}} version.
 
 
-## Roll back by restoring the {{kib}} feature state from a snapshot [_roll_back_by_restoring_the_kib_feature_state_from_a_snapshot] 
+## Roll back by restoring the {{kib}} feature state from a snapshot [_roll_back_by_restoring_the_kib_feature_state_from_a_snapshot]
 
 1. Before proceeding, [take a snapshot](../../tools/snapshot-and-restore/create-snapshots.md) that contains the `kibana` feature state. By default, snapshots include the `kibana` feature state.
 2. To make sure no {{kib}} instances are performing an upgrade migration, shut down all {{kib}} instances.

--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-upgrade.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece_re_running_the_ece_upgrade.html
 applies_to:
   deployment:
-    ece:  
+    ece:
 ---
 
 % The upgrade procedure is expected to change with ECE 3.8.0 release. This document is currently a temporary draft, pending to be refined.
@@ -15,7 +15,7 @@ This page provides instructions on how to upgrade the ECE operator.
 
 To learn how to upgrade {{stack}} applications like {{es}} or {{kib}}, refer to [Upgrade the Elastic Stack version](../deployment-or-cluster.md).
 
-Periodically, you might need to upgrade an Elastic Cloud Enterprise installation as new versions with additional features become available. The upgrade process updates all hosts that are part of an Elastic Cloud Enterprise installation to the latest version of ECE, with little or no downtime for managed deployments. To upgrade your deployment to {{stack}} 9.x, the minimum required ECE version is 3.0.0.  
+Periodically, you might need to upgrade an Elastic Cloud Enterprise installation as new versions with additional features become available. The upgrade process updates all hosts that are part of an Elastic Cloud Enterprise installation to the latest version of ECE, with little or no downtime for managed deployments. To upgrade your deployment to {{stack}} 9.x, the minimum required ECE version is 3.0.0.
 
 Before initiating the ECE upgrade process, review the [Support matrix](https://www.elastic.co/support/matrix#elastic-cloud-enterprise) to ensure the operating system (OS), Docker, or Podman versions you're running are compatible with the ECE version you’re upgrading to. We recommend that Docker, Podman, and the operating system are at the target version before starting the ECE upgrade.
 
@@ -79,7 +79,7 @@ Before starting the upgrade process, verify that your setup meets the following 
 - **Proxies and load balancing**. To avoid any downtime for Elastic Cloud Enterprise, the installation must include more than one proxy and must use a load balancer as recommended. If only a single proxy is configured or if the installation is not using a load balancer, some downtime is expected when the containers on the proxies are upgraded. Each container upgrade typically takes five to ten seconds, times the number of containers on a typical host.
 - **For *offline* or *air-gapped* installations**. Additional steps are required to upgrade Elastic Cloud Enterprise. After downloading the installation script for the new version, pull and load the required container images and push them to a private Docker registry. To learn more about pulling and loading Docker images, check Install [ECE offline](../../../deploy-manage/deploy/cloud-enterprise/air-gapped-install.md).
 - Check the security cluster’s zone count. Due to internal limitations in ECE, the built-in security cluster cannot be scaled to two zones during the ECE upgrade procedure. If the zone count is set to 2 zones, scale the cluster to 3 or 1 zone(s) before upgrading ECE.
-- **[Verify if you can upgrade directly](#ece-upgrade-version-matrix)**. When upgrading to ECE 4.0 or a higher version: 
+- **[Verify if you can upgrade directly](#ece-upgrade-version-matrix)**. When upgrading to ECE 4.0 or a higher version:
   - You need to first upgrade to ECE 3.8.0 or later. Refer to the ECE version 3.8.0 upgrade instructions for details.
 
   :::{warning}

--- a/deploy-manage/users-roles/cloud-organization/manage-users.md
+++ b/deploy-manage/users-roles/cloud-organization/manage-users.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-invite-users.html
   - https://www.elastic.co/guide/en/serverless/current/general-manage-organization.html
   - https://www.elastic.co/guide/en/cloud/current/ec-api-organizations.html

--- a/deploy-manage/users-roles/cloud-organization/user-roles.md
+++ b/deploy-manage/users-roles/cloud-organization/user-roles.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-user-privileges.html
   - https://www.elastic.co/guide/en/serverless/current/general-manage-organization.html
 applies_to:
@@ -15,7 +15,7 @@ Within an {{ecloud}} organization, users can have one or more roles and each rol
 
 You can assign user roles when you [invite users to join your organization](/deploy-manage/users-roles/cloud-organization/manage-users.md#ec-invite-users). You can also edit the roles assigned to a user later.
 
-On this page, you'll learn the following: 
+On this page, you'll learn the following:
 
 * [How to edit a user's roles](#edit-a-users-roles)
 * The [types of roles](#types-of-roles) available, the levels where they can be applied, and the [scope](#ec-role-scoping) of each role type
@@ -26,7 +26,7 @@ On this page, you'll learn the following:
 To edit the roles assigned to a user:
 
 1. Go to the user icon on the header bar and select **Organization**.
-2. Find the user on the **Members** tab of the **Organization** page. Click the member name to view their roles. 
+2. Find the user on the **Members** tab of the **Organization** page. Click the member name to view their roles.
 3. Click **Edit** to change the user's roles.
 
 ## Types of roles
@@ -48,7 +48,7 @@ You can set instance access roles at two levels:
 * **Globally**, for all {{ech}} deployments, or for all {{serverless-full}} projects of the time type ({{es-serverless}}, {{observability}}, or {{elastic-sec}}). In this case, the role will also apply to new deployments, or projects of the specified type type, created later.
 * **Individually**, for specific deployments or projects only. To do that, you have to leave the **Role for all hosted deployments** field, or the **Role for all** for the project type, blank.
 
-{{ech}} deployments and {{serverless-full}} projects each have a set of predefined instance access roles available: 
+{{ech}} deployments and {{serverless-full}} projects each have a set of predefined instance access roles available:
 
 * [{{ech}} predefined roles](#ech-predefined-roles)
 * [{{serverless-full}} predefined roles](#general-assign-user-roles-table)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Cluster or deployment"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters.html
   - https://www.elastic.co/guide/en/cloud/current/ec-security.html
 applies_to:
@@ -41,7 +41,7 @@ You can also learn the basics of Elasticsearch authentication, learn about accou
 
 After a user is authenticated, use role-based access control to determine whether the user behind an incoming request is allowed to execute the request.
 
-Key tasks for managing user authorization include: 
+Key tasks for managing user authorization include:
 
 * [Defining roles](/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md)
 * Assigning [built-in roles](/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md) or your own roles to users
@@ -52,6 +52,6 @@ You can also learn the basics of Elasticsearch authorization, and perform advanc
 
 ::::{tip}
 User roles are also used to control access to [{{kib}} spaces](/deploy-manage/manage-spaces.md).
-:::: 
+::::
 
 [View all user authorization docs](/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md)

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/active-directory-realm.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-ad.html
 applies_to:
@@ -16,7 +16,7 @@ navigation_title: "Active Directory"
 You can configure {{stack}} {{security-features}} to communicate with Active Directory to authenticate users.
 
 :::{{tip}}
-This topic describes implementing Active Directory at the cluster or deployment level, for the purposes of authenticating with {{es}} and {{kib}}. 
+This topic describes implementing Active Directory at the cluster or deployment level, for the purposes of authenticating with {{es}} and {{kib}}.
 
 You can also configure an {{ece}} installation to use an Active Directory to authenticate users. [Learn more](/deploy-manage/users-roles/cloud-enterprise-orchestrator/active-directory.md).
 :::
@@ -29,7 +29,7 @@ The path to an entry is a *Distinguished Name* (DN) that uniquely identifies a u
 
 The {{security-features}} supports only Active Directory security groups. You can't map distribution groups to roles.
 
-::::{note} 
+::::{note}
 When you use Active Directory for authentication, the username entered by the user is expected to match the `sAMAccountName` or `userPrincipalName`, not the common name.
 ::::
 
@@ -47,8 +47,8 @@ If your Active Directory domain supports authentication with user-provided crede
 
     See [Active Directory realm settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#ref-ad-settings) for all of the options you can set for an `active_directory` realm.
 
-    :::{note} 
-    Binding to Active Directory fails if the domain name is not mapped in DNS. 
+    :::{note}
+    Binding to Active Directory fails if the domain name is not mapped in DNS.
 
     In a self-managed cluster, if DNS is not being provided by a Windows DNS server, you can add a mapping for the domain in the local `/etc/hosts` file.
     :::
@@ -64,7 +64,7 @@ If your Active Directory domain supports authentication with user-provided crede
       authc:
         realms:
           active_directory:
-            my_ad:  
+            my_ad:
               order: 0 <1>
               domain_name: ad.example.com <2>
               url: ldaps://ad.example.com:636 <3>
@@ -73,7 +73,7 @@ If your Active Directory domain supports authentication with user-provided crede
   1. The order in which the `active_directory` realm is consulted during an authentication attempt.
   2. The primary domain in Active Directory. Binding to Active Directory fails if the domain name is not mapped in DNS.
   3. The LDAP URL pointing to the Active Directory Domain Controller that should handle authentication. If you don’t specify the URL, it defaults to `ldap:<domain_name>:389`.
-  
+
   :::
 
   :::{tab-item} Forest
@@ -102,16 +102,16 @@ If your Active Directory domain supports authentication with user-provided crede
   3. A load balancing setting is provided to indicate the desired behavior when choosing the server to connect to.
 
 
-  In this configuration, users will need to use either their full User Principal Name (UPN) or their down-level logon name: 
-  * A UPN is typically a concatenation of the username with `@<DOMAIN_NAME` such as `johndoe@ad.example.com`. 
-  * The down-level logon name is the NetBIOS domain name, followed by a `\` and the username, such as `AD\johndoe`. 
-  
+  In this configuration, users will need to use either their full User Principal Name (UPN) or their down-level logon name:
+  * A UPN is typically a concatenation of the username with `@<DOMAIN_NAME` such as `johndoe@ad.example.com`.
+  * The down-level logon name is the NetBIOS domain name, followed by a `\` and the username, such as `AD\johndoe`.
+
     Use of down-level logon name requires a connection to the regular LDAP ports (389 or 636) in order to query the configuration container to retrieve the domain name from the NetBIOS name.
   :::
 
   ::::
 
-  ::::{important} 
+  ::::{important}
   When you configure realms in `elasticsearch.yml`, only the realms you specify are used for authentication. If you also want to use the `native` or `file` realms, you must include them in the realm chain.
   ::::
 
@@ -129,17 +129,17 @@ If your Active Directory domain supports authentication with user-provided crede
 
 ## Step 2: Configure a bind user (Optional) [ece-ad-configuration-with-bind-user]
 
-You can choose to configure an Active Directory realm using a bind user. 
+You can choose to configure an Active Directory realm using a bind user.
 
 The Active Directory realm authenticates users using an LDAP bind request. By default, all of the LDAP operations are run by the user that {{es}} is authenticating. In some cases, regular users may not be able to access all of the necessary items within Active Directory and a bind user is needed. A bind user can be configured and is used to perform all operations other than the LDAP bind request, which is required to authenticate the credentials provided by the user.
 
 When you specify a `bind_dn`, this specific user is used to search for the Distinguished Name (`DN`) of the authenticating user based on the provided username and an LDAP attribute. If found, this user is authenticated by attempting to bind to the LDAP server using the found `DN` and the provided password.
 
-The use of a bind user enables the [run as feature](/deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md) to be used with the Active Directory realm. 
+The use of a bind user enables the [run as feature](/deploy-manage/users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md) to be used with the Active Directory realm.
 
 In self-managed clusters, use of a bind user also enables the ability to maintain a set of pooled connections to Active Directory. These pooled connections reduce the number of resources that must be created and destroyed with every user authentication.
 
-To configure a bind user: 
+To configure a bind user:
 
 1. [Add your user settings](../../../deploy-manage/deploy/cloud-enterprise/edit-stack-settings.md) for the `active_directory` realm as follows:
 
@@ -154,9 +154,9 @@ To configure a bind user:
           realms:
             active_directory:
               my_ad:
-                order: 2 
-                domain_name: ad.example.com 
-                url: ldap://ad.example.com:389 
+                order: 2
+                domain_name: ad.example.com
+                url: ldap://ad.example.com:389
                 bind_dn: es_svc_user@ad.example.com <1>
     ```
 
@@ -176,12 +176,12 @@ An integral part of a realm authentication process is to resolve the roles assoc
 
 Because users are managed externally in the Active Directory server, the expectation is that their roles are managed there as well. Active Directory groups often represent user roles for different systems in the organization.
 
-The `active_directory` realm enables you to map Active Directory users to roles using their Active Directory groups or other metadata. 
+The `active_directory` realm enables you to map Active Directory users to roles using their Active Directory groups or other metadata.
 
-You can map Active Directory groups to roles for your users in the following ways: 
+You can map Active Directory groups to roles for your users in the following ways:
 
 * Using the role mappings page in {{kib}}.
-* Using the [role mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role-mapping). 
+* Using the [role mapping API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-put-role-mapping).
 * Using a role mapping file.
 
 For more information, see [Mapping users and groups to roles](/deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md).
@@ -213,10 +213,10 @@ POST /_security/role_mapping/ldap-superuser
 
 ### Example: Using a role mapping file [ece_using_the_role_mapping_files_2]
 
-:::{tip} 
+:::{tip}
 If you're using {{ece}} or {{ech}}, then you must [upload this file as a custom bundle](/deploy-manage/deploy/elastic-cloud/upload-custom-plugins-bundles.md) before it can be referenced.
 
-If you're using {{eck}}, then install the file as a [custom configuration file](/deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md#use-a-volume-and-volume-mount-together-with-a-configmap-or-secret). 
+If you're using {{eck}}, then install the file as a [custom configuration file](/deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md#use-a-volume-and-volume-mount-together-with-a-configmap-or-secret).
 
 If you're using a self-managed cluster, then the file must be present on each node.
 :::
@@ -280,7 +280,7 @@ If you're using {{ech}} or {{ece}}, then you must [upload your certificate as a 
 
 If you're using {{eck}}, then install the certificate as a [custom configuration file](/deploy-manage/deploy/cloud-on-k8s/custom-configuration-files-plugins.md#use-a-volume-and-volume-mount-together-with-a-configmap-or-secret).
 
-:::{tip} 
+:::{tip}
 
 If you're using {{ece}} or {{ech}}, then these steps are required only if TLS is enabled and the Active Directory controller is using self-signed certificates.
 :::
@@ -315,7 +315,7 @@ xpack:
 
 For more information about these settings, see [Active Directory realm settings](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#ref-ad-settings).
 
-::::{note} 
+::::{note}
 By default, when you configure {{es}} to connect to Active Directory using SSL/TLS, it attempts to verify the hostname or IP address specified with the `url` attribute in the realm configuration with the values in the certificate. If the values in the certificate and realm configuration do not match, {{es}} does not allow a connection to the Active Directory server. This is done to protect against man-in-the-middle attacks. If necessary, you can disable this behavior by setting the `ssl.verification_mode` property to `certificate`.
 ::::
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-roles.html
   - https://www.elastic.co/guide/en/kibana/current/xpack-security-authorization.html
 applies_to:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-sm.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-sm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/change-passwords-native-users.html
 applies_to:
   deployment:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-users.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html
 applies_to:
   deployment:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/document-level-security.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/field-level-security.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/field-and-document-access-control.html

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html
@@ -54,9 +54,9 @@ When you use the UI or APIs to manage roles, the roles are stored in an internal
 ### Role management UI [roles-management-ui]
 $$$adding_kibana_privileges$$$
 
-You can manage users and roles easily in {{kib}}. 
+You can manage users and roles easily in {{kib}}.
 
-To manage roles, log in to {{kib}} and go to **Management > Security > Roles**. 
+To manage roles, log in to {{kib}} and go to **Management > Security > Roles**.
 
 [Learn more about using the role management UI](/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md).
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/file-realm.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
 applies_to:
@@ -18,7 +18,7 @@ The `file` realm is useful as a fallback or recovery realm. For example in cases
 You can configure only one file realm on {{es}} nodes.
 
 ::::{important}
-* In self-managed deployments, as the administrator of the cluster, it is your responsibility to ensure the same users are defined on every node in the cluster. The {{stack}} {{security-features}} do not deliver any mechanism to guarantee this. 
+* In self-managed deployments, as the administrator of the cluster, it is your responsibility to ensure the same users are defined on every node in the cluster. The {{stack}} {{security-features}} do not deliver any mechanism to guarantee this.
 * You can't add or manage users in the `file` realm using the [user APIs](https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-security), or using the {{kib}} **Management > Security > Users** page.
 ::::
 
@@ -42,14 +42,14 @@ You don’t need to explicitly configure a `file` realm. The `file` and `native`
 
 2. If you're using a self-managed {{es}} cluster, optionally change how often the `users` and `users_roles` files are checked.
 
-    By default, {{es}} checks these files for changes every 5 seconds. You can change this default behavior by changing the `resource.reload.interval.high` setting in the `elasticsearch.yml` file. 
-    
+    By default, {{es}} checks these files for changes every 5 seconds. You can change this default behavior by changing the `resource.reload.interval.high` setting in the `elasticsearch.yml` file.
+
     :::{{warning}}
     Because `resource.reload.interval.high` is a common setting in {{es}}, changing its value may effect other schedules in the system.
     :::
 
-3. Restart {{es}}. 
-   
+3. Restart {{es}}.
+
    In {{eck}}, this change is propagated automatically.
 
 
@@ -59,7 +59,7 @@ You don’t need to explicitly configure a `file` realm. The `file` and `native`
 
 **In an {{eck}} deployment**, you can pass file realm user information in two ways:
 
-1. Using [`users` and `user_roles`](#using-users-and-users_roles-files) files, which are passed using file realm content secrets 
+1. Using [`users` and `user_roles`](#using-users-and-users_roles-files) files, which are passed using file realm content secrets
 2. [Using Kubernetes basic authentication secrets](#k8s-basic)
 
 You can reference several secrets in the {{es}} specification. ECK aggregates their content into a single secret, mounted in every {{es}} Pod.

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-securing-clusters-JWT.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-JWT.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-securing-clusters-JWT.html

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/kerberos.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/kerberos.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-secure-clusters-kerberos.html
   - https://www.elastic.co/guide/en/cloud/current/ec-secure-clusters-kerberos.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-secure-clusters-kerberos.html

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-role-management.html
 applies_to:
   deployment:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ldap-realm.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-ldap.html
 applies_to:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/managed-credentials-eck.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/managed-credentials-eck.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-rotate-credentials.html
 applies_to:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/mapping-users-groups-to-roles.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-roles.html
   - https://www.elastic.co/guide/en/kibana/current/role-mappings.html
 applies_to:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/native-realm.html
   - https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-users-and-roles.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/change-passwords-native-users.html
@@ -20,7 +20,7 @@ The easiest way to manage and authenticate users is with the internal `native` r
 In self-managed {{es}} clusters, you can also reset passwords for users in the native realm [using the command line](#reset-pw-cmd-line).
 
 :::{{tip}}
-This topic describes using the native realm at the cluster or deployment level, for the purposes of authenticating with {{es}} and {{kib}}. 
+This topic describes using the native realm at the cluster or deployment level, for the purposes of authenticating with {{es}} and {{kib}}.
 
 You can also manage and authenticate users natively at the following levels:
 
@@ -42,7 +42,7 @@ You can configure a `native` realm in the `xpack.security.authc.realms.native` n
 
 1. Add a realm configuration to `elasticsearch.yml` under the `xpack.security.authc.realms.native` namespace. It is recommended that you explicitly set the `order` attribute for the realm.
 
-    ::::{note} 
+    ::::{note}
     You can configure only one native realm on {{es}} nodes.
     ::::
 
@@ -54,7 +54,7 @@ You can configure a `native` realm in the `xpack.security.authc.realms.native` n
       order: 0
     ```
 
-    ::::{note} 
+    ::::{note}
     To limit exposure to credential theft and mitigate credential compromise, the native realm stores passwords and caches user credentials according to security best practices. By default, a hashed version of user credentials is stored in memory, using a salted `sha-256` hash algorithm and a hashed version of passwords is stored on disk salted and hashed with the `bcrypt` hash algorithm. To use different hash algorithms, see [User cache and password hash algorithms](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#hashing-settings).
     ::::
 
@@ -80,7 +80,7 @@ Elastic enables you to easily manage users in {{kib}} on the **Stack Management 
 
 ## Manage native users using the `user` API [native-users-api]
 
-You can manage users through the Elasticsearch `user` API. 
+You can manage users through the Elasticsearch `user` API.
 
 For example, you can change a user's password:
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/oidc-examples.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/oidc-examples.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-securing-clusters-oidc-op.html
 navigation_title: With Azure, Google, or Okta
 applies_to:
@@ -38,9 +38,9 @@ For more information about OpenID connect in Azure, refer to [Azure OAuth 2.0 an
 
         2. Enter a **Name** for your application, for example `ec-oauth2`.
         3. Select a **Supported Account Type** according to your preferences.
-        4. Set the **Redirect URI**. 
-            
-            It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`, where `<KIBANA_ENDPOINT_URL>` is the base URL for your {{kib}} instance. 
+        4. Set the **Redirect URI**.
+
+            It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`, where `<KIBANA_ENDPOINT_URL>` is the base URL for your {{kib}} instance.
 
             If you're using {{ech}}, then set this value to `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`.
         5. Select **Register**.
@@ -173,8 +173,8 @@ For more information about OpenID connect in Google, refer to [Google OpenID Con
         2. For **Application Type** choose `Web application`.
         3. Choose a **Name** for your OAuth 2 client, for example `ec-oauth2`.
         4. Add an **Authorized redirect URI**.
-    
-            It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`, where `<KIBANA_ENDPOINT_URL>` is the base URL for your {{kib}} instance. 
+
+            It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`, where `<KIBANA_ENDPOINT_URL>` is the base URL for your {{kib}} instance.
 
             If you're using {{ech}}, then set this value to `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`.
         5. Select **Create** and copy your client ID and your client secret for later use.
@@ -213,9 +213,9 @@ For more information about OpenID connect in Google, refer to [Google OpenID Con
     Where:
 
     * `YOUR_CLIENT_ID` is your Client ID.
-    * `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback` is your Kibana endpoint. 
-  
-        It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`, where `<KIBANA_ENDPOINT_URL>` is the base URL for your {{kib}} instance. 
+    * `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback` is your Kibana endpoint.
+
+        It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`, where `<KIBANA_ENDPOINT_URL>` is the base URL for your {{kib}} instance.
 
         If you're using {{ech}}, then set this value to `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`.
     * `YOUR_DOMAIN` and `TLD` in the `claim_patterns.principal` regular expression are your organization email domain and top level domain.
@@ -286,9 +286,9 @@ For more information about OpenID connect in Okta, refer to [Okta OAuth 2.0 docu
 
         2. For the **Platform** page settings, select **Web** then **Next**.
         3. In the **Application settings** choose a **Name** for your application, for example `Kibana OIDC`.
-        4. Set the **Base URI** to `KIBANA_ENDPOINT_URL`. 
-        5. Set the **Login redirect URI**.  
-            
+        4. Set the **Base URI** to `KIBANA_ENDPOINT_URL`.
+        5. Set the **Login redirect URI**.
+
             It will typically be `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`.
 
             If you're using {{ech}}, then set this value to `<KIBANA_ENDPOINT_URL>/api/security/oidc/callback`.

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/openid-connect.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/oidc-realm.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/oidc-guide.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-secure-clusters-oidc.html

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/role-mapping-resources.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/role-mapping-resources.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/role-mapping-resources.html
 navigation_title: "Role mapping properties"
 applies_to:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/saml-entra.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/saml-entra.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-securing-clusters-saml-azure.html
 navigation_title: With Microsoft Entra ID
 applies_to:

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-realm.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece_sign_outgoing_saml_message.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece_optional_settings.html

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/user-authentication.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
   - https://www.elastic.co/guide/en/kibana/current/kibana-authentication.html
 applies_to:

--- a/deploy-manage/users-roles/serverless-custom-roles.md
+++ b/deploy-manage/users-roles/serverless-custom-roles.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/custom-roles.html
 applies_to:
   serverless:

--- a/explore-analyze/ai-assistant.md
+++ b/explore-analyze/ai-assistant.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/search-ai-assistant.html
   - https://www.elastic.co/guide/en/observability/current/obs-ai-assistant.html
   - https://www.elastic.co/guide/en/serverless/current/security-ai-for-security.html
@@ -24,7 +24,7 @@ $$$token-limits$$$
 - **Visualizing and analyzing data**: Assists you in creating visualizations and analyzing your data using Kibana.
 - **Troubleshooting**: Explains errors, messages, and suggests remediation.
 
-AI Assistant requires specific privileges and a generative AI connector. 
+AI Assistant requires specific privileges and a generative AI connector.
 
 % Check [Configure AI Assistant](../deploy-manage/) for more details on how to enable and configure it.
 

--- a/explore-analyze/alerts-cases.md
+++ b/explore-analyze/alerts-cases.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html#alerting-concepts-differences
   - https://www.elastic.co/guide/en/serverless/current/project-settings-alerts.html
 ---

--- a/explore-analyze/alerts-cases/alerts.md
+++ b/explore-analyze/alerts-cases/alerts.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html
   - https://www.elastic.co/guide/en/serverless/current/rules.html
   - https://www.elastic.co/guide/en/cloud/current/ec-organizations-notifications-domain-allowlist.html

--- a/explore-analyze/alerts-cases/alerts/maintenance-windows.md
+++ b/explore-analyze/alerts-cases/alerts/maintenance-windows.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/maintenance-windows.html
   - https://www.elastic.co/guide/en/serverless/current/maintenance-windows.html
 ---

--- a/explore-analyze/alerts-cases/alerts/notifications-domain-allowlist.md
+++ b/explore-analyze/alerts-cases/alerts/notifications-domain-allowlist.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-organizations-notifications-domain-allowlist.html
 ---
 

--- a/explore-analyze/alerts-cases/watcher.md
+++ b/explore-analyze/alerts-cases/watcher.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-alerting.html
   - https://www.elastic.co/guide/en/cloud/current/ec-watcher.html
   - https://www.elastic.co/guide/en/kibana/current/watcher-ui.html

--- a/explore-analyze/elastic-inference/inference-api.md
+++ b/explore-analyze/elastic-inference/inference-api.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/inference-endpoints.html
 
 navigation_title: Inference integrations

--- a/explore-analyze/find-and-organize.md
+++ b/explore-analyze/find-and-organize.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/project-settings-content.html
 ---
 
@@ -13,7 +13,7 @@ $$$saved-objects-copy-to-other-spaces$$$
 
 $$$saved-objects-import-and-export$$$
 
-When using Elastic, you create, manage, and export various types of content, called objects. From data views that let your organize your {{es}} data into logical subsets, to dashboards and reports that let you visualize and share insights with others. 
+When using Elastic, you create, manage, and export various types of content, called objects. From data views that let your organize your {{es}} data into logical subsets, to dashboards and reports that let you visualize and share insights with others.
 
 This section describes what those objects are, how you can organize them, and how you can find them quickly when navigating the user interface.
 

--- a/explore-analyze/find-and-organize/data-views.md
+++ b/explore-analyze/find-and-organize/data-views.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/data-views.html
   - https://www.elastic.co/guide/en/serverless/current/data-views.html
   - https://www.elastic.co/guide/en/kibana/current/managing-data-views.html

--- a/explore-analyze/find-and-organize/saved-objects.md
+++ b/explore-analyze/find-and-organize/saved-objects.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/saved-objects.html
   - https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html
   - https://www.elastic.co/guide/en/kibana/current/saved-object-ids.html

--- a/explore-analyze/find-and-organize/tags.md
+++ b/explore-analyze/find-and-organize/tags.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/tags.html
   - https://www.elastic.co/guide/en/kibana/current/managing-tags.html
 ---

--- a/explore-analyze/index.md
+++ b/explore-analyze/index.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-explore-your-data.html
   - https://www.elastic.co/guide/en/kibana/current/introduction.html#visualize-and-analyze
   - https://www.elastic.co/guide/en/kibana/current/get-started.html

--- a/explore-analyze/machine-learning.md
+++ b/explore-analyze/machine-learning.md
@@ -3,7 +3,7 @@ applies_to:
   stack: ga
   serverless: ga
 navigation_title: Machine learning
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/machine-learning/current/index.html
   - https://www.elastic.co/guide/en/machine-learning/current/machine-learning-intro.html
   - https://www.elastic.co/guide/en/serverless/current/machine-learning.html

--- a/explore-analyze/machine-learning/anomaly-detection.md
+++ b/explore-analyze/machine-learning/anomaly-detection.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/machine-learning/current/ml-ad-overview.html
   - https://www.elastic.co/guide/en/kibana/current/xpack-ml-anomalies.html
 ---

--- a/explore-analyze/machine-learning/data-frame-analytics.md
+++ b/explore-analyze/machine-learning/data-frame-analytics.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/machine-learning/current/ml-dfanalytics.html
   - https://www.elastic.co/guide/en/kibana/current/xpack-ml-dfanalytics.html
 ---

--- a/explore-analyze/query-filter/filtering.md
+++ b/explore-analyze/query-filter/filtering.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/kibana-concepts-analysts.html
   - https://www.elastic.co/guide/en/kibana/current/set-time-filter.html
 ---

--- a/explore-analyze/query-filter/languages/esql.md
+++ b/explore-analyze/query-filter/languages/esql.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-getting-started.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-using.html

--- a/explore-analyze/query-filter/languages/querydsl.md
+++ b/explore-analyze/query-filter/languages/querydsl.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html
 ---

--- a/explore-analyze/query-filter/tools/console.md
+++ b/explore-analyze/query-filter/tools/console.md
@@ -3,7 +3,7 @@ applies_to:
   stack: ga
   serverless: ga
 navigation_title: Console
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/console-kibana.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-api-console.html
   - https://www.elastic.co/guide/en/serverless/current/devtools-run-api-requests-in-the-console.html

--- a/explore-analyze/query-filter/tools/saved-queries.md
+++ b/explore-analyze/query-filter/tools/saved-queries.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/save-load-delete-query.html
 ---
 

--- a/explore-analyze/report-and-share.md
+++ b/explore-analyze/report-and-share.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/reporting-getting-started.html
 ---
 

--- a/explore-analyze/transforms.md
+++ b/explore-analyze/transforms.md
@@ -2,7 +2,7 @@
 applies_to:
   stack: ga
   serverless: ga
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/transforms.html
   - https://www.elastic.co/guide/en/serverless/current/transforms.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/data-rollup-transform.html

--- a/get-started/deployment-options.md
+++ b/get-started/deployment-options.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro-deploy.html
 ---
 

--- a/get-started/the-stack.md
+++ b/get-started/the-stack.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/stack-components.html
   - https://www.elastic.co/guide/en/kibana/current/introduction.html
   - https://www.elastic.co/guide/en/kibana/current/index.html

--- a/manage-data/data-store/data-streams.md
+++ b/manage-data/data-store/data-streams.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html#manage-data-streams
   - https://www.elastic.co/guide/en/serverless/current/index-management.html#index-management-manage-data-streams

--- a/manage-data/data-store/index-basics.md
+++ b/manage-data/data-store/index-basics.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/documents-indices.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html#view-edit-indices
   - https://www.elastic.co/guide/en/serverless/current/index-management.html

--- a/manage-data/data-store/manage-data-from-the-command-line.md
+++ b/manage-data/data-store/manage-data-from-the-command-line.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-working-with-elasticsearch.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-working-with-elasticsearch.html
 applies_to:

--- a/manage-data/data-store/mapping.md
+++ b/manage-data/data-store/mapping.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-mapper.html
 applies_to:

--- a/manage-data/data-store/templates/ignore-missing-component-templates.md
+++ b/manage-data/data-store/templates/ignore-missing-component-templates.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore_missing_component_templates.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/_usage_example.html
 applies_to:

--- a/manage-data/data-store/templates/index-template-management.md
+++ b/manage-data/data-store/templates/index-template-management.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html#manage-index-templates
   - https://www.elastic.co/guide/en/serverless/current/index-management.html#index-management-manage-index-templates
 applies_to:

--- a/manage-data/data-store/text-analysis.md
+++ b/manage-data/data-store/text-analysis.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-overview.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-analysis.html

--- a/manage-data/ingest.md
+++ b/manage-data/ingest.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-cloud-ingest-data.html
   - https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-ingest-your-data.html

--- a/manage-data/ingest/ingesting-data-from-applications.md
+++ b/manage-data/ingest/ingesting-data-from-applications.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-ingest-guides.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-ingest-guides.html
 applies_to:
@@ -28,7 +28,7 @@ The following tutorials demonstrate how you can use the Elasticsearch language c
 [Ingest logs from a Node.js web application using Filebeat](ingesting-data-from-applications/ingest-logs-from-nodejs-web-application-using-filebeat.md)
 :   Get HTTP request logs from a Node.js web application and deliver them securely into your {{ech}} or {{ece}} deployment. You’ll set up Filebeat to monitor an ECS-formatted log file and then view real-time visualizations of the log events as HTTP requests occur on your Node.js web server.
 
-::::{tip} 
+::::{tip}
 You can use [Elasticsearch ingest pipelines](transform-enrich/ingest-pipelines.md) to preprocess incoming data. This enables you to optimize how your data is indexed, and simplifies tasks such as extracting error codes from a log file and mapping geographic locations to IP addresses.
 ::::
 

--- a/manage-data/ingest/ingesting-data-from-applications/ingest-data-from-beats-to-elasticsearch-service-with-logstash-as-proxy.md
+++ b/manage-data/ingest/ingesting-data-from-applications/ingest-data-from-beats-to-elasticsearch-service-with-logstash-as-proxy.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-beats-logstash.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-getting-started-search-use-cases-beats-logstash.html
 applies_to:

--- a/manage-data/ingest/ingesting-data-from-applications/ingest-data-from-relational-database-into-elasticsearch-service.md
+++ b/manage-data/ingest/ingesting-data-from-applications/ingest-data-from-relational-database-into-elasticsearch-service.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-db-logstash.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-getting-started-search-use-cases-db-logstash.html
 applies_to:

--- a/manage-data/ingest/ingesting-data-from-applications/ingest-data-with-nodejs-on-elasticsearch-service.md
+++ b/manage-data/ingest/ingesting-data-from-applications/ingest-data-with-nodejs-on-elasticsearch-service.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-node-js.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-getting-started-node-js.html
 applies_to:

--- a/manage-data/ingest/ingesting-data-from-applications/ingest-data-with-python-on-elasticsearch-service.md
+++ b/manage-data/ingest/ingesting-data-from-applications/ingest-data-with-python-on-elasticsearch-service.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-python.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-getting-started-python.html
 applies_to:

--- a/manage-data/ingest/ingesting-data-from-applications/ingest-logs-from-nodejs-web-application-using-filebeat.md
+++ b/manage-data/ingest/ingesting-data-from-applications/ingest-logs-from-nodejs-web-application-using-filebeat.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-node-logs.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-getting-started-search-use-cases-node-logs.html
 applies_to:

--- a/manage-data/ingest/ingesting-data-from-applications/ingest-logs-from-python-application-using-filebeat.md
+++ b/manage-data/ingest/ingesting-data-from-applications/ingest-logs-from-python-application-using-filebeat.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-getting-started-search-use-cases-python-logs.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-getting-started-search-use-cases-python-logs.html
 applies_to:

--- a/manage-data/ingest/sample-data.md
+++ b/manage-data/ingest/sample-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/sample-data.html
   - https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html#_add_sample_data
 applies_to:
@@ -13,9 +13,9 @@ Using sample data is a great way to start exploring the system and learn your wa
 
 ## Add sample data sets
 
-The simplest way is to add one or more of our sample data sets. These data sets come with sample visualizations, dashboards, and more to help you explore the interface before you add your own data. 
+The simplest way is to add one or more of our sample data sets. These data sets come with sample visualizations, dashboards, and more to help you explore the interface before you add your own data.
 
-If you have no data, you will be prompted to install these packages when running {{kib}} for the first time. 
+If you have no data, you will be prompted to install these packages when running {{kib}} for the first time.
 
 You can also access and install them from the **Integrations** page. Go to **Integrations** and search for **Sample Data**. On the **Sample Data** page, expand the **Other sample data sets** section and add the type of data you want.
 <br>
@@ -40,7 +40,7 @@ Make sure to execute `node scripts/makelogs` *after* {{es}} is up and running.
 
 ## Upload a file
 
-You can also upload your own sample data using the **Upload a file** option on the **Integrations** page. 
+You can also upload your own sample data using the **Upload a file** option on the **Integrations** page.
 
 Go to **Integrations** and search for **Upload a file**. On the **Upload file** page, select or drag and drop a file to add your data.
 <br>

--- a/manage-data/ingest/tools.md
+++ b/manage-data/ingest/tools.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-cloud-ingest-data.html
   - https://www.elastic.co/guide/en/fleet/current/beats-agent-comparison.html
   - https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html

--- a/manage-data/ingest/transform-enrich/data-enrichment.md
+++ b/manage-data/ingest/transform-enrich/data-enrichment.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-enriching-data.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-mgmt.html#manage-enrich-policies
 applies_to:

--- a/manage-data/ingest/transform-enrich/ingest-pipelines-serverless.md
+++ b/manage-data/ingest/transform-enrich/ingest-pipelines-serverless.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/ingest-pipelines.html
 applies_to:
   stack: ga

--- a/manage-data/ingest/transform-enrich/ingest-pipelines.md
+++ b/manage-data/ingest/transform-enrich/ingest-pipelines.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html
 applies_to:
   stack: ga

--- a/manage-data/ingest/upload-data-files.md
+++ b/manage-data/ingest/upload-data-files.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-ingest-data-file-upload.html
   - https://www.elastic.co/guide/en/kibana/current/connect-to-elasticsearch.html#upload-data-kibana
 applies_to:
@@ -18,7 +18,7 @@ applies_to:
 
 % Note from David: I've removed the ID $$$upload-data-kibana$$$ from manage-data/ingest.md as those links should instead point to this page. So, please ensure that the following ID is included on this page. I've added it beside the title.
 
-You can upload files, view their fields and metrics, and optionally import them to {{es}} with the Data Visualizer. 
+You can upload files, view their fields and metrics, and optionally import them to {{es}} with the Data Visualizer.
 
 To use the Data Visualizer, click **Upload a file** on the {{es}} **Getting Started** page or navigate to the **Integrations** view and search for **Upload a file**. Clicking **Upload a file** opens the Data Visualizer UI.
 

--- a/manage-data/lifecycle.md
+++ b/manage-data/lifecycle.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/data-management.html
 applies_to:
   stack: ga

--- a/manage-data/lifecycle/data-tiers.md
+++ b/manage-data/lifecycle/data-tiers.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/data-tiers.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-disable-data-tier.html
   - https://www.elastic.co/guide/en/cloud/current/ec-disable-data-tier.html
@@ -115,9 +115,9 @@ To add a data tier to an existing deployment:
 Disabling a data tier, attempting to scale nodes down in size, reducing availability zones, or reverting an [autoscaling](/deploy-manage/autoscaling.md) change can all result in cluster instability, cluster inaccessibility, and even data corruption or loss in extreme cases.
 
 To avoid this, especially for [production environments](/deploy-manage/production-guidance.md), and in addition to making configuration changes to your indices and ILM as described on this page:
-* Review the disk size, CPU, JVM memory pressure, and other [performance metrics](/deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md) of your deployment **before** attempting to perform the scaling down action. 
+* Review the disk size, CPU, JVM memory pressure, and other [performance metrics](/deploy-manage/monitor/access-performance-metrics-on-elastic-cloud.md) of your deployment **before** attempting to perform the scaling down action.
 * Make sure that you have enough resources and [availability zones](/deploy-manage/production-guidance/availability-and-resilience.md) to handle your workloads after scaling down.
-* Check that your [deployment hardware profile](/deploy-manage/deploy/elastic-cloud/ec-change-hardware-profile.md) (for {{ech}}) or [deployment template](/deploy-manage/deploy/cloud-enterprise/configure-deployment-templates.md) (for {{ece}}) is correct for your business use case. For example, if you need to scale due to CPU pressure increases and are using a *Storage Optimized* hardware profile, consider switching to a *CPU Optimized* configuration instead. 
+* Check that your [deployment hardware profile](/deploy-manage/deploy/elastic-cloud/ec-change-hardware-profile.md) (for {{ech}}) or [deployment template](/deploy-manage/deploy/cloud-enterprise/configure-deployment-templates.md) (for {{ece}}) is correct for your business use case. For example, if you need to scale due to CPU pressure increases and are using a *Storage Optimized* hardware profile, consider switching to a *CPU Optimized* configuration instead.
 
 Read [https://www.elastic.co/cloud/shared-responsibility](https://www.elastic.co/cloud/shared-responsibility) for additional details.
 If in doubt, reach out to Support.
@@ -128,10 +128,10 @@ The process of disabling a data tier depends on whether we are dealing with [sea
 The hot and warm tiers store regular indices, while the frozen tier stores searchable snapshots. However, the cold tier can store either regular indices or searchable snapshots. To check if a cold tier contains searchable snapshots perform the following request:
 
 ```sh
-# cold data tier searchable snapshot indices 
+# cold data tier searchable snapshot indices
 GET /_cat/indices/restored-*
 
-# frozen data tier searchable snapshot indices 
+# frozen data tier searchable snapshot indices
 GET /_cat/indices/partial-*
 ```
 

--- a/manage-data/lifecycle/index-lifecycle-management.md
+++ b/manage-data/lifecycle/index-lifecycle-management.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/overview-index-lifecycle-management.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-concepts.html

--- a/manage-data/lifecycle/rollup.md
+++ b/manage-data/lifecycle/rollup.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-rollup.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/rollup-overview.html
 ---

--- a/manage-data/migrate.md
+++ b/manage-data/migrate.md
@@ -1,12 +1,12 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-migrating-data.html
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-migrating-data.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-migrate-data2.html
 applies_to:
   stack: ga
   deployment:
-    eck: unavailable 
+    eck: unavailable
     ess: ga
     ece: ga
   serverless: unavailable
@@ -146,30 +146,30 @@ For {{ece}} users, while it is most common to have Amazon S3 buckets, you should
 3. Add the snapshot repository:
 
     ::::{tab-set}
-    
+
     :::{tab-item} {{ech}}
 
     From the [console](https://cloud.elastic.co?page=docs&placement=docs-body) of the **new** {{es}} cluster, add the snapshot repository.
-    
+
     For details, check our guidelines for:
     * [Amazon Web Services (AWS) Storage](../deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md)
     * [Google Cloud Storage (GCS)](../deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md)
     * [Azure Blob Storage](../deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md).
-    
+
     If you’re migrating [searchable snapshots](../deploy-manage/tools/snapshot-and-restore/searchable-snapshots.md), the repository name must be identical in the source and     destination clusters.
-    
+
     If the source cluster is still writing to the repository, you need to set the destination cluster’s repository connection to `readonly:true` to avoid data corruption. Refer to [backup a repository](../deploy-manage/tools/snapshot-and-restore/self-managed.md#snapshots-repository-backup) for details.
     :::
-        
+
     :::{tab-item} {{ece}}
-    
+
     From the Cloud UI of the **new** {{es}} cluster add the snapshot repository.
-    
+
     For details about configuring snapshot repositories on Amazon Web Services (AWS), Google Cloud Storage (GCS), or Azure Blob Storage, check [manage Snapshot Repositories](../deploy-manage/tools/snapshot-and-restore/cloud-enterprise.md).
-    
+
     If you’re migrating [searchable snapshots](../deploy-manage/tools/snapshot-and-restore/searchable-snapshots.md), the repository name must be identical in the source and     destination clusters.
     :::
-        
+
     ::::
 
 4. Start the Restore process.

--- a/manage-data/migrate/migrate-internal-indices.md
+++ b/manage-data/migrate/migrate-internal-indices.md
@@ -1,12 +1,12 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-migrate-data-internal.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-migrate-data-internal.html
 applies:
 applies_to:
   stack: ga
   deployment:
-    eck: unavailable 
+    eck: unavailable
     ess: ga
     ece: unavailable
   serverless: unavailable
@@ -49,7 +49,7 @@ To restore internal indices from a snapshot, the procedure is a bit different fr
 
 
 
-3. To restore internal {{es}} indices, you need to register the snapshot repository in `read-only` mode. 
+3. To restore internal {{es}} indices, you need to register the snapshot repository in `read-only` mode.
 
     First, add the authentication information for the repository to the {{ech}} keystore, following the steps for your cloud provider:
     * [AWS S3](../../deploy-manage/tools/snapshot-and-restore/ec-aws-custom-repository.md#ec-snapshot-secrets-keystore)

--- a/solutions/observability/apps.md
+++ b/solutions/observability/apps.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/application-and-service-monitoring.html
   - https://www.elastic.co/guide/en/observability/current/application-and-service-monitoring.html
 

--- a/solutions/observability/apps/act-on-data.md
+++ b/solutions/observability/apps/act-on-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-act-on-data.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-act-on-data.html
 

--- a/solutions/observability/apps/analyze-data-from-synthetic-monitors.md
+++ b/solutions/observability/apps/analyze-data-from-synthetic-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-analyze.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-analyze.html
 

--- a/solutions/observability/apps/application-performance-monitoring-apm.md
+++ b/solutions/observability/apps/application-performance-monitoring-apm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm.html
 ---

--- a/solutions/observability/apps/applications-ui-settings.md
+++ b/solutions/observability/apps/applications-ui-settings.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-settings-in-kibana.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-kibana-settings.html
 

--- a/solutions/observability/apps/collect-application-data.md
+++ b/solutions/observability/apps/collect-application-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-collect-application-data.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-send-data-to-elastic.html
 ---

--- a/solutions/observability/apps/collect-metrics.md
+++ b/solutions/observability/apps/collect-metrics.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-open-telemetry-collect-metrics.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-opentelemetry-collect-metrics.html
 ---

--- a/solutions/observability/apps/configure-apm-server.md
+++ b/solutions/observability/apps/configure-apm-server.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-manage-apm-settings.html
   - https://www.elastic.co/guide/en/observability/current/apm-configuring-howto-apm-server.html
 applies_to:

--- a/solutions/observability/apps/configure-individual-browser-monitors.md
+++ b/solutions/observability/apps/configure-individual-browser-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-monitor-use.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-monitor-use.html
 

--- a/solutions/observability/apps/configure-lightweight-monitors.md
+++ b/solutions/observability/apps/configure-lightweight-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-lightweight.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-lightweight.html
 ---

--- a/solutions/observability/apps/configure-synthetics-projects.md
+++ b/solutions/observability/apps/configure-synthetics-projects.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-configuration.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-configuration.html
 ---

--- a/solutions/observability/apps/create-apm-rules-alerts.md
+++ b/solutions/observability/apps/create-apm-rules-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-alerts.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-alerts.html
 

--- a/solutions/observability/apps/create-custom-links.md
+++ b/solutions/observability/apps/create-custom-links.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-custom-links.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-create-custom-links.html
 

--- a/solutions/observability/apps/create-monitors-in-synthetics-app.md
+++ b/solutions/observability/apps/create-monitors-in-synthetics-app.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-get-started-ui.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-get-started-ui.html
 

--- a/solutions/observability/apps/create-monitors-with-project-monitors.md
+++ b/solutions/observability/apps/create-monitors-with-project-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-get-started-project.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-get-started-project.html
 

--- a/solutions/observability/apps/dependencies.md
+++ b/solutions/observability/apps/dependencies.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-dependencies.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-dependencies.html
 ---

--- a/solutions/observability/apps/drill-down-into-data.md
+++ b/solutions/observability/apps/drill-down-into-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-ui-drill-down.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-ui-drill-down.html
 

--- a/solutions/observability/apps/elastic-apm-agents.md
+++ b/solutions/observability/apps/elastic-apm-agents.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-agents.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-elastic-apm-agents.html
 

--- a/solutions/observability/apps/errors-2.md
+++ b/solutions/observability/apps/errors-2.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-errors.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-errors.html
 ---

--- a/solutions/observability/apps/filter-application-data.md
+++ b/solutions/observability/apps/filter-application-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-filters.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-filter-your-data.html
 

--- a/solutions/observability/apps/filter-search-application-data.md
+++ b/solutions/observability/apps/filter-search-application-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-filter-and-search-data.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-filter-and-search-data.html
 

--- a/solutions/observability/apps/find-transaction-latency-failure-correlations.md
+++ b/solutions/observability/apps/find-transaction-latency-failure-correlations.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-correlations.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-find-transaction-latency-and-failure-correlations.html
 ---

--- a/solutions/observability/apps/get-started-with-apm.md
+++ b/solutions/observability/apps/get-started-with-apm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-getting-started-apm-server.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-get-started.html
 

--- a/solutions/observability/apps/get-started.md
+++ b/solutions/observability/apps/get-started.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-get-started.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-get-started.html
 ---

--- a/solutions/observability/apps/grant-users-access-to-secured-resources.md
+++ b/solutions/observability/apps/grant-users-access-to-secured-resources.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-feature-roles.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-feature-roles.html
 ---

--- a/solutions/observability/apps/infrastructure.md
+++ b/solutions/observability/apps/infrastructure.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-infrastructure.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-infrastructure.html
 ---

--- a/solutions/observability/apps/integrate-with-machine-learning.md
+++ b/solutions/observability/apps/integrate-with-machine-learning.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-machine-learning-integration.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-integrate-with-machine-learning.html
 ---

--- a/solutions/observability/apps/interpret-application-data.md
+++ b/solutions/observability/apps/interpret-application-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-interpret-data.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-interpret-data.html
 

--- a/solutions/observability/apps/learn-about-application-data-types.md
+++ b/solutions/observability/apps/learn-about-application-data-types.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-data-model.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-data-types.html
 ---

--- a/solutions/observability/apps/limitations.md
+++ b/solutions/observability/apps/limitations.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-open-telemetry-known-limitations.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-opentelemetry-limitations.html
 ---

--- a/solutions/observability/apps/logs.md
+++ b/solutions/observability/apps/logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-logs.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-logs.html
 ---

--- a/solutions/observability/apps/manage-data-retention.md
+++ b/solutions/observability/apps/manage-data-retention.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-manage-retention.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-manage-retention.html
 ---

--- a/solutions/observability/apps/manage-monitors.md
+++ b/solutions/observability/apps/manage-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-manage-monitors.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-manage-monitors.html
 ---

--- a/solutions/observability/apps/metrics-2.md
+++ b/solutions/observability/apps/metrics-2.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-metrics.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-metrics.html
 ---

--- a/solutions/observability/apps/monitor-resources-on-private-networks.md
+++ b/solutions/observability/apps/monitor-resources-on-private-networks.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-private-location.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-private-location.html
 ---

--- a/solutions/observability/apps/monitoring-aws-lambda-functions.md
+++ b/solutions/observability/apps/monitoring-aws-lambda-functions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-monitoring-aws-lambda.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-aws-lambda-functions.html
 

--- a/solutions/observability/apps/multi-factor-authentication-mfa-for-browser-monitors.md
+++ b/solutions/observability/apps/multi-factor-authentication-mfa-for-browser-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-mfa.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-mfa.html
 

--- a/solutions/observability/apps/observe-lambda-functions.md
+++ b/solutions/observability/apps/observe-lambda-functions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-lambda.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-observe-lambda-functions.html
 ---

--- a/solutions/observability/apps/overviews.md
+++ b/solutions/observability/apps/overviews.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-ui.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-ui-overview.html
 

--- a/solutions/observability/apps/reduce-storage.md
+++ b/solutions/observability/apps/reduce-storage.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-reduce-apm-storage.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-reduce-your-data-usage.html
 ---

--- a/solutions/observability/apps/resource-atrributes.md
+++ b/solutions/observability/apps/resource-atrributes.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-open-telemetry-resource-attributes.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-opentelemetry-resource-attributes.html
 applies_to:

--- a/solutions/observability/apps/scale-architect-synthetics-deployment.md
+++ b/solutions/observability/apps/scale-architect-synthetics-deployment.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-scale-and-architect.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-scale-and-architect.html
 

--- a/solutions/observability/apps/scripting-browser-monitors.md
+++ b/solutions/observability/apps/scripting-browser-monitors.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-journeys.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-journeys.html
 ---

--- a/solutions/observability/apps/service-map.md
+++ b/solutions/observability/apps/service-map.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-service-maps.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-service-map.html
 ---

--- a/solutions/observability/apps/service-overview.md
+++ b/solutions/observability/apps/service-overview.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-service-overview.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-service-overview.html
 ---

--- a/solutions/observability/apps/services.md
+++ b/solutions/observability/apps/services.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-services.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-services.html
 applies_to:

--- a/solutions/observability/apps/spans.md
+++ b/solutions/observability/apps/spans.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-data-model-spans.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-compress-spans.html
 ---

--- a/solutions/observability/apps/synthetic-monitoring.md
+++ b/solutions/observability/apps/synthetic-monitoring.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/monitor-uptime-synthetics.html
   - https://www.elastic.co/guide/en/serverless/current/observability-monitor-synthetics.html
 ---

--- a/solutions/observability/apps/synthetics-encryption-security.md
+++ b/solutions/observability/apps/synthetics-encryption-security.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-security-encryption.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-security-encryption.html
 ---

--- a/solutions/observability/apps/trace-sample-timeline.md
+++ b/solutions/observability/apps/trace-sample-timeline.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-spans.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-trace-sample-timeline.html
 ---

--- a/solutions/observability/apps/traces-2.md
+++ b/solutions/observability/apps/traces-2.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-traces.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-traces.html
 ---

--- a/solutions/observability/apps/traces.md
+++ b/solutions/observability/apps/traces.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-distributed-tracing.html
   - https://www.elastic.co/guide/en/observability/current/apm-data-model-traces.html
 ---

--- a/solutions/observability/apps/track-deployments-with-annotations.md
+++ b/solutions/observability/apps/track-deployments-with-annotations.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-transactions-annotations.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-track-deployments-with-annotations.html
 

--- a/solutions/observability/apps/transaction-sampling.md
+++ b/solutions/observability/apps/transaction-sampling.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-sampling.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-transaction-sampling.html
 ---

--- a/solutions/observability/apps/transactions-2.md
+++ b/solutions/observability/apps/transactions-2.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-transactions.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-transactions.html
 ---

--- a/solutions/observability/apps/upstream-opentelemetry-collectors-language-sdks.md
+++ b/solutions/observability/apps/upstream-opentelemetry-collectors-language-sdks.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-open-telemetry-direct.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-opentelemetry-opentelemetry-native-support.html
 ---

--- a/solutions/observability/apps/use-advanced-queries-on-application-data.md
+++ b/solutions/observability/apps/use-advanced-queries-on-application-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-advanced-queries.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-query-your-data.html
 

--- a/solutions/observability/apps/use-apm-securely.md
+++ b/solutions/observability/apps/use-apm-securely.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-securing-apm-server.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-keep-data-secure.html
 ---

--- a/solutions/observability/apps/use-opentelemetry-with-apm.md
+++ b/solutions/observability/apps/use-opentelemetry-with-apm.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "OpenTelemetry"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-agents-opentelemetry.html
   - https://www.elastic.co/guide/en/observability/current/apm-open-telemetry.html
 ---

--- a/solutions/observability/apps/use-synthetics-cli.md
+++ b/solutions/observability/apps/use-synthetics-cli.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-command-reference.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-command-reference.html
 

--- a/solutions/observability/apps/use-synthetics-recorder.md
+++ b/solutions/observability/apps/use-synthetics-recorder.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-recorder.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-recorder.html
 ---

--- a/solutions/observability/apps/view-analyze-data.md
+++ b/solutions/observability/apps/view-analyze-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-view-and-analyze-data.html
   - https://www.elastic.co/guide/en/serverless/current/observability-apm-view-and-analyze-traces.html
 ---

--- a/solutions/observability/apps/work-with-params-secrets.md
+++ b/solutions/observability/apps/work-with-params-secrets.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-params-secrets.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-params-secrets.html
 ---

--- a/solutions/observability/apps/write-synthetic-test.md
+++ b/solutions/observability/apps/write-synthetic-test.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/synthetics-create-test.html
   - https://www.elastic.co/guide/en/serverless/current/observability-synthetics-create-test.html
 ---

--- a/solutions/observability/data-set-quality-monitoring.md
+++ b/solutions/observability/data-set-quality-monitoring.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/monitor-datasets.html
   - https://www.elastic.co/guide/en/serverless/current/observability-monitor-datasets.html
 applies_to:

--- a/solutions/observability/get-started.md
+++ b/solutions/observability/get-started.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/observability-get-started.html
   - https://www.elastic.co/guide/en/observability/current/observability-get-started.html
   - https://www.elastic.co/guide/en/observability/current/index.html

--- a/solutions/observability/get-started/quickstart-collect-data-with-aws-firehose.md
+++ b/solutions/observability/get-started/quickstart-collect-data-with-aws-firehose.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/collect-data-with-aws-firehose.html
   - https://www.elastic.co/guide/en/serverless/current/collect-data-with-aws-firehose.html
 applies_to:

--- a/solutions/observability/get-started/quickstart-monitor-hosts-with-opentelemetry.md
+++ b/solutions/observability/get-started/quickstart-monitor-hosts-with-opentelemetry.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/quickstart-monitor-hosts-with-otel.html
   - https://www.elastic.co/guide/en/serverless/current/quickstart-monitor-hosts-with-otel.html
 applies_to:

--- a/solutions/observability/get-started/quickstart-monitor-kubernetes-cluster-with-elastic-agent.md
+++ b/solutions/observability/get-started/quickstart-monitor-kubernetes-cluster-with-elastic-agent.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/observability-quickstarts-k8s-logs-metrics.html
   - https://www.elastic.co/guide/en/observability/current/monitor-k8s-logs-metrics-with-elastic-agent.html
 applies_to:

--- a/solutions/observability/get-started/quickstart-unified-kubernetes-observability-with-elastic-distributions-of-opentelemetry-edot.md
+++ b/solutions/observability/get-started/quickstart-unified-kubernetes-observability-with-elastic-distributions-of-opentelemetry-edot.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/monitor-k8s-otel-edot.html
   - https://www.elastic.co/guide/en/serverless/current/monitor-k8s-otel-edot.html
 applies_to:

--- a/solutions/observability/get-started/what-is-elastic-observability.md
+++ b/solutions/observability/get-started/what-is-elastic-observability.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/observability-introduction.html
   - https://www.elastic.co/guide/en/serverless/current/observability-serverless-observability-overview.html
 

--- a/solutions/observability/incident-management.md
+++ b/solutions/observability/incident-management.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/incident-management.html
   - https://www.elastic.co/guide/en/serverless/current/incident-management.html
 applies_to:
-  stack: 
-  serverless: 
+  stack:
+  serverless:
 ---
 
 # Incident management [incident-management]

--- a/solutions/observability/incident-management/aggregation-options.md
+++ b/solutions/observability/incident-management/aggregation-options.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/aggregation-options.html
   - https://www.elastic.co/guide/en/serverless/current/observability-aggregationOptions.html
 ---

--- a/solutions/observability/incident-management/alerting.md
+++ b/solutions/observability/incident-management/alerting.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/create-alerts.html
   - https://www.elastic.co/guide/en/serverless/current/observability-alerting.html
 ---

--- a/solutions/observability/incident-management/cases.md
+++ b/solutions/observability/incident-management/cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/create-cases.html
   - https://www.elastic.co/guide/en/serverless/current/observability-cases.html
 ---

--- a/solutions/observability/incident-management/configure-case-settings.md
+++ b/solutions/observability/incident-management/configure-case-settings.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/manage-cases-settings.html
   - https://www.elastic.co/guide/en/serverless/current/observability-case-settings.html
 ---

--- a/solutions/observability/incident-management/create-an-apm-anomaly-rule.md
+++ b/solutions/observability/incident-management/create-an-apm-anomaly-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-anomaly-rule.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-anomaly-alert-rule.html
 

--- a/solutions/observability/incident-management/create-an-error-count-threshold-rule.md
+++ b/solutions/observability/incident-management/create-an-error-count-threshold-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-error-count-threshold-rule.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-error-count-threshold-alert-rule.html
 

--- a/solutions/observability/incident-management/create-an-inventory-rule.md
+++ b/solutions/observability/incident-management/create-an-inventory-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/infrastructure-threshold-alert.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-inventory-threshold-alert-rule.html
 

--- a/solutions/observability/incident-management/create-an-slo-burn-rate-rule.md
+++ b/solutions/observability/incident-management/create-an-slo-burn-rate-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/slo-burn-rate-alert.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-slo-burn-rate-alert-rule.html
 

--- a/solutions/observability/incident-management/create-an-slo.md
+++ b/solutions/observability/incident-management/create-an-slo.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/slo-create.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-an-slo.html
 ---

--- a/solutions/observability/incident-management/create-custom-threshold-rule.md
+++ b/solutions/observability/incident-management/create-custom-threshold-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/custom-threshold-alert.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-custom-threshold-alert-rule.html
 
@@ -127,7 +127,7 @@ The behavior of the alert depends on whether any **group alerts by** fields are 
     * If `host-1` reports CPU usage below the threshold of 80%, the alert status is changed to recovered.
 
 
-::::{note} 
+::::{note}
 **How to untrack decommissioned hosts**
 
 If a host (for example, `host-1`) is decommissioned, you probably no longer want to see "no data" alerts about it. To mark an alert as untracked: Go to the Alerts table, click the ![More actions](/solutions/images/serverless-boxesHorizontal.svg "") icon to expand the "More actions" menu, and click *Mark as untracked*.

--- a/solutions/observability/incident-management/create-failed-transaction-rate-threshold-rule.md
+++ b/solutions/observability/incident-management/create-failed-transaction-rate-threshold-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-failed-transaction-rate-threshold-rule.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-failed-transaction-rate-threshold-alert-rule.html
 

--- a/solutions/observability/incident-management/create-latency-threshold-rule.md
+++ b/solutions/observability/incident-management/create-latency-threshold-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/apm-latency-threshold-rule.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-latency-threshold-alert-rule.html
 

--- a/solutions/observability/incident-management/create-manage-cases.md
+++ b/solutions/observability/incident-management/create-manage-cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/manage-cases.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-a-new-case.html
 ---

--- a/solutions/observability/incident-management/create-manage-rules.md
+++ b/solutions/observability/incident-management/create-manage-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/create-alerts-rules.html
   - https://www.elastic.co/guide/en/serverless/current/observability-create-manage-rules.html
 ---

--- a/solutions/observability/incident-management/create-monitor-status-rule.md
+++ b/solutions/observability/incident-management/create-monitor-status-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/monitor-status-alert.html
   - https://www.elastic.co/guide/en/serverless/current/observability-monitor-status-alert.html
 

--- a/solutions/observability/incident-management/rate-aggregation.md
+++ b/solutions/observability/incident-management/rate-aggregation.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/rate-aggregation.html
   - https://www.elastic.co/guide/en/serverless/current/observability-rateAggregation.html
 ---

--- a/solutions/observability/incident-management/service-level-objectives-slos.md
+++ b/solutions/observability/incident-management/service-level-objectives-slos.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/slo.html
   - https://www.elastic.co/guide/en/serverless/current/observability-slos.html
 ---

--- a/solutions/observability/incident-management/triage-slo-burn-rate-breaches.md
+++ b/solutions/observability/incident-management/triage-slo-burn-rate-breaches.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/triage-slo-burn-rate-breaches.html
   - https://www.elastic.co/guide/en/serverless/current/observability-triage-slo-burn-rate-breaches.html
 

--- a/solutions/observability/incident-management/triage-threshold-breaches.md
+++ b/solutions/observability/incident-management/triage-threshold-breaches.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/triage-threshold-breaches.html
   - https://www.elastic.co/guide/en/serverless/current/observability-triage-threshold-breaches.html
 

--- a/solutions/observability/incident-management/view-alerts.md
+++ b/solutions/observability/incident-management/view-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/view-observability-alerts.html
   - https://www.elastic.co/guide/en/serverless/current/observability-view-alerts.html
 ---

--- a/solutions/observability/infra-and-hosts.md
+++ b/solutions/observability/infra-and-hosts.md
@@ -1,12 +1,12 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/infrastructure-and-host-monitoring-intro.html
   - https://www.elastic.co/guide/en/serverless/current/infrastructure-and-host-monitoring-intro.html
 
 navigation_title: "Infrastructure and hosts"
 applies_to:
-  stack: 
-  serverless: 
+  stack:
+  serverless:
 ---
 
 # Infrastructure and host monitoring [infrastructure-and-host-monitoring-intro]

--- a/solutions/observability/infra-and-hosts/analyze-compare-hosts.md
+++ b/solutions/observability/infra-and-hosts/analyze-compare-hosts.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/analyze-hosts.html
   - https://www.elastic.co/guide/en/serverless/current/observability-analyze-hosts.html
 applies_to:
-  stack: 
+  stack:
   serverless:
 ---
 
@@ -21,7 +21,7 @@ The **Hosts** page provides a metrics-driven view of your infrastructure backed 
 
 To access the **Hosts** page in:
 - **Elastic Stack,** find **Infrastructure** in the main menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
-- **Serverless,** go to **Infrastructure → Hosts** in your Elastic Observability Serverless project. 
+- **Serverless,** go to **Infrastructure → Hosts** in your Elastic Observability Serverless project.
 
 :::{image} /solutions/images/serverless-hosts.png
 :alt: Screenshot of the Hosts page

--- a/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md
+++ b/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/monitor-infrastructure-and-hosts.html
   - https://www.elastic.co/guide/en/serverless/current/observability-infrastructure-monitoring.html
 applies_to:
-  stack: 
-  serverless: 
+  stack:
+  serverless:
 ---
 
 # Analyze infrastructure and host metrics [observability-infrastructure-monitoring]

--- a/solutions/observability/infra-and-hosts/configure-settings.md
+++ b/solutions/observability/infra-and-hosts/configure-settings.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/configure-settings.html
   - https://www.elastic.co/guide/en/serverless/current/observability-configure-intra-settings.html
 ---

--- a/solutions/observability/infra-and-hosts/detect-metric-anomalies.md
+++ b/solutions/observability/infra-and-hosts/detect-metric-anomalies.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/inspect-metric-anomalies.html
   - https://www.elastic.co/guide/en/serverless/current/observability-detect-metric-anomalies.html
 applies_to:

--- a/solutions/observability/infra-and-hosts/get-started-with-system-metrics.md
+++ b/solutions/observability/infra-and-hosts/get-started-with-system-metrics.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-metrics-get-started.html
   - https://www.elastic.co/guide/en/serverless/current/observability-get-started-with-metrics.html
 applies_to:

--- a/solutions/observability/infra-and-hosts/understanding-no-results-found-message.md
+++ b/solutions/observability/infra-and-hosts/understanding-no-results-found-message.md
@@ -1,9 +1,9 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/handle-no-results-found-message.html
   - https://www.elastic.co/guide/en/serverless/current/observability-handle-no-results-found-message.html
 applies_to:
-  stack: 
+  stack:
 ---
 
 # Understanding "no results found" message [observability-handle-no-results-found-message]

--- a/solutions/observability/infra-and-hosts/view-infrastructure-metrics-by-resource-type.md
+++ b/solutions/observability/infra-and-hosts/view-infrastructure-metrics-by-resource-type.md
@@ -1,10 +1,10 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/view-infrastructure-metrics.html
   - https://www.elastic.co/guide/en/serverless/current/observability-view-infrastructure-metrics.html
 applies_to:
-  stack: 
-  serverless: 
+  stack:
+  serverless:
 ---
 
 # View infrastructure metrics by resource type [observability-view-infrastructure-metrics]

--- a/solutions/observability/logs.md
+++ b/solutions/observability/logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-checklist.html
   - https://www.elastic.co/guide/en/serverless/current/observability-log-monitoring.html
 

--- a/solutions/observability/logs/add-service-name-to-logs.md
+++ b/solutions/observability/logs/add-service-name-to-logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/add-logs-service-name.html
   - https://www.elastic.co/guide/en/serverless/current/observability-add-logs-service-name.html
 applies_to:

--- a/solutions/observability/logs/apm-agent-log-sending.md
+++ b/solutions/observability/logs/apm-agent-log-sending.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-send-application.html
   - https://www.elastic.co/guide/en/serverless/current/observability-send-application-logs.html
 applies_to:

--- a/solutions/observability/logs/ecs-formatted-application-logs.md
+++ b/solutions/observability/logs/ecs-formatted-application-logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-ecs-application.html
   - https://www.elastic.co/guide/en/serverless/current/observability-ecs-application-logs.html
 applies_to:

--- a/solutions/observability/logs/filter-aggregate-logs.md
+++ b/solutions/observability/logs/filter-aggregate-logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-filter-and-aggregate.html
   - https://www.elastic.co/guide/en/serverless/current/observability-filter-and-aggregate-logs.html
 applies_to:

--- a/solutions/observability/logs/logs-explorer.md
+++ b/solutions/observability/logs/logs-explorer.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/explore-logs.html
   - https://www.elastic.co/guide/en/serverless/current/observability-discover-and-explore-logs.html
 applies_to:

--- a/solutions/observability/logs/parse-route-logs.md
+++ b/solutions/observability/logs/parse-route-logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-parse.html
   - https://www.elastic.co/guide/en/serverless/current/observability-parse-log-data.html
 applies_to:

--- a/solutions/observability/logs/plaintext-application-logs.md
+++ b/solutions/observability/logs/plaintext-application-logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-plaintext.html
   - https://www.elastic.co/guide/en/serverless/current/observability-plaintext-application-logs.html
 applies_to:

--- a/solutions/observability/logs/stream-any-log-file.md
+++ b/solutions/observability/logs/stream-any-log-file.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/logs-stream.html
   - https://www.elastic.co/guide/en/serverless/current/observability-stream-log-files.html
 applies_to:

--- a/solutions/observability/logs/stream-application-logs.md
+++ b/solutions/observability/logs/stream-application-logs.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/application-logs.html
   - https://www.elastic.co/guide/en/serverless/current/observability-correlate-application-logs.html
 applies_to:

--- a/solutions/search/apis-and-tools.md
+++ b/solutions/search/apis-and-tools.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-dev-tools.html
   - https://www.elastic.co/guide/en/enterprise-search/current/search-ui.html
 applies_to:

--- a/solutions/search/full-text/search-with-synonyms.md
+++ b/solutions/search/full-text/search-with-synonyms.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-with-synonyms.html
 applies_to:
   stack:

--- a/solutions/search/get-started.md
+++ b/solutions/search/get-started.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-get-started.html
 applies_to:
@@ -16,8 +16,8 @@ applies_to:
 Building a search experience with {{es}} requires a number of fundamental implementation decisions:
 
 1. [**Deployment**](/deploy-manage/index.md): Where will you run Elastic?
-1. [**Ingestion**](ingest-for-search.md): What tools will you use to get your content into {{es}}? 
-1. [**Search approaches**](search-approaches.md): What search techniques and algorithms will you use to find relevant results? 
+1. [**Ingestion**](ingest-for-search.md): What tools will you use to get your content into {{es}}?
+1. [**Search approaches**](search-approaches.md): What search techniques and algorithms will you use to find relevant results?
 1. **Implementation tools**: How will you write queries and interact with {{es}}?
    - Which programming language client matches your application?
    - Which API endpoints and [query language(s)](querying-for-search.md) will you use to express your search logic?

--- a/solutions/search/ingest-for-search.md
+++ b/solutions/search/ingest-for-search.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/es-ingestion-overview.html#es-ingestion-overview-general-content
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-ingest-data-through-api.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-pipeline-search.html
@@ -27,7 +27,7 @@ There are several methods to ingest data into {{es}} for search use cases. Choos
 If you just want to do a quick test, you can load [sample data](/manage-data/ingest/sample-data.md) into your {{es}} cluster using the UI.
 ::::
 
-## Use APIs [es-ingestion-overview-apis] 
+## Use APIs [es-ingestion-overview-apis]
 
 You can use the [`_bulk` API](https://www.elastic.co/docs/api/doc/elasticsearch/v8/group/endpoint-document) to add data to your {{es}} indices, using any HTTP client, including the [{{es}} client libraries](/solutions/search/site-or-app/clients.md).
 

--- a/solutions/search/querydsl-full-text-filter-tutorial.md
+++ b/solutions/search/querydsl-full-text-filter-tutorial.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/full-text-filter-tutorial.html
 navigation_title: "Search and filter with Query DSL"
 applies_to:

--- a/solutions/search/querying-for-search.md
+++ b/solutions/search/querying-for-search.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-your-data.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-search-your-data.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-search-your-data-the-search-api.html
@@ -11,7 +11,7 @@ applies_to:
 
 # Build your search queries
 
-::::{tip} 
+::::{tip}
 This page is focused on the search use case. For an overview of Elastic query languages for every use case, refer to the [complete overview](/explore-analyze/query-filter/languages.md).
 ::::
 
@@ -25,11 +25,11 @@ Once you know which [search approaches](search-approaches.md) you need to use, y
 
 These query languages are complementary, not mutually exclusive. You can use different query languages for different parts of your application, based on your specific needs. This flexibility allows you to gradually adopt newer interfaces as your requirements evolve.
 
-::::{note} 
+::::{note}
 You can use the [{{es}} REST APIs](https://www.elastic.co/docs/api/doc/elasticsearch) to search your data using any HTTP client, including the [{{es}} client libraries](site-or-app/clients.md), or directly in [Console](/explore-analyze/query-filter/tools/console.md). You can also run searches using [Discover](/explore-analyze/discover.md) in the UI.
 ::::
 
 
-::::{tip} 
+::::{tip}
 Try our hands-on [quick start tutorials](api-quickstarts.md) to get started, or check out our [Python notebooks](https://github.com/elastic/elasticsearch-labs/tree/main/notebooks#readme).
 ::::

--- a/solutions/search/rag/playground.md
+++ b/solutions/search/rag/playground.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-playground.html
   - https://www.elastic.co/guide/en/kibana/current/playground.html
 applies_to:

--- a/solutions/search/retrievers-examples.md
+++ b/solutions/search/retrievers-examples.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/master/retrievers-examples.html
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/_retrievers_examples.html
 applies_to:

--- a/solutions/search/retrievers-overview.md
+++ b/solutions/search/retrievers-overview.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/retrievers-overview.html
 applies_to:
   stack:

--- a/solutions/search/run-elasticsearch-locally.md
+++ b/solutions/search/run-elasticsearch-locally.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Run {{es}} locally"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html
 applies_to:
   stack:

--- a/solutions/search/search-connection-details.md
+++ b/solutions/search/search-connection-details.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Find connection details"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/search-space-connection-details.html
 applies_to:
   stack:

--- a/solutions/search/semantic-search.md
+++ b/solutions/search/semantic-search.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-reference-semantic-search.html
 applies_to:
@@ -68,7 +68,7 @@ Refer to [vector queries and field types](vector.md#vector-queries-and-field-typ
 ### Blogs
 
 - [{{es}} new semantic_text mapping: Simplifying semantic search](https://www.elastic.co/search-labs/blog/semantic-search-simplified-semantic-text)
-- [GA information for `semantic_text`](https://www.elastic.co/search-labs/blog/semantic-text-ga) 
+- [GA information for `semantic_text`](https://www.elastic.co/search-labs/blog/semantic-text-ga)
 - [Introducing ELSER: Elastic's AI model for semantic search](https://www.elastic.co/blog/may-2023-launch-sparse-encoder-ai-model)
 - [How to get the best of lexical and AI-powered search with Elastic's vector database](https://www.elastic.co/blog/lexical-ai-powered-search-elastic-vector-database)
 - Information retrieval blog series:

--- a/solutions/search/serverless-elasticsearch-get-started.md
+++ b/solutions/search/serverless-elasticsearch-get-started.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Get started on Serverless"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-connecting-to-es-serverless-endpoint.html
 applies_to:
   serverless:

--- a/solutions/search/site-or-app/clients.md
+++ b/solutions/search/site-or-app/clients.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/client/index.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-clients.html
 applies_to:

--- a/solutions/search/vector/knn.md
+++ b/solutions/search/vector/knn.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-knn-search.html
 applies_to:
@@ -544,7 +544,7 @@ In our data set, the only document with the file type of `png` has a vector of `
 ### Nested kNN Search [nested-knn-search]
 
 It is common for text to exceed a particular model’s token limit and requires chunking before building the embeddings for individual chunks. When using [`nested`](elasticsearch://reference/elasticsearch/mapping-reference/nested.md) with [`dense_vector`](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md), you can achieve nearest passage retrieval without copying top-level document metadata.
-Note that nested kNN queries only support [score_mode](elasticsearch://reference/query-languages/query-dsl/query-dsl-nested-query.md#nested-top-level-params)=`max`. 
+Note that nested kNN queries only support [score_mode](elasticsearch://reference/query-languages/query-dsl/query-dsl-nested-query.md#nested-top-level-params)=`max`.
 
 Here is a simple passage vectors index that stores vectors and some top-level metadata for filtering.
 

--- a/solutions/security/advanced-entity-analytics.md
+++ b/solutions/security/advanced-entity-analytics.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/advanced-entity-analytics-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-advanced-entity-analytics.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/advanced-behavioral-detections.md
+++ b/solutions/security/advanced-entity-analytics/advanced-behavioral-detections.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/advanced-behavioral-detections.html
   - https://www.elastic.co/guide/en/serverless/current/security-advanced-behavioral-detections.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/anomaly-detection.md
+++ b/solutions/security/advanced-entity-analytics/anomaly-detection.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/machine-learning.html
   - https://www.elastic.co/guide/en/serverless/current/security-machine-learning.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/asset-criticality.md
+++ b/solutions/security/advanced-entity-analytics/asset-criticality.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/asset-criticality.html
   - https://www.elastic.co/guide/en/serverless/current/security-asset-criticality.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/behavioral-detection-use-cases.md
+++ b/solutions/security/advanced-entity-analytics/behavioral-detection-use-cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/behavioral-detection-use-cases.html
   - https://www.elastic.co/guide/en/serverless/current/security-behavioral-detection-use-cases.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/entity-risk-scoring-requirements.md
+++ b/solutions/security/advanced-entity-analytics/entity-risk-scoring-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ers-requirements.html
   - https://www.elastic.co/guide/en/serverless/current/security-ers-requirements.html
 applies_to:
@@ -114,4 +114,4 @@ To turn on the entity store, you need the following:
 
 #### {{kib}}
 
-**All** for the **Security** and **Saved Objects Management** features 
+**All** for the **Security** and **Saved Objects Management** features

--- a/solutions/security/advanced-entity-analytics/entity-risk-scoring.md
+++ b/solutions/security/advanced-entity-analytics/entity-risk-scoring.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/entity-risk-scoring.html
   - https://www.elastic.co/guide/en/serverless/current/security-entity-risk-scoring.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/machine-learning-job-rule-requirements.md
+++ b/solutions/security/advanced-entity-analytics/machine-learning-job-rule-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ml-requirements.html
   - https://www.elastic.co/guide/en/serverless/current/security-ml-requirements.html
 applies_to:
@@ -22,7 +22,7 @@ Additionally, to configure [alert suppression](/solutions/security/detect-and-al
 
 For more information, go to [Set up {{ml-features}}](/explore-analyze/machine-learning/setting-up-machine-learning.md).
 
-::::{important} 
+::::{important}
 Some roles (for example, in {{stack}}, the `machine_learning_admin` and `machine_learning_user` built-in roles) give access to the results of *all* {{anomaly-jobs}}, irrespective of whether the user has access to the source indices. Likewise, a user who has full or read-only access to {{ml-features}} within a given {{kib}} space can view the results of *all* {{anomaly-jobs}} that are visible in that space. You must carefully consider who is given these roles and feature privileges; {{anomaly-job}} results may propagate field values that contain sensitive information from the source indices to the results.
 
 ::::

--- a/solutions/security/advanced-entity-analytics/optimizing-anomaly-results.md
+++ b/solutions/security/advanced-entity-analytics/optimizing-anomaly-results.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/tuning-anomaly-results.html
   - https://www.elastic.co/guide/en/serverless/current/security-tuning-anomaly-results.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/turn-on-risk-scoring-engine.md
+++ b/solutions/security/advanced-entity-analytics/turn-on-risk-scoring-engine.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/turn-on-risk-engine.html
   - https://www.elastic.co/guide/en/serverless/current/security-turn-on-risk-engine.html
 applies_to:

--- a/solutions/security/advanced-entity-analytics/view-analyze-risk-score-data.md
+++ b/solutions/security/advanced-entity-analytics/view-analyze-risk-score-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/analyze-risk-score-data.html
   - https://www.elastic.co/guide/en/serverless/current/security-analyze-risk-score-data.html
 applies_to:

--- a/solutions/security/ai.md
+++ b/solutions/security/ai.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ai-for-security.html
   - https://www.elastic.co/guide/en/serverless/current/security-ai-for-security.html
 applies_to:

--- a/solutions/security/ai/ai-assistant-knowledge-base.md
+++ b/solutions/security/ai/ai-assistant-knowledge-base.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ai-assistant-knowledge-base.html
   - https://www.elastic.co/guide/en/serverless/current/ai-assistant-knowledge-base.html
 applies_to:

--- a/solutions/security/ai/ai-assistant.md
+++ b/solutions/security/ai/ai-assistant.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/security-assistant.html
   - https://www.elastic.co/guide/en/serverless/current/security-ai-assistant.html
 applies_to:
@@ -117,7 +117,7 @@ AI Assistant can remember particular information you tell it to remember. For ex
 
 ## Configure AI Assistant [configure-ai-assistant]
 
-To adjust AI Assistant's settings from the chat window, click the **More** (three dots) button in the upper-right. 
+To adjust AI Assistant's settings from the chat window, click the **More** (three dots) button in the upper-right.
 
 ::::{image} ../../../images/security-attack-discovery-more-popover.png
 :alt: AI Assistant's more options popover

--- a/solutions/security/ai/attack-discovery.md
+++ b/solutions/security/ai/attack-discovery.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/attack-discovery.html
   - https://www.elastic.co/guide/en/serverless/current/attack-discovery.html
 applies_to:
@@ -51,7 +51,7 @@ Attack Discovery is designed for use with alerts based on data that complies wit
 
 1.  Select an alert with some of the non-ECS fields you want to analyze, and go to its details flyout. From here, use the **Chat** button to open AI Assistant.
 2.  At the bottom of the chat window, the alert's information appears. Click **Edit** to open the anonymization window to this alert's fields.
-3.  Search for and select the non-ECS fields you want Attack Discovery to analyze. Set them to **Allowed**. 
+3.  Search for and select the non-ECS fields you want Attack Discovery to analyze. Set them to **Allowed**.
 
 The selected fields can now be analyzed the next time you run Attack Discovery.
 :::

--- a/solutions/security/ai/connect-to-amazon-bedrock.md
+++ b/solutions/security/ai/connect-to-amazon-bedrock.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/assistant-connect-to-bedrock.html
   - https://www.elastic.co/guide/en/serverless/current/security-connect-to-bedrock.html
 applies_to:

--- a/solutions/security/ai/connect-to-azure-openai.md
+++ b/solutions/security/ai/connect-to-azure-openai.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/assistant-connect-to-azure-openai.html
   - https://www.elastic.co/guide/en/serverless/current/security-connect-to-azure-openai.html
 applies_to:

--- a/solutions/security/ai/connect-to-google-vertex.md
+++ b/solutions/security/ai/connect-to-google-vertex.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/connect-to-vertex.html
   - https://www.elastic.co/guide/en/serverless/current/security-connect-to-google-vertex.html
 applies_to:

--- a/solutions/security/ai/connect-to-openai.md
+++ b/solutions/security/ai/connect-to-openai.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/assistant-connect-to-openai.html
   - https://www.elastic.co/guide/en/serverless/current/security-connect-to-openai.html
 applies_to:

--- a/solutions/security/ai/connect-to-own-local-llm.md
+++ b/solutions/security/ai/connect-to-own-local-llm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/connect-to-byo-llm.html
   - https://www.elastic.co/guide/en/serverless/current/connect-to-byo-llm.html
 applies_to:

--- a/solutions/security/ai/generate-customize-learn-about-esorql-queries.md
+++ b/solutions/security/ai/generate-customize-learn-about-esorql-queries.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/esql-queries-assistant.html
   - https://www.elastic.co/guide/en/serverless/current/security-ai-assistant-esql-queries.html
 applies_to:

--- a/solutions/security/ai/identify-investigate-document-threats.md
+++ b/solutions/security/ai/identify-investigate-document-threats.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/attack-discovery-ai-assistant-incident-reporting.html
   - https://www.elastic.co/guide/en/serverless/current/security-ai-usecase-incident-reporting.html
 applies_to:

--- a/solutions/security/ai/large-language-model-performance-matrix.md
+++ b/solutions/security/ai/large-language-model-performance-matrix.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/llm-performance-matrix.html
   - https://www.elastic.co/guide/en/serverless/current/security-llm-performance-matrix.html
 applies_to:

--- a/solutions/security/ai/set-up-connectors-for-large-language-models-llm.md
+++ b/solutions/security/ai/set-up-connectors-for-large-language-models-llm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/llm-connector-guides.html
   - https://www.elastic.co/guide/en/serverless/current/security-llm-connector-guides.html
 applies_to:
@@ -10,14 +10,14 @@ applies_to:
 
 # Enable large language model (LLM) access
 
-{{elastic-sec}} uses large language models (LLMs) for some of its advanced analytics features. To enable these features, you can connect to Elastic LLM, a third-party LLM provider, or a custom local LLM. 
+{{elastic-sec}} uses large language models (LLMs) for some of its advanced analytics features. To enable these features, you can connect to Elastic LLM, a third-party LLM provider, or a custom local LLM.
 
 :::{important}
 Different LLMs have varying performance when used to power different features and use-cases. For more information about how various models perform on different tasks in {{elastic-sec}}, refer to the [Large language model performance matrix](/solutions/security/ai/large-language-model-performance-matrix.md).
 :::
 
 
-## Connect to Elastic LLM 
+## Connect to Elastic LLM
 
 Elastic LLM is enabled by default for any user with the necessary Elastic license or subscription. To use it:
 

--- a/solutions/security/ai/triage-alerts.md
+++ b/solutions/security/ai/triage-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/assistant-triage.html
   - https://www.elastic.co/guide/en/serverless/current/security-triage-alerts-with-elastic-ai-assistant.html
 applies_to:

--- a/solutions/security/ai/use-cases.md
+++ b/solutions/security/ai/use-cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/assistant-use-cases.html
   - https://www.elastic.co/guide/en/serverless/current/security-ai-use-cases.html
 applies_to:

--- a/solutions/security/cloud.md
+++ b/solutions/security/cloud.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cloud-native-security-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-cloud-native-security-overview.html
 applies_to:
@@ -15,28 +15,28 @@ Elastic Security for Cloud helps you improve your cloud security posture by comp
 This page describes what each solution does and provides links to more information.
 
 
-## Cloud Security Posture Management (CSPM) [_cloud_security_posture_management_cspm] 
+## Cloud Security Posture Management (CSPM) [_cloud_security_posture_management_cspm]
 
 Discovers and evaluates the services in your cloud environment — like storage, compute, IAM, and more — against configuration security guidelines defined by the [Center for Internet Security](https://www.cisecurity.org/) (CIS) to help you identify and remediate risks that could undermine the confidentiality, integrity, and availability of your cloud data.
 
 [Read the CSPM docs](/solutions/security/cloud/cloud-security-posture-management.md).
 
 
-## Kubernetes Security Posture Management (KSPM) [_kubernetes_security_posture_management_kspm] 
+## Kubernetes Security Posture Management (KSPM) [_kubernetes_security_posture_management_kspm]
 
 Allows you to identify configuration risks in the various components that make up your Kubernetes cluster. It does this by evaluating your Kubernetes clusters against secure configuration guidelines defined by the Center for Internet Security (CIS) and generating findings with step-by-step instructions for remediating potential security risks.
 
 [Read the KSPM docs](/solutions/security/cloud/kubernetes-security-posture-management.md).
 
 
-## Cloud Native Vulnerability Management (CNVM) [_cloud_native_vulnerability_management_cnvm] 
+## Cloud Native Vulnerability Management (CNVM) [_cloud_native_vulnerability_management_cnvm]
 
 Scans your cloud workloads for known vulnerabilities. When it finds a vulnerability, it supports your risk assessment by quickly providing information such as the vulnerability’s CVSS and severity, which software versions it affects, and whether a fix is available.
 
 [Read the CNVM docs](/solutions/security/cloud/cloud-native-vulnerability-management.md).
 
 
-## Cloud Workload Protection for VMs [_cloud_workload_protection_for_vms] 
+## Cloud Workload Protection for VMs [_cloud_workload_protection_for_vms]
 
 Helps you monitor and protect your Linux VMs. It uses {{elastic-defend}} to instantly detect and prevent malicious behavior and malware, and captures workload telemetry data for process, file, and network activity. You can use this data with Elastic’s out-of-the-box detection rules and {{ml}} models. These detections generate alerts that quickly help you identify and remediate threats.
 

--- a/solutions/security/cloud/benchmarks.md
+++ b/solutions/security/cloud/benchmarks.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-benchmark-rules.html
   - https://www.elastic.co/guide/en/serverless/current/security-benchmark-rules.html
   - https://www.elastic.co/guide/en/serverless/current/security-benchmark-rules-kspm.html

--- a/solutions/security/cloud/capture-environment-variables.md
+++ b/solutions/security/cloud/capture-environment-variables.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/environment-variable-capture.html
   - https://www.elastic.co/guide/en/serverless/current/security-environment-variable-capture.html
 applies_to:

--- a/solutions/security/cloud/cloud-native-vulnerability-management.md
+++ b/solutions/security/cloud/cloud-native-vulnerability-management.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/vuln-management-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-vuln-management-overview.html
 applies_to:
@@ -14,7 +14,7 @@ Elastic’s Cloud Native Vulnerability Management (CNVM) feature helps you ident
 
 Setup uses infrastructure as code. For instructions, refer to [Get started with Cloud Native Vulnerability Management](/solutions/security/cloud/get-started-with-cnvm.md).
 
-::::{note} 
+::::{note}
 CNVM currently only supports AWS EC2 Linux workloads.
 ::::
 
@@ -29,7 +29,7 @@ CNVM currently only supports AWS EC2 Linux workloads.
 
 
 
-## How CNVM works [vuln-management-overview-how-it-works] 
+## How CNVM works [vuln-management-overview-how-it-works]
 
 During setup, you will use an infrastructure as code provisioning template to create a new virtual machine (VM) in the cloud region you wish to scan. This VM installs {{agent}} and the Cloud Native Vulnerability Management (CNVM) integration, and conducts all vulnerability scanning.
 
@@ -37,7 +37,7 @@ The CNVM integration uses [Trivy](https://github.com/aquasecurity/trivy), a comp
 
 The scanning process begins immediately upon deployment, then repeats every twenty-four hours. After each scan, the integration sends the discovered vulnerabilities to {{es}}, where they appear in the **Vulnerabilities** tab of the [Findings page](/solutions/security/cloud/findings-page-3.md).
 
-::::{note} 
+::::{note}
 Environments with more VMs take longer to scan.
 ::::
 

--- a/solutions/security/cloud/cloud-security-posture-management.md
+++ b/solutions/security/cloud/cloud-security-posture-management.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm.html
 applies_to:
@@ -22,7 +22,7 @@ This feature currently supports agentless and agent-based deployments on Amazon 
 
 ::::
 
-## How CSPM works [cspm-how-it-works] 
+## How CSPM works [cspm-how-it-works]
 
 Using the read-only credentials you will provide during the setup process, it will evaluate the configuration of resources in your environment every 24 hours. After each evaluation, the integration sends findings to Elastic. A high-level summary of the findings appears on the [Cloud Security Posture dashboard](/solutions/security/dashboards/cloud-security-posture-dashboard.md), and detailed findings appear on the [Findings page](/solutions/security/cloud/findings-page-2.md).
 

--- a/solutions/security/cloud/cloud-workload-protection-for-vms.md
+++ b/solutions/security/cloud/cloud-workload-protection-for-vms.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cloud-workload-protection.html
   - https://www.elastic.co/guide/en/serverless/current/security-cloud-workload-protection.html
 applies_to:

--- a/solutions/security/cloud/cspm-frequently-asked-questions-faq.md
+++ b/solutions/security/cloud/cspm-frequently-asked-questions-faq.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-security-posture-faq.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-security-posture-faq.html
   - https://www.elastic.co/guide/en/serverless/current/security-posture-faq.html

--- a/solutions/security/cloud/cspm-privilege-requirements.md
+++ b/solutions/security/cloud/cspm-privilege-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-required-permissions.html
   - https://www.elastic.co/guide/en/serverless/current/cspm-required-permissions.html
 applies_to:

--- a/solutions/security/cloud/findings-page-2.md
+++ b/solutions/security/cloud/findings-page-2.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/findings-page.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-findings-page-kspm-kspm.html
 applies_to:
@@ -31,9 +31,9 @@ By default, the Findings page lists all findings, without grouping or filtering.
 
 ### Group findings [_group_findings_2]
 
-Click **Group findings by** to group your data by a field. Select one of the suggested fields or **Custom field** to choose your own. You can select up to three group fields at once. 
+Click **Group findings by** to group your data by a field. Select one of the suggested fields or **Custom field** to choose your own. You can select up to three group fields at once.
 
-* When grouping is turned on, click a group to expand it and examine all sub-groups or findings within that group. 
+* When grouping is turned on, click a group to expand it and examine all sub-groups or findings within that group.
 * To turn off grouping, click **Group findings by** and select **None**.
 
   ::::{note}

--- a/solutions/security/cloud/findings-page.md
+++ b/solutions/security/cloud/findings-page.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-findings-page.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-findings-page.html
 applies_to:
@@ -34,9 +34,9 @@ By default, the Findings page lists all findings, without grouping or filtering.
 
 ### Group findings [_group_findings]
 
-Click **Group findings by** to group your data by a field. Select one of the suggested fields or **Custom field** to choose your own. You can select up to three group fields at once. 
+Click **Group findings by** to group your data by a field. Select one of the suggested fields or **Custom field** to choose your own. You can select up to three group fields at once.
 
-* When grouping is turned on, click a group to expand it and examine all sub-groups or findings within that group. 
+* When grouping is turned on, click a group to expand it and examine all sub-groups or findings within that group.
 * To turn off grouping, click **Group findings by** and select **None**.
 
   ::::{note}

--- a/solutions/security/cloud/get-started-with-cnvm.md
+++ b/solutions/security/cloud/get-started-with-cnvm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/vuln-management-get-started.html
   - https://www.elastic.co/guide/en/serverless/current/security-vuln-management-get-started.html
 applies_to:

--- a/solutions/security/cloud/get-started-with-cspm-for-aws.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-aws.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-get-started.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-get-started.html
 applies_to:

--- a/solutions/security/cloud/get-started-with-cspm-for-azure.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-azure.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-get-started-azure.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-get-started-azure.html
 applies_to:

--- a/solutions/security/cloud/get-started-with-cspm-for-gcp.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-gcp.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cspm-get-started-gcp.html
   - https://www.elastic.co/guide/en/serverless/current/security-cspm-get-started-gcp.html
 applies_to:

--- a/solutions/security/cloud/get-started-with-kspm.md
+++ b/solutions/security/cloud/get-started-with-kspm.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/get-started-with-kspm.html
   - https://www.elastic.co/guide/en/serverless/current/security-get-started-with-kspm.html
 applies_to:

--- a/solutions/security/cloud/ingest-aws-security-hub-data.md
+++ b/solutions/security/cloud/ingest-aws-security-hub-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ingest-aws-securityhub-data.html
   - https://www.elastic.co/guide/en/serverless/current/ingest-aws-securityhub-data.html
 applies_to:
@@ -25,4 +25,3 @@ After you’ve completed these steps, AWS Security Hub data will appear on the M
 
 Any available findings data will also appear in the [Insights section](/solutions/security/detect-and-alert/view-detection-alert-details.md#insights-section) for related alerts. If alerts are present for a user or host that has findings data from AWS Security Hub, the findings will appear on the [entity details flyout](/solutions/security/advanced-entity-analytics/view-entity-details.md#entity-details-flyout).
 
- 

--- a/solutions/security/cloud/ingest-cncf-falco-data.md
+++ b/solutions/security/cloud/ingest-cncf-falco-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ingest-falco.html
   - https://www.elastic.co/guide/en/serverless/current/ingest-falco.html
 applies_to:

--- a/solutions/security/cloud/ingest-third-party-cloud-security-data.md
+++ b/solutions/security/cloud/ingest-third-party-cloud-security-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ingest-third-party-cloud-security-data.html
   - https://www.elastic.co/guide/en/serverless/current/ingest-third-party-cloud-security-data.html
 applies_to:
@@ -15,14 +15,14 @@ This section describes how to ingest cloud security data from third-party tools 
 You can ingest both third-party cloud workload protection data and third-party security posture and vulnerability data.
 
 
-## Ingest third-party workload protection data [_ingest_third_party_workload_protection_data] 
+## Ingest third-party workload protection data [_ingest_third_party_workload_protection_data]
 
 You can ingest third-party cloud security alerts into {{elastic-sec}} to view them on the [Alerts page](/solutions/security/advanced-entity-analytics/view-analyze-risk-score-data.md#alerts-page) and incorporate them into your triage and threat hunting workflows.
 
 * Learn to [ingest alerts from Sysdig Falco](/solutions/security/cloud/ingest-cncf-falco-data.md).
 
 
-## Ingest third-party security posture and vulnerability data [_ingest_third_party_security_posture_and_vulnerability_data] 
+## Ingest third-party security posture and vulnerability data [_ingest_third_party_security_posture_and_vulnerability_data]
 
 You can ingest third-party data into {{elastic-sec}} to review and investigate it alongside data collected by {{elastic-sec}}'s native cloud security integrations. Once ingested, cloud security posture and vulnerability data appears on the [Findings](/solutions/security/cloud/findings-page.md) page, on the [Cloud Posture dashboard](/solutions/security/dashboards/cloud-security-posture-dashboard.md), and in the [entity details](/solutions/security/advanced-entity-analytics/view-entity-details.md#entity-details-flyout) and [alert details](/solutions/security/detect-and-alert/view-detection-alert-details.md#insights-section) flyouts.
 

--- a/solutions/security/cloud/ingest-wiz-data.md
+++ b/solutions/security/cloud/ingest-wiz-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ingest-wiz-data.html
   - https://www.elastic.co/guide/en/serverless/current/ingest-wiz-data.html
 applies_to:
@@ -31,4 +31,4 @@ After you’ve completed these steps, Wiz data will appear on the [Misconfiguati
 :alt: Wiz data on the Findings page
 :::
 
-Any available findings data will also appear in the [Insights section](/solutions/security/detect-and-alert/view-detection-alert-details.md#insights-section) for related alerts. If alerts are present for a user or host that has findings data from Wiz, the findings will appear on the [entity details flyout](/solutions/security/advanced-entity-analytics/view-entity-details.md#entity-details-flyout). 
+Any available findings data will also appear in the [Insights section](/solutions/security/detect-and-alert/view-detection-alert-details.md#insights-section) for related alerts. If alerts are present for a user or host that has findings data from Wiz, the findings will appear on the [entity details flyout](/solutions/security/advanced-entity-analytics/view-entity-details.md#entity-details-flyout).

--- a/solutions/security/cloud/kubernetes-security-posture-management.md
+++ b/solutions/security/cloud/kubernetes-security-posture-management.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/kspm.html
   - https://www.elastic.co/guide/en/serverless/current/security-kspm.html
 applies_to:
@@ -18,7 +18,7 @@ applies_to:
 % - [ ] ./raw-migrated-files/docs-content/serverless/security-kspm.md
 
 
-## Overview [kspm-overview] 
+## Overview [kspm-overview]
 
 The Kubernetes Security Posture Management (KSPM) integration allows you to identify configuration risks in the various components that make up your Kubernetes cluster. It does this by evaluating your Kubernetes clusters against secure configuration guidelines defined by the Center for Internet Security (CIS) and generating findings with step-by-step instructions for remediating potential security risks.
 
@@ -32,14 +32,14 @@ This integration supports Amazon EKS and unmanaged Kubernetes clusters. For setu
 
 
 
-## How KSPM works [kspm-how-kspm-works] 
+## How KSPM works [kspm-how-kspm-works]
 
 1. When you add a KSPM integration, it generates a Kubernetes manifest. When applied to a cluster, the manifest deploys an {{agent}} as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset) to ensure all nodes are evaluated.
 2. Upon deployment, the integration immediately assesses the security posture of your Kubernetes resources. The evaluation process repeats every four hours.
 3. After each evaluation, the integration sends findings to {{es}}. Findings appear on the [Cloud Security Posture dashboard](/solutions/security/dashboards/cloud-security-posture-dashboard.md) and the [findings](/solutions/security/cloud/findings-page-2.md) page.
 
 
-## Use cases [kspm-use-cases] 
+## Use cases [kspm-use-cases]
 
 The KSPM integration helps you to:
 
@@ -48,7 +48,7 @@ The KSPM integration helps you to:
 * Identify risks in particular CIS benchmark sections
 
 
-### Identify and remediate failed findings [kspm-remediate-failed-findings] 
+### Identify and remediate failed findings [kspm-remediate-failed-findings]
 
 To identify and remediate failed failed findings:
 
@@ -57,13 +57,13 @@ To identify and remediate failed failed findings:
 3. Click a failed finding. The findings flyout opens.
 4. Follow the steps under **Remediation** to correct the misconfiguration.
 
-   ::::{note} 
+   ::::{note}
    Remediation steps typically include commands for you to execute. These sometimes contain placeholder values that you must replace before execution.
    ::::
 
 
 
-### Identify the most misconfigured Kubernetes resources [kspm-identify-misconfigured-resources] 
+### Identify the most misconfigured Kubernetes resources [kspm-identify-misconfigured-resources]
 
 To identify the Kubernetes resources generating the most failed findings:
 
@@ -72,7 +72,7 @@ To identify the Kubernetes resources generating the most failed findings:
 3. Click a resource ID to view the findings associated with that resource.
 
 
-### Identify configuration risks by CIS section [kspm-identify-config-risks-by-section] 
+### Identify configuration risks by CIS section [kspm-identify-config-risks-by-section]
 
 To identify risks in particular CIS sections:
 

--- a/solutions/security/cloud/security-posture-management-overview.md
+++ b/solutions/security/cloud/security-posture-management-overview.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/security-posture-management.html
   - https://www.elastic.co/guide/en/serverless/current/security-posture-management.html
 applies_to:

--- a/solutions/security/configure-elastic-defend.md
+++ b/solutions/security/configure-elastic-defend.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-protection-intro.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-protection-intro.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/configure-an-integration-policy-for-elastic-defend.md
+++ b/solutions/security/configure-elastic-defend/configure-an-integration-policy-for-elastic-defend.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html
   - https://www.elastic.co/guide/en/serverless/current/security-configure-endpoint-integration-policy.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint.md
+++ b/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Configure data volume"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-data-volume.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-data-volume.html
 applies_to:
@@ -12,7 +12,7 @@ applies_to:
 
 {{elastic-endpoint}}, the installed component that performs {{elastic-defend}}'s threat monitoring and prevention, is optimized to reduce data volume and CPU usage. You can disable or modify some of these optimizations by reconfiguring the following [advanced settings](configure-an-integration-policy-for-elastic-defend.md#adv-policy-settings) in the {{elastic-defend}} integration policy.
 
-::::{important} 
+::::{important}
 Modifying these advanced settings from their defaults will increase the volume of data that {{elastic-endpoint}} processes and ingests, and increase {{elastic-endpoint}}'s CPU usage. Make sure you’re aware of how these changes will affect your storage capabilities and performance.
 ::::
 
@@ -20,7 +20,7 @@ Modifying these advanced settings from their defaults will increase the volume o
 Each setting has several OS-specific variants, represented by `[linux|mac|windows]` in the names listed below. Use the variant relevant to your hosts' operating system (for example, `windows.advanced.events.deduplicate_network_events` to configure network event deduplication for Windows hosts).
 
 
-## Network event deduplication [network-event-deduplication] 
+## Network event deduplication [network-event-deduplication]
 
 When repeated network connections are detected from the same process, {{elastic-endpoint}} will not produce network events for subsequent connections. To disable or reduce deduplication of network events, use these advanced settings:
 
@@ -31,20 +31,20 @@ When repeated network connections are detected from the same process, {{elastic-
 :   Enter a transfer size threshold (in bytes) for events you want to deduplicate. Connections below the threshold are deduplicated, and connections above it are not deduplicated. This allows you to suppress repeated connections for smaller data transfers but always generate events for larger transfers. Default: `1048576` (1MB)
 
 
-## Data in `host.*` fields [host-fields] 
+## Data in `host.*` fields [host-fields]
 
 {{elastic-endpoint}} includes only a small subset of the data in the `host.*` fieldset in event documents. Full `host.*` information is still included in documents written to the `metrics-*` index pattern and in {{elastic-endpoint}} alerts. To override this behavior and include all `host.*` data for events, use this advanced setting:
 
 `[linux|mac|windows].advanced.set_extended_host_information`
 :   Enter `true` to include all `host.*` event data. Default: `false`
 
-::::{note} 
+::::{note}
 Users should take note of how a lack of some `host.*` information may affect their [event filters](../manage-elastic-defend/event-filters.md) or [Endpoint alert exceptions](../detect-and-alert/add-manage-exceptions.md#endpoint-rule-exceptions).
 ::::
 
 
 
-## Merged process and network events [merged-process-network] 
+## Merged process and network events [merged-process-network]
 
 {{elastic-endpoint}} merges process `create`/`terminate` events (Windows) and `fork`/`exec`/`end` events (macOS/Linux) when possible. This means short-lived processes only generate a single event containing the details from when the process terminated. {{elastic-endpoint}} also merges network `connection/termination` events (Windows/macOS/Linux) when possible for short-lived connections. To disable this behavior, use these advanced settings:
 
@@ -54,13 +54,13 @@ Users should take note of how a lack of some `host.*` information may affect the
 `[linux|mac|windows].advanced.events.aggregate_network`
 :   Enter `false` to disable merging of network events. Default: `true`
 
-::::{note} 
+::::{note}
 Merged events can affect the results of [event filters](../manage-elastic-defend/event-filters.md). Notably, for merged events, `event.action` is an array containing all actions merged into the single event, such as `event.action=[fork, exec, end]`. In that example, if your event filter omits all fork events (`event.action : fork`), it will also filter out all merged events that include a `fork` action. To prevent such issues, you’ll need to modify your event filters accordingly, or set the `[linux|mac|windows].advanced.events.aggregate_process` and `[linux|mac|windows].advanced.events.aggregate_network` advanced settings to `false` to prevent {{elastic-endpoint}} from merging events.
 ::::
 
 
 
-## MD5 and SHA-1 hashes [md5-sha1-hashes] 
+## MD5 and SHA-1 hashes [md5-sha1-hashes]
 
 {{elastic-endpoint}} does not report MD5 and SHA-1 hashes in event data by default. These will still be reported if any [trusted applications](../manage-elastic-defend/trusted-applications.md), [blocklist entries](../manage-elastic-defend/blocklist.md), [event filters](../manage-elastic-defend/event-filters.md), or [Endpoint exceptions](../detect-and-alert/add-manage-exceptions.md#endpoint-rule-exceptions) require them. To include these hashes in all event data, use these advanced settings:
 

--- a/solutions/security/configure-elastic-defend/configure-linux-file-system-monitoring.md
+++ b/solutions/security/configure-elastic-defend/configure-linux-file-system-monitoring.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/linux-file-monitoring.html
   - https://www.elastic.co/guide/en/serverless/current/security-linux-file-monitoring.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/configure-self-healing-rollback-for-windows-endpoints.md
+++ b/solutions/security/configure-elastic-defend/configure-self-healing-rollback-for-windows-endpoints.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/self-healing-rollback.html
   - https://www.elastic.co/guide/en/serverless/current/security-self-healing-rollback.html
 applies_to:
@@ -18,7 +18,7 @@ This can help contain the impact of malicious activity, as {{elastic-defend}} no
 :class: note
 * Self-healing rollback is only supported for Windows endpoints.
 * In {{stack}}, this feature requires a [Platinum or Enterprise subscription](https://www.elastic.co/pricing).
-* In {{serverless-short}}, this feature requires the Endpoint Protection Complete [project feature](/deploy-manage/deploy/elastic-cloud/project-settings.md). 
+* In {{serverless-short}}, this feature requires the Endpoint Protection Complete [project feature](/deploy-manage/deploy/elastic-cloud/project-settings.md).
 ::::
 
 

--- a/solutions/security/configure-elastic-defend/configure-updates-for-protection-artifacts.md
+++ b/solutions/security/configure-elastic-defend/configure-updates-for-protection-artifacts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/artifact-control.html
   - https://www.elastic.co/guide/en/serverless/current/security-protection-artifact-control.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/deploy-on-macos-with-mdm.md
+++ b/solutions/security/configure-elastic-defend/deploy-on-macos-with-mdm.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Deploy on macOS with MDM"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/deploy-with-mdm.html
   - https://www.elastic.co/guide/en/serverless/current/security-deploy-with-mdm.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/elastic-defend-feature-privileges.md
+++ b/solutions/security/configure-elastic-defend/elastic-defend-feature-privileges.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-management-req.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-management-req.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/elastic-defend-requirements.md
+++ b/solutions/security/configure-elastic-defend/elastic-defend-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/elastic-endpoint-deploy-reqs.html
   - https://www.elastic.co/guide/en/serverless/current/security-elastic-endpoint-deploy-reqs.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/enable-access-for-macos-monterey.md
+++ b/solutions/security/configure-elastic-defend/enable-access-for-macos-monterey.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/deploy-elastic-endpoint.html
   - https://www.elastic.co/guide/en/serverless/current/security-install-endpoint-manually.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/enable-access-for-macos-ventura-higher.md
+++ b/solutions/security/configure-elastic-defend/enable-access-for-macos-ventura-higher.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/deploy-elastic-endpoint-ven.html
   - https://www.elastic.co/guide/en/serverless/current/security-deploy-elastic-endpoint-ven.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/install-elastic-defend.md
+++ b/solutions/security/configure-elastic-defend/install-elastic-defend.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Install {{elastic-defend}}"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/install-endpoint.html
   - https://www.elastic.co/guide/en/serverless/current/security-install-edr.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/prevent-elastic-agent-uninstallation.md
+++ b/solutions/security/configure-elastic-defend/prevent-elastic-agent-uninstallation.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/agent-tamper-protection.html
   - https://www.elastic.co/guide/en/serverless/current/security-agent-tamper-protection.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/turn-off-diagnostic-data-for-elastic-defend.md
+++ b/solutions/security/configure-elastic-defend/turn-off-diagnostic-data-for-elastic-defend.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-diagnostic-data.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-diagnostic-data.html
 applies_to:

--- a/solutions/security/configure-elastic-defend/uninstall-elastic-agent.md
+++ b/solutions/security/configure-elastic-defend/uninstall-elastic-agent.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/uninstall-agent.html
   - https://www.elastic.co/guide/en/serverless/current/security-uninstall-agent.html
 applies_to:

--- a/solutions/security/dashboards.md
+++ b/solutions/security/dashboards.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/dashboards-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-dashboards-overview.html
 applies_to:

--- a/solutions/security/dashboards/cloud-native-vulnerability-management-dashboard.md
+++ b/solutions/security/dashboards/cloud-native-vulnerability-management-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/vuln-management-dashboard-dash.html
   - https://www.elastic.co/guide/en/serverless/current/security-vuln-management-dashboard-dash.html
   - https://www.elastic.co/guide/en/serverless/current/_cloud_native_vulnerability_management_dashboard.html

--- a/solutions/security/dashboards/cloud-security-posture-dashboard.md
+++ b/solutions/security/dashboards/cloud-security-posture-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cloud-posture-dashboard.html
   - https://www.elastic.co/guide/en/serverless/current/security-cloud-posture-dashboard-dash.html
   - https://www.elastic.co/guide/en/serverless/current/security-cloud-posture-dashboard-dash-cspm.html

--- a/solutions/security/dashboards/data-quality-dashboard.md
+++ b/solutions/security/dashboards/data-quality-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/data-quality-dash.html
   - https://www.elastic.co/guide/en/serverless/current/security-data-quality-dash.html
 applies_to:
@@ -26,7 +26,7 @@ Use the Data Quality dashboard to:
 
 
 ::::{note}
-* On {{serverless-short}} deployments, index `Size` data is not available. 
+* On {{serverless-short}} deployments, index `Size` data is not available.
 * The Data Quality dashboard doesn’t show data from cold or frozen [data tiers](/manage-data/lifecycle/data-tiers.md). It also doesn’t display data from remote clusters using cross-cluster search. To view data from another cluster, log in to that cluster’s {{kib}} instance.
 ::::
 

--- a/solutions/security/dashboards/detection-response-dashboard.md
+++ b/solutions/security/dashboards/detection-response-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/detection-response-dashboard.html
   - https://www.elastic.co/guide/en/serverless/current/security-detection-response-dashboard.html
 applies_to:

--- a/solutions/security/dashboards/detection-rule-monitoring-dashboard.md
+++ b/solutions/security/dashboards/detection-rule-monitoring-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/rule-monitoring-dashboard.html
   - https://www.elastic.co/guide/en/serverless/current/security-rule-monitoring-dashboard.html
 applies_to:

--- a/solutions/security/dashboards/entity-analytics-dashboard.md
+++ b/solutions/security/dashboards/entity-analytics-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/detection-entity-dashboard.html
   - https://www.elastic.co/guide/en/serverless/current/security-detection-entity-dashboard.html
 applies_to:
@@ -98,11 +98,11 @@ Displays service risk score data for your environment, including the total numbe
 :::
 
 
-Interact with the table to filter data, view more details, and take action: 
+Interact with the table to filter data, view more details, and take action:
 
-* Select the **Service risk level** menu to filter the chart by the selected level. 
+* Select the **Service risk level** menu to filter the chart by the selected level.
 * Click a service name link to open the service details flyout.
-* Hover over a service name link to display inline actions: **Add to timeline**, which adds the selected value to Timeline, and **Copy to Clipboard**, which copies the service name value for you to paste later. 
+* Hover over a service name link to display inline actions: **Add to timeline**, which adds the selected value to Timeline, and **Copy to Clipboard**, which copies the service name value for you to paste later.
 * Click the number link in the *Alerts* column to view the alerts on the Alerts page. Hover over the number and select **Investigate in timeline** (![Investigate in timeline icon](/solutions/images/security-timeline-button-osquery.png "title =20x20")) to launch Timeline with a query that includes the associated service name value.
 
 For more information about service risk scores, refer to [Entity risk scoring](/solutions/security/advanced-entity-analytics/entity-risk-scoring.md).

--- a/solutions/security/dashboards/overview-dashboard.md
+++ b/solutions/security/dashboards/overview-dashboard.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/overview-dashboard.html
   - https://www.elastic.co/guide/en/serverless/current/security-overview-dashboard.html
 applies_to:

--- a/solutions/security/detect-and-alert.md
+++ b/solutions/security/detect-and-alert.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/detection-engine-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-detection-engine-overview.html
 applies_to:
@@ -104,7 +104,7 @@ To learn how your rules and alerts are affected by using the [logsdb index mode]
 
 ## Manage rules as code [manage-rule-dac]
 
-Utilize the [Detection-as-Code](https://dac-reference.readthedocs.io/en/latest/dac_concept_and_workflows.html) (DaC) principles to externally manage your detection rules. 
+Utilize the [Detection-as-Code](https://dac-reference.readthedocs.io/en/latest/dac_concept_and_workflows.html) (DaC) principles to externally manage your detection rules.
 
 The {{elastic-sec}} Labs team uses the [detection-rules](https://github.com/elastic/detection-rules) repo to develop, test, and release {{elastic-sec}}'s[ prebuilt rules](https://github.com/elastic/detection-rules/tree/main/rules). The repo provides DaC features and allows you to customize settings to simplify the setup for managing user rules with the DaCe pipeline.
 

--- a/solutions/security/detect-and-alert/about-building-block-rules.md
+++ b/solutions/security/detect-and-alert/about-building-block-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/building-block-rule.html
   - https://www.elastic.co/guide/en/serverless/current/security-building-block-rules.html
 applies_to:

--- a/solutions/security/detect-and-alert/about-detection-rules.md
+++ b/solutions/security/detect-and-alert/about-detection-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/about-rules.html
   - https://www.elastic.co/guide/en/serverless/current/security-about-rules.html
 applies_to:

--- a/solutions/security/detect-and-alert/add-detection-alerts-to-cases.md
+++ b/solutions/security/detect-and-alert/add-detection-alerts-to-cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/signals-to-cases.html
   - https://www.elastic.co/guide/en/serverless/current/security-signals-to-cases.html
 applies_to:

--- a/solutions/security/detect-and-alert/add-manage-exceptions.md
+++ b/solutions/security/detect-and-alert/add-manage-exceptions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/add-exceptions.html
   - https://www.elastic.co/guide/en/serverless/current/security-add-exceptions.html
 applies_to:

--- a/solutions/security/detect-and-alert/create-detection-rule.md
+++ b/solutions/security/detect-and-alert/create-detection-rule.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/rules-ui-create.html
   - https://www.elastic.co/guide/en/serverless/current/security-rules-create.html
 applies_to:
@@ -85,9 +85,9 @@ Additional configuration is required for detection rules using cross-cluster sea
 ## Create a machine learning rule [create-ml-rule]
 
 ::::{admonition} Requirements
-To create or edit {{ml}} rules, you need: 
+To create or edit {{ml}} rules, you need:
 * The appropriate [{{stack}} subscription](https://www.elastic.co/pricing) or [{{serverless-short}} project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md).
-* The [`machine_learning_admin`](/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md) in {{stack}} or the appropriate [user role](/deploy-manage/users-roles/cloud-organization/user-roles.md) in {{serverless-short}}. 
+* The [`machine_learning_admin`](/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md) in {{stack}} or the appropriate [user role](/deploy-manage/users-roles/cloud-organization/user-roles.md) in {{serverless-short}}.
 * The selected {{ml}} job to be running for the rule to function correctly.
 
 ::::

--- a/solutions/security/detect-and-alert/create-manage-shared-exception-lists.md
+++ b/solutions/security/detect-and-alert/create-manage-shared-exception-lists.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/shared-exception-lists.html
   - https://www.elastic.co/guide/en/serverless/current/security-shared-exception-lists.html
 applies_to:

--- a/solutions/security/detect-and-alert/create-manage-value-lists.md
+++ b/solutions/security/detect-and-alert/create-manage-value-lists.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/value-lists-exceptions.html
   - https://www.elastic.co/guide/en/serverless/current/security-value-lists-exceptions.html
 applies_to:

--- a/solutions/security/detect-and-alert/detections-requirements.md
+++ b/solutions/security/detect-and-alert/detections-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/detections-permissions-section.html
   - https://www.elastic.co/guide/en/serverless/current/security-detections-requirements.html
 applies_to:

--- a/solutions/security/detect-and-alert/install-manage-elastic-prebuilt-rules.md
+++ b/solutions/security/detect-and-alert/install-manage-elastic-prebuilt-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/prebuilt-rules-management.html
   - https://www.elastic.co/guide/en/serverless/current/security-prebuilt-rules-management.html
 
@@ -23,7 +23,7 @@ Follow these guidelines to start using the {{security-app}}'s [prebuilt rules](s
 ::::{note}
 * Most prebuilt rules don’t start running by default. You can use the **Install and enable** option to start running rules as you install them, or first install the rules, then enable them manually. After installation, only a few prebuilt rules will be enabled by default, such as the Endpoint Security rule.
 
-* Without an [Enterprise subscription](https://www.elastic.co/pricing) subscription on {{stack}} or a [Complete project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md) subscription on {{serverless-short}}, you can't modify most settings on Elastic prebuilt rules. You must first duplicate them, then make your changes to the duplicated rules. Refer to [Select and duplicate all prebuilt rules](/solutions/security/detect-and-alert/install-manage-elastic-prebuilt-rules.md#select-all-prebuilt-rules) to learn more. 
+* Without an [Enterprise subscription](https://www.elastic.co/pricing) subscription on {{stack}} or a [Complete project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md) subscription on {{serverless-short}}, you can't modify most settings on Elastic prebuilt rules. You must first duplicate them, then make your changes to the duplicated rules. Refer to [Select and duplicate all prebuilt rules](/solutions/security/detect-and-alert/install-manage-elastic-prebuilt-rules.md#select-all-prebuilt-rules) to learn more.
 * On {{stack}}, automatic updates of Elastic prebuilt rules are supported for the current {{elastic-sec}} version and the latest three previous minor releases. For example, if you’re on {{elastic-sec}} 9.0, you’ll be able to use the Rules UI to update your prebuilt rules until {{elastic-sec}} 9.4 is released. After that point, you can still manually download and install updated prebuilt rules, but you must upgrade to the latest {{elastic-sec}} version to receive automatic updates.
 
 ::::
@@ -104,20 +104,20 @@ Without an [Enterprise subscription](https://www.elastic.co/pricing) subscriptio
 
 1. Find **Detection rules (SIEM)** in the navigation menu or by using the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. In the **Rules** table, select the **Elastic rules** filter.
-3. Select one or more rules, or click **Select all *x* rules** above the Rules table. 
+3. Select one or more rules, or click **Select all *x* rules** above the Rules table.
 4. Click **Bulk actions** → **Duplicate**.
 5. (Optional) Select whether to duplicate the rules' exceptions, then click **Duplicate**.
 
-You can then modify the duplicated rules and, if required, delete the prebuilt ones. 
+You can then modify the duplicated rules and, if required, delete the prebuilt ones.
 
 
 ## Update Elastic prebuilt rules [update-prebuilt-rules]
 
 ::::{important}
 
-The following steps are only applicable if you have a [Platinum](https://www.elastic.co/pricing) subscription  or lower on  {{stack}} or an [Essentials project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md) subscription on {{serverless-short}}. 
+The following steps are only applicable if you have a [Platinum](https://www.elastic.co/pricing) subscription  or lower on  {{stack}} or an [Essentials project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md) subscription on {{serverless-short}}.
 
-If you have an Enterprise subscription on {{stack}} or a Complete project tier subscription on {{serverless-short}}, follow the guidelines in [Update modified and unmodified Elastic prebuilt rules](/solutions/security/detect-and-alert/prebuilt-rules-update-modified-unmodified.md) instead. 
+If you have an Enterprise subscription on {{stack}} or a Complete project tier subscription on {{serverless-short}}, follow the guidelines in [Update modified and unmodified Elastic prebuilt rules](/solutions/security/detect-and-alert/prebuilt-rules-update-modified-unmodified.md) instead.
 ::::
 
 Elastic regularly updates prebuilt rules to optimize their performance and ensure they detect the latest threats and techniques. When updated versions are available for your installed prebuilt rules, the **Rule Updates** tab appears on the **Rules** page, allowing you to update your installed rules with the latest versions.

--- a/solutions/security/detect-and-alert/launch-timeline-from-investigation-guides.md
+++ b/solutions/security/detect-and-alert/launch-timeline-from-investigation-guides.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/interactive-investigation-guides.html
   - https://www.elastic.co/guide/en/serverless/current/security-interactive-investigation-guides.html
 applies_to:

--- a/solutions/security/detect-and-alert/manage-detection-alerts.md
+++ b/solutions/security/detect-and-alert/manage-detection-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/alerts-ui-manage.html
   - https://www.elastic.co/guide/en/serverless/current/security-alerts-manage.html
 applies_to:

--- a/solutions/security/detect-and-alert/manage-detection-rules.md
+++ b/solutions/security/detect-and-alert/manage-detection-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/rules-ui-management.html
   - https://www.elastic.co/guide/en/serverless/current/security-rules-ui-management.html
 applies_to:
@@ -64,9 +64,9 @@ For {{ml}} rules, an indicator icon (![Error icon from rules table](/solutions/i
 ## Modify existing rules settings [edit-rules-settings]
 
 ::::{admonition} Requirements
-* You can edit custom rules and bulk-modify them with any [{{stack}} subscription](https://www.elastic.co/pricing) or [{{serverless-short}} project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md). 
+* You can edit custom rules and bulk-modify them with any [{{stack}} subscription](https://www.elastic.co/pricing) or [{{serverless-short}} project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md).
 * You can edit [rule notifications](/solutions/security/detect-and-alert/create-detection-rule.md#rule-notifications) (notifications and response actions) for prebuilt rules with any {{stack}} subscription or {{serverless-short}} project tier.
-* You must have an [Enterprise subscription](https://www.elastic.co/pricing) {{stack}} or a [Complete project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md) subscription on {{serverless-short}} to edit all prebuilt rule settings (except for the **Author** and **License** fields) and bulk-modify them. 
+* You must have an [Enterprise subscription](https://www.elastic.co/pricing) {{stack}} or a [Complete project tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md) subscription on {{serverless-short}} to edit all prebuilt rule settings (except for the **Author** and **License** fields) and bulk-modify them.
 
 ::::
 
@@ -128,7 +128,7 @@ When duplicating a rule with exceptions, you can choose to duplicate the rule an
 
 
 
-## Run rules manually [manually-run-rules] 
+## Run rules manually [manually-run-rules]
 
 Manually run enabled rules for a specified period of time to deliberately test them, provide additional rule coverage, or fill gaps in rule executions.
 
@@ -212,18 +212,18 @@ The rules are exported to an `.ndjson` file.
 ### Import rules [impr=ort-rules-ui]
 
 1. Above the Rules table, click *Import rules*.
-2. In the Import rules modal: 
+2. In the Import rules modal:
 
-    1. Drag and drop the `.ndjson` file that contains the exported rules. 
+    1. Drag and drop the `.ndjson` file that contains the exported rules.
     2. (Optional) Select the appropriate options to overwrite existing data:
 
         * **Overwrite existing detection rules with conflicting "rule_id"**: Updates existing rules if they match the `rule_id` value of any rules in the import file. Configuration data included with the rules, such as actions, is also overwritten.
         * **Overwrite existing exception lists with conflicting "list_id"**: Replaces existing exception lists with exception lists from the import file if they have a matching `list_id` value.
         * **Overwrite existing connectors with conflicting action "id"**: Updates existing connectors if they match the `action id` value of any rule actions in the import file. Configuration data included with the actions is also overwritten.
 
-The imported rules are added to the Rules table. 
+The imported rules are added to the Rules table.
 
- 
+
 ## Confirm rule prerequisites [rule-prerequisites]
 
 Many detection rules are designed to work with specific [Elastic integrations](https://docs.elastic.co/en/integrations) and data fields. These prerequisites are identified in **Related integrations** and **Required fields** on a rule’s details page. **Related integrations** also displays each integration’s installation status and includes links for installing and configuring the listed integrations.
@@ -243,12 +243,12 @@ You can also check rules' related integrations in the **Installed Rules** and **
 :::
 
 ::::{tip}
-You can hide the **integrations** badge in the Rules tables by turning off the `securitySolution:showRelatedIntegrations` [advanced setting](/solutions/security/get-started/configure-advanced-settings.md#show-related-integrations). 
+You can hide the **integrations** badge in the Rules tables by turning off the `securitySolution:showRelatedIntegrations` [advanced setting](/solutions/security/get-started/configure-advanced-settings.md#show-related-integrations).
 ::::
 
 ## Manage rules as code [manage-rule-dac]
 
-Utilize the [Detection-as-Code](https://dac-reference.readthedocs.io/en/latest/dac_concept_and_workflows.html) (DaC) principles to externally manage your detection rules. 
+Utilize the [Detection-as-Code](https://dac-reference.readthedocs.io/en/latest/dac_concept_and_workflows.html) (DaC) principles to externally manage your detection rules.
 
 The {{elastic-sec}} Labs team uses the [detection-rules](https://github.com/elastic/detection-rules) repo to develop, test, and release {{elastic-sec}}'s[ prebuilt rules](https://github.com/elastic/detection-rules/tree/main/rules). The repo provides DaC features and allows you to customize settings to simplify the setup for managing user rules with the DaCe pipeline.
 

--- a/solutions/security/detect-and-alert/mitre-attandckr-coverage.md
+++ b/solutions/security/detect-and-alert/mitre-attandckr-coverage.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/rules-coverage.html
   - https://www.elastic.co/guide/en/serverless/current/security-rules-coverage.html
 applies_to:

--- a/solutions/security/detect-and-alert/monitor-rule-executions.md
+++ b/solutions/security/detect-and-alert/monitor-rule-executions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/alerts-ui-monitor.html
   - https://www.elastic.co/guide/en/serverless/current/security-alerts-ui-monitor.html
 applies_to:
@@ -37,17 +37,17 @@ To sort the rules list, click any column header. To sort in descending order, cl
 
 For detailed information on a rule, the alerts it generated, and associated errors, click on its name in the table. This also allows you to perform the same actions that are available on the [**Installed Rules** tab](manage-detection-rules.md), such as modifying or deleting rules, activating or deactivating rules, exporting or importing rules, and duplicating prebuilt rules.
 
-For information about rule execution gaps (which are periods of time when a rule didn't run), use the panel above the table. The time filter on the left allows you to select a time range for viewing gap data. The **Total rules with gaps:** field tells you how many rules have unfilled or partially filled gaps within the selected time range. The **Only rules with gaps** filter on the right lets you only display rules with unfilled or partially filled gaps. 
+For information about rule execution gaps (which are periods of time when a rule didn't run), use the panel above the table. The time filter on the left allows you to select a time range for viewing gap data. The **Total rules with gaps:** field tells you how many rules have unfilled or partially filled gaps within the selected time range. The **Only rules with gaps** filter on the right lets you only display rules with unfilled or partially filled gaps.
 
 Within the table, the **Last Gap (if any)** column conveys how long the most recent gap for a rule lasted. The **Unfilled gaps duration** column shows whether a rule still has gaps and provides a total sum of the remaining unfilled or partially filled gaps. The total sum can change based on the time range that you select in the panel above the table. If a rule has no gaps, the columns display a dash (`––`).
 
-::::{tip} 
+::::{tip}
 For a detailed view of a rule's gaps, go to the **Execution results** tab and check the [Gaps table](/solutions/security/detect-and-alert/monitor-rule-executions.md#gaps-table).
 ::::
 
 ## Execution results tab [rule-execution-logs]
 
-From the **Execution results** tab, you can access the rule’s execution log, monitor and address gaps in a rule's execution schedule, and check manual runs for the rule. To find the tab, click the rule's name to open its details, then scroll down. 
+From the **Execution results** tab, you can access the rule’s execution log, monitor and address gaps in a rule's execution schedule, and check manual runs for the rule. To find the tab, click the rule's name to open its details, then scroll down.
 
 ### Execution log table [execution-log-table]
 
@@ -91,7 +91,7 @@ Gaps in rule executions are periods of time where a rule didn’t run. They can 
 Refer to the [Troubleshoot gaps](../../../troubleshoot/security/detection-rules.md#troubleshoot-gaps) section for strategies for avoiding gaps.
 ::::
 
-Use the information in the Gaps table to assess the scope and severity of rule execution gaps. To control what's shown in the table, you can filter the table by gap status, select a time range for viewing gap data, and sort multiple columns. 
+Use the information in the Gaps table to assess the scope and severity of rule execution gaps. To control what's shown in the table, you can filter the table by gap status, select a time range for viewing gap data, and sort multiple columns.
 
 :::{image} /solutions/images/security-gaps-table.png
 :alt: Gaps table on the rule execution results tab
@@ -103,20 +103,20 @@ The Gaps table has the following columns:
 * **Status**: The current state of the gap. It can be `Filled`, `Partially filled`, or `Unfilled`.
 * **Detected at**: The date and time the gap was first discovered.
 * **Manual fill tasks**: The status of the manual run that’s filling the gap. For more details about the manual run, refer to its entry in the [Manual runs table](/solutions/security/detect-and-alert/monitor-rule-executions.md#manual-runs-table).
-* **Event time covered**: How much progress the manual run has made filling the gap. 
+* **Event time covered**: How much progress the manual run has made filling the gap.
 
-    ::::{note} 
+    ::::{note}
     If you stop a manual run that's hasn't finished filling a gap, the gap’s status will be set to `Partially filled`. To fill the remaining gap, you can select the **Fill remaining gap** action or [manually run](/solutions/security/detect-and-alert/manage-detection-rules.md#manually-run-rules) the rule over the gap's time frame.
     ::::
 
-* **Range**: When the gap started and ended. 
+* **Range**: When the gap started and ended.
 * **Total gap duration**: How long the gap lasted.
 * **Actions**: The actions that you can take for the gap. They can be **Fill gap** (starts a manual run to fill the gap) or **Fill remaining gap** (starts a manual run that fills the leftover portion of the gap).
 
 
 ### Manual runs table [manual-runs-table]
 
-You can [manually run](/solutions/security/detect-and-alert/manage-detection-rules.md#manually-run-rules) enabled rules for a specified period of time to deliberately test them, provide additional rule coverage, or fill gaps in rule executions. Each manual run can produce multiple rule executions, depending on the time range of the run and the rule's execution schedule. 
+You can [manually run](/solutions/security/detect-and-alert/manage-detection-rules.md#manually-run-rules) enabled rules for a specified period of time to deliberately test them, provide additional rule coverage, or fill gaps in rule executions. Each manual run can produce multiple rule executions, depending on the time range of the run and the rule's execution schedule.
 
 ::::{note}
 Manual runs are executed with low priority and limited concurrency, meaning they might take longer to complete. This can be especially apparent for rules requiring multiple executions.
@@ -127,13 +127,13 @@ The Manual runs table tracks manual rule executions and provides important detai
 * The total number of rule executions that the manual run will produce and how many are failing, pending, running, and completed.
 * When the manual run started and the time range that it will cover.
 
-    ::::{note} 
+    ::::{note}
     To stop an active run, go to the appropriate row in the table and click **Stop run** in the **Actions** column. Completed rule executions for each manual run are logged in the Execution log table.
     ::::
 
 * The status of each manual run:
 
-    * `Pending`: The rule is not yet running. 
+    * `Pending`: The rule is not yet running.
     * `Running`: The rule is executing during the time range you specified. Some rule types, such as indicator match rules, can take longer to run.
     * `Error`: The rule's configuration is preventing it from running correctly. For example, the rule's conditions cannot be validated.
 

--- a/solutions/security/detect-and-alert/query-alert-indices.md
+++ b/solutions/security/detect-and-alert/query-alert-indices.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/query-alert-indices.html
   - https://www.elastic.co/guide/en/serverless/current/security-query-alert-indices.html
 applies_to:

--- a/solutions/security/detect-and-alert/reduce-notifications-alerts.md
+++ b/solutions/security/detect-and-alert/reduce-notifications-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/reduce-notifications-alerts.html
   - https://www.elastic.co/guide/en/serverless/current/security-reduce-notifications-alerts.html
 applies_to:

--- a/solutions/security/detect-and-alert/rule-exceptions.md
+++ b/solutions/security/detect-and-alert/rule-exceptions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/detections-ui-exceptions.html
   - https://www.elastic.co/guide/en/serverless/current/security-rule-exceptions.html
 applies_to:

--- a/solutions/security/detect-and-alert/suppress-detection-alerts.md
+++ b/solutions/security/detect-and-alert/suppress-detection-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/alert-suppression.html
   - https://www.elastic.co/guide/en/serverless/current/security-alert-suppression.html
 applies_to:

--- a/solutions/security/detect-and-alert/tune-detection-rules.md
+++ b/solutions/security/detect-and-alert/tune-detection-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/tuning-detection-signals.html
   - https://www.elastic.co/guide/en/serverless/current/security-tune-detection-signals.html
 applies_to:

--- a/solutions/security/detect-and-alert/using-logsdb-index-mode-with-elastic-security.md
+++ b/solutions/security/detect-and-alert/using-logsdb-index-mode-with-elastic-security.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/detections-logsdb-index-mode-impact.html
   - https://www.elastic.co/guide/en/serverless/current/detections-logsdb-index-mode-impact.html
 applies_to:
@@ -23,7 +23,7 @@ When the `_source` is reconstructed, [modifications](elasticsearch://reference/e
 
 Continue reading to find out how this affects specific {{elastic-sec}} components.
 
-::::{note} 
+::::{note}
 The following statement applies to {{stack}} users only:
 
 Logsdb is not recommended for {{elastic-sec}} at this time. Users must fully understand and accept the documented changes to detection alert documents (see below), and ensure their deployment has excess hot data tier CPU resource capacity before enabling logsdb mode, as logsdb mode requires additional CPU resources during the ingest/indexing process. Enabling logsdb without sufficient hot data tier CPU may result in data ingestion backups and/or security detection rule timeouts and errors.

--- a/solutions/security/detect-and-alert/view-detection-alert-details.md
+++ b/solutions/security/detect-and-alert/view-detection-alert-details.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/view-alert-details.html
   - https://www.elastic.co/guide/en/serverless/current/security-view-alert-details.html
 applies_to:

--- a/solutions/security/detect-and-alert/visualize-detection-alerts.md
+++ b/solutions/security/detect-and-alert/visualize-detection-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/visualize-alerts.html
   - https://www.elastic.co/guide/en/serverless/current/security-visualize-alerts.html
 applies_to:

--- a/solutions/security/endpoint-response-actions.md
+++ b/solutions/security/endpoint-response-actions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/response-actions.html
   - https://www.elastic.co/guide/en/serverless/current/security-response-actions.html
 applies_to:

--- a/solutions/security/endpoint-response-actions/automated-response-actions.md
+++ b/solutions/security/endpoint-response-actions/automated-response-actions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/automated-response-actions.html
   - https://www.elastic.co/guide/en/serverless/current/security-automated-response-actions.html
 applies_to:

--- a/solutions/security/endpoint-response-actions/configure-third-party-response-actions.md
+++ b/solutions/security/endpoint-response-actions/configure-third-party-response-actions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/response-actions-config.html
   - https://www.elastic.co/guide/en/serverless/current/security-response-actions-config.html
 applies_to:

--- a/solutions/security/endpoint-response-actions/isolate-host.md
+++ b/solutions/security/endpoint-response-actions/isolate-host.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/host-isolation-ov.html
   - https://www.elastic.co/guide/en/serverless/current/security-isolate-host.html
 applies_to:

--- a/solutions/security/endpoint-response-actions/response-actions-history.md
+++ b/solutions/security/endpoint-response-actions/response-actions-history.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/response-actions-history.html
   - https://www.elastic.co/guide/en/serverless/current/security-response-actions-history.html
 applies_to:

--- a/solutions/security/endpoint-response-actions/third-party-response-actions.md
+++ b/solutions/security/endpoint-response-actions/third-party-response-actions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/third-party-actions.html
   - https://www.elastic.co/guide/en/serverless/current/security-third-party-actions.html
 applies_to:

--- a/solutions/security/explore.md
+++ b/solutions/security/explore.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/sec-explore-intro.html
   - https://www.elastic.co/guide/en/serverless/current/security-explore-your-data.html
 applies_to:

--- a/solutions/security/explore/configure-network-map-data.md
+++ b/solutions/security/explore/configure-network-map-data.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/conf-map-ui.html
   - https://www.elastic.co/guide/en/serverless/current/security-conf-map-ui.html
 applies_to:

--- a/solutions/security/explore/hosts-page.md
+++ b/solutions/security/explore/hosts-page.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/hosts-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-hosts-overview.html
 applies_to:

--- a/solutions/security/explore/network-page.md
+++ b/solutions/security/explore/network-page.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/network-page-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-network-page-overview.html
 applies_to:

--- a/solutions/security/explore/users-page.md
+++ b/solutions/security/explore/users-page.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/users-page.html
   - https://www.elastic.co/guide/en/serverless/current/security-users-page.html
 applies_to:

--- a/solutions/security/get-started/agentless-integrations.md
+++ b/solutions/security/get-started/agentless-integrations.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/agentless-integrations.html
   - https://www.elastic.co/guide/en/serverless/current/security-agentless-integrations.html
 applies_to:

--- a/solutions/security/get-started/automatic-import.md
+++ b/solutions/security/get-started/automatic-import.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/automatic-import.html
   - https://www.elastic.co/guide/en/serverless/current/security-automatic-import.html
 applies_to:
@@ -21,7 +21,7 @@ Click [here](https://elastic.navattic.com/automatic-import) to access an interac
 
 ::::{admonition} Requirements
 
-* A working [LLM connector](/solutions/security/ai/set-up-connectors-for-large-language-models-llm.md). 
+* A working [LLM connector](/solutions/security/ai/set-up-connectors-for-large-language-models-llm.md).
 * {{stack}} users: An [Enterprise](https://www.elastic.co/pricing) subscription.
 * {{serverless-short}} users: a [Security Analytics Complete subscription](/deploy-manage/deploy/elastic-cloud/project-settings.md).
 * A sample of the data you want to import.
@@ -29,7 +29,7 @@ Click [here](https://elastic.navattic.com/automatic-import) to access an interac
 ::::
 
 ::::{admonition} Notes on sample data
-To use Automatic Import, you must provide a sample of the data you wish to import. An LLM will process that sample and automatically create an integration suitable for processing the data represented by the sample. **Any structured or unstructured format is acceptable, including but not limited to JSON, NDJSON, CSV, Syslog.** 
+To use Automatic Import, you must provide a sample of the data you wish to import. An LLM will process that sample and automatically create an integration suitable for processing the data represented by the sample. **Any structured or unstructured format is acceptable, including but not limited to JSON, NDJSON, CSV, Syslog.**
 
 * You can upload a sample of arbitrary size. The LLM will detect its format and select up to 100 documents for detailed analysis.
 * The more variety in your sample, the more accurate the pipeline will be. For best results, include a wide range of unique log entries in your sample instead of repeating similar logs.

--- a/solutions/security/get-started/configure-advanced-settings.md
+++ b/solutions/security/get-started/configure-advanced-settings.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/advanced-settings.html
   - https://www.elastic.co/guide/en/serverless/current/security-advanced-settings.html
 applies_to:

--- a/solutions/security/get-started/create-runtime-fields-in-elastic-security.md
+++ b/solutions/security/get-started/create-runtime-fields-in-elastic-security.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/runtime-fields.html
   - https://www.elastic.co/guide/en/serverless/current/security-runtime-fields.html
 applies_to:

--- a/solutions/security/get-started/data-views-elastic-security.md
+++ b/solutions/security/get-started/data-views-elastic-security.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/data-views-in-sec.html
   - https://www.elastic.co/guide/en/serverless/current/security-data-views-in-sec.html
 applies_to:

--- a/solutions/security/get-started/elastic-security-requirements.md
+++ b/solutions/security/get-started/elastic-security-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/sec-requirements.html
   - https://www.elastic.co/guide/en/serverless/current/security-requirements-overview.html
 applies_to:

--- a/solutions/security/get-started/elastic-security-ui.md
+++ b/solutions/security/get-started/elastic-security-ui.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/es-ui-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-ui.html
 applies_to:

--- a/solutions/security/get-started/enable-threat-intelligence-integrations.md
+++ b/solutions/security/get-started/enable-threat-intelligence-integrations.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html
   - https://www.elastic.co/guide/en/serverless/current/security-threat-intelligence.html
 applies_to:

--- a/solutions/security/get-started/ingest-data-to-elastic-security.md
+++ b/solutions/security/get-started/ingest-data-to-elastic-security.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/ingest-data.html
   - https://www.elastic.co/guide/en/serverless/current/security-ingest-data.html
 applies_to:

--- a/solutions/security/get-started/spaces-elastic-security.md
+++ b/solutions/security/get-started/spaces-elastic-security.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/security-spaces.html
   - https://www.elastic.co/guide/en/serverless/current/security-spaces.html
 applies_to:
@@ -14,7 +14,7 @@ applies_to:
 
 For example, if you create a `SOC_prod` space in which you load and activate all the {{elastic-sec}} prebuilt detection rules, these rules and any detection alerts they generate will be accessible only when visiting the {{security-app}} in the `SOC_prod` space. If you then create a new `SOC_dev` space, you’ll notice that no detection rules or alerts are present. Any rules subsequently loaded or created here will be private to the `SOC_dev` space, and they will run independently of those in the `SOC_prod` space.
 
-::::{note} 
+::::{note}
 By default, alerts created by detection rules are stored in {{es}} indices under the `.alerts-security.alerts-<space-name>` index pattern, and they may be accessed by any user with role privileges to access those {{es}} indices. In our example above, any user with {{es}} privileges to access `.alerts-security.alerts-SOC_prod` will be able to view `SOC_prod` alerts from within {{es}} and other {{kib}} apps such as Discover.
 
 To ensure that detection alert data remains private to the space in which it was created, ensure that the roles assigned to your {{elastic-sec}} users include {{es}} privileges that limit their access to alerts within their space’s alerts index.

--- a/solutions/security/investigate.md
+++ b/solutions/security/investigate.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/investigations-tools.html
   - https://www.elastic.co/guide/en/serverless/current/security-investigate-events.html
 applies_to:

--- a/solutions/security/investigate/add-osquery-response-actions.md
+++ b/solutions/security/investigate/add-osquery-response-actions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/osquery-response-action.html
   - https://www.elastic.co/guide/en/serverless/current/security-osquery-response-action.html
 applies_to:

--- a/solutions/security/investigate/cases-requirements.md
+++ b/solutions/security/investigate/cases-requirements.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/case-permissions.html
   - https://www.elastic.co/guide/en/serverless/current/security-cases-requirements.html
 applies_to:

--- a/solutions/security/investigate/cases.md
+++ b/solutions/security/investigate/cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cases-overview.html
   - https://www.elastic.co/guide/en/serverless/current/security-cases-overview.html
 applies_to:

--- a/solutions/security/investigate/configure-case-settings.md
+++ b/solutions/security/investigate/configure-case-settings.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cases-manage-settings.html
   - https://www.elastic.co/guide/en/serverless/current/security-cases-settings.html
 applies_to:

--- a/solutions/security/investigate/examine-osquery-results.md
+++ b/solutions/security/investigate/examine-osquery-results.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/view-osquery-results.html
   - https://www.elastic.co/guide/en/serverless/current/security-examine-osquery-results.html
 applies_to:

--- a/solutions/security/investigate/indicators-of-compromise.md
+++ b/solutions/security/investigate/indicators-of-compromise.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/indicators-of-compromise.html
   - https://www.elastic.co/guide/en/serverless/current/security-indicators-of-compromise.html
 applies_to:

--- a/solutions/security/investigate/notes.md
+++ b/solutions/security/investigate/notes.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/add-manage-notes.html
   - https://www.elastic.co/guide/en/serverless/current/security-add-manage-notes.html
 applies_to:
@@ -18,7 +18,7 @@ Configure the `securitySolution:maxUnassociatedNotes` [advanced setting](/soluti
 
 ## Grant access to notes [notes-privileges]
 
-You can control access to notes by setting the [{{kib}} privileges](../../../deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md) for the **Notes** feature under **Security**. 
+You can control access to notes by setting the [{{kib}} privileges](../../../deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md) for the **Notes** feature under **Security**.
 
 ## View and add notes to alerts and events [notes-alerts-events]
 

--- a/solutions/security/investigate/open-manage-cases.md
+++ b/solutions/security/investigate/open-manage-cases.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/cases-open-manage.html
   - https://www.elastic.co/guide/en/serverless/current/security-cases-open-manage.html
 applies_to:

--- a/solutions/security/investigate/osquery.md
+++ b/solutions/security/investigate/osquery.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/use-osquery.html
   - https://www.elastic.co/guide/en/serverless/current/security-query-operating-systems.html
   - https://www.elastic.co/guide/en/kibana/current/osquery.html
@@ -20,7 +20,7 @@ With Osquery, you can:
 * View a history of past queries and their results
 * Save queries and build a library of queries for specific use cases
 
-To use Osquery, you must add the [Osquery manager integration](manage-integration.md) to an {{agent}} policy. After completing that step, you can use the Osquery features that are available in your solution. 
+To use Osquery, you must add the [Osquery manager integration](manage-integration.md) to an {{agent}} policy. After completing that step, you can use the Osquery features that are available in your solution.
 
 % The following Osquery features are available from {{elastic-sec}}:
 

--- a/solutions/security/investigate/run-osquery-from-alerts.md
+++ b/solutions/security/investigate/run-osquery-from-alerts.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/alerts-run-osquery.html
   - https://www.elastic.co/guide/en/serverless/current/security-alerts-run-osquery.html
 applies_to:

--- a/solutions/security/investigate/run-osquery-from-investigation-guides.md
+++ b/solutions/security/investigate/run-osquery-from-investigation-guides.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/invest-guide-run-osquery.html
   - https://www.elastic.co/guide/en/serverless/current/security-invest-guide-run-osquery.html
 applies_to:

--- a/solutions/security/investigate/session-view.md
+++ b/solutions/security/investigate/session-view.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/session-view.html
   - https://www.elastic.co/guide/en/serverless/current/security-session-view.html
 applies_to:

--- a/solutions/security/investigate/timeline-templates.md
+++ b/solutions/security/investigate/timeline-templates.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/timeline-templates-ui.html
   - https://www.elastic.co/guide/en/serverless/current/security-timeline-templates-ui.html
 applies_to:

--- a/solutions/security/investigate/timeline.md
+++ b/solutions/security/investigate/timeline.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/timelines-ui.html
   - https://www.elastic.co/guide/en/serverless/current/security-timelines-ui.html
 applies_to:
@@ -24,7 +24,7 @@ In addition to Timelines, you can create and attach Timeline templates to [detec
 
 ## Grant access to Timeline [timeline-privileges]
 
-You can control access to Timeline by setting the [{{kib}} privileges](../../../deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md) for the **Timeline** feature under **Security**. 
+You can control access to Timeline by setting the [{{kib}} privileges](../../../deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md) for the **Timeline** feature under **Security**.
 
 ## Create new or open existing Timeline [open-create-timeline]
 

--- a/solutions/security/investigate/use-placeholder-fields-in-osquery-queries.md
+++ b/solutions/security/investigate/use-placeholder-fields-in-osquery-queries.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html
   - https://www.elastic.co/guide/en/serverless/current/security-osquery-placeholder-fields.html
 applies_to:

--- a/solutions/security/investigate/visual-event-analyzer.md
+++ b/solutions/security/investigate/visual-event-analyzer.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/visual-event-analyzer.html
   - https://www.elastic.co/guide/en/serverless/current/security-visual-event-analyzer.html
 applies_to:
@@ -13,7 +13,7 @@ applies_to:
 {{elastic-sec}} allows any event detected by {{elastic-endpoint}} to be analyzed using a process-based visual analyzer, which shows a graphical timeline of processes that led up to the alert and the events that occurred immediately after. Examining events in the visual event analyzer is useful to determine the origin of potentially malicious activity and other areas in your environment that may be compromised. It also enables security analysts to drill down into all related hosts, processes, and other events to aid in their investigations.
 
 ::::{tip}
-If you’re experiencing performance degradation, you can [exclude cold and frozen tier data](/solutions/security/get-started/configure-advanced-settings.md#exclude-cold-frozen-tiers) from analyzer queries. This setting is only available for the {{stack}}. 
+If you’re experiencing performance degradation, you can [exclude cold and frozen tier data](/solutions/security/get-started/configure-advanced-settings.md#exclude-cold-frozen-tiers) from analyzer queries. This setting is only available for the {{stack}}.
 ::::
 
 

--- a/solutions/security/manage-elastic-defend.md
+++ b/solutions/security/manage-elastic-defend.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/sec-manage-intro.html
   - https://www.elastic.co/guide/en/serverless/current/security-manage-endpoint-protection.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/allowlist-elastic-endpoint-in-third-party-antivirus-apps.md
+++ b/solutions/security/manage-elastic-defend/allowlist-elastic-endpoint-in-third-party-antivirus-apps.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/allowlist-endpoint-3rd-party-av-apps.html
   - https://www.elastic.co/guide/en/serverless/current/security-allowlist-endpoint.html
 applies_to:
@@ -12,20 +12,20 @@ applies_to:
 
 # Allowlist {{elastic-endpoint}} in third-party antivirus apps [allowlist-endpoint-3rd-party-av-apps]
 
-::::{note} 
+::::{note}
 If you use other antivirus (AV) software along with {{elastic-defend}}, you may need to add the other system as a trusted application in the {{security-app}}. Refer to [*Trusted applications*](trusted-applications.md) for more information.
 ::::
 
 
 Third-party antivirus (AV) applications may identify the expected behavior of {{elastic-endpoint}}—the installed component that performs {{elastic-defend}}'s threat monitoring and prevention—as a potential threat. Add {{elastic-endpoint}}'s digital signatures and file paths to your AV software’s allowlist to ensure {{elastic-endpoint}} continues to function as intended. We recommend you allowlist both the file paths and digital signatures, if applicable.
 
-::::{note} 
+::::{note}
 Your AV software may refer to allowlisted processes as process exclusions, ignored processes, or trusted processes. It is important to note that file, folder, and path-based exclusions/exceptions are distinct from trusted applications and will not achieve the same result. This page explains how to ignore actions taken by processes, not how to ignore the files that spawned those processes.
 ::::
 
 
 
-## Allowlist {{elastic-endpoint}} on Windows [allowlist-endpoint-on-windows] 
+## Allowlist {{elastic-endpoint}} on Windows [allowlist-endpoint-on-windows]
 
 File paths:
 
@@ -33,7 +33,7 @@ File paths:
 * Driver: `c:\Windows\system32\drivers\elastic-endpoint-driver.sys`
 * Executable: `c:\Program Files\Elastic\Endpoint\elastic-endpoint.exe`
 
-    ::::{note} 
+    ::::{note}
     The executable runs as `elastic-endpoint.exe`.
     ::::
 
@@ -46,19 +46,19 @@ Digital signatures:
 For additional information about allowlisting on Windows, refer to [Trusting Elastic Defend in other software](https://github.com/elastic/endpoint/blob/main/PerformanceIssues-Windows.md#trusting-elastic-defend-in-other-software).
 
 
-## Allowlist {{elastic-endpoint}} on macOS [allowlist-endpoint-on-macos] 
+## Allowlist {{elastic-endpoint}} on macOS [allowlist-endpoint-on-macos]
 
 File paths:
 
 * System extension (recursive directory structure): `/Applications/ElasticEndpoint.app/`
 
-    ::::{note} 
+    ::::{note}
     The system extension runs as `co.elastic.systemextension`.
     ::::
 
 * Executable: `/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint`
 
-    ::::{note} 
+    ::::{note}
     The executable runs as `elastic-endpoint`.
     ::::
 
@@ -69,13 +69,13 @@ Digital signatures:
 * Team ID: `2BT3HPN62Z`
 
 
-## Allowlist {{elastic-endpoint}} on Linux [allowlist-endpoint-on-linux] 
+## Allowlist {{elastic-endpoint}} on Linux [allowlist-endpoint-on-linux]
 
 File path:
 
 * Executable: `/opt/Elastic/Endpoint/elastic-endpoint`
 
-    ::::{note} 
+    ::::{note}
     The executable runs as `elastic-endpoint`.
     ::::
 

--- a/solutions/security/manage-elastic-defend/blocklist.md
+++ b/solutions/security/manage-elastic-defend/blocklist.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/blocklist.html
   - https://www.elastic.co/guide/en/serverless/current/security-blocklist.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/elastic-endpoint-self-protection-features.md
+++ b/solutions/security/manage-elastic-defend/elastic-endpoint-self-protection-features.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-self-protection.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-self-protection.html
 applies_to:
@@ -28,7 +28,7 @@ Self-protection is also enabled on the following macOS versions:
 * macOS 11 (Big Sur)
 * macOS 12 (Monterey)
 
-::::{note} 
+::::{note}
 Other Windows and macOS variants (and all Linux distributions) do not have self-protection.
 ::::
 

--- a/solutions/security/manage-elastic-defend/endpoint-protection-rules.md
+++ b/solutions/security/manage-elastic-defend/endpoint-protection-rules.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-protection-rules.html
   - https://www.elastic.co/guide/en/serverless/current/endpoint-protection-rules.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/endpoints.md
+++ b/solutions/security/manage-elastic-defend/endpoints.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/admin-page-ov.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoints-page.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/event-capture-elastic-defend.md
+++ b/solutions/security/manage-elastic-defend/event-capture-elastic-defend.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-event-capture.html
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-event-capture.html
 applies_to:
@@ -15,35 +15,35 @@ applies_to:
 You can supplement {{elastic-defend}}'s protection capabilities with additional [Elastic integrations](https://docs.elastic.co/en/integrations) and tools that provide more visibility and historical data. Consult the following sections to expand data collection for specific system events.
 
 
-## Network port creation and deletion [_network_port_creation_and_deletion] 
+## Network port creation and deletion [_network_port_creation_and_deletion]
 
 {{elastic-defend}} tracks TCP connections. If a port is created but no traffic flows, no events are generated.
 
 For complete capture of network port creation and deletion, consider capturing Windows event ID 5158 using the [Custom Windows Event Logs](https://docs.elastic.co/en/integrations/winlog) integration.
 
 
-## Network in/out connections [_network_inout_connections] 
+## Network in/out connections [_network_inout_connections]
 
 {{elastic-defend}} tracks TCP connections, which don’t include network in/out connections.
 
 For complete network capture, consider deploying {{packetbeat}} using the [Network Packet Capture](https://docs.elastic.co/en/integrations/network_traffic) integration.
 
 
-## User behavior [_user_behavior] 
+## User behavior [_user_behavior]
 
 {{elastic-defend}} only captures user security events required by its behavioral protection. This doesn’t include every user event such as logins and logouts, or every time a user account is created, deleted, or modified.
 
 For complete capture of all or specific Windows security events, consider the [Custom Windows Event Logs](https://docs.elastic.co/en/integrations/winlog) integration.
 
 
-## System service registration, deletion, and modification [_system_service_registration_deletion_and_modification] 
+## System service registration, deletion, and modification [_system_service_registration_deletion_and_modification]
 
 {{elastic-defend}} only captures system service security events required by its behavioral protection engine. Service creation and modification can also be detected in registry activity, for which {{elastic-defend}} has internal rules such as [Registry or File Modification from Suspicious Memory](https://github.com/elastic/protections-artifacts/blob/6d54ae289b290b1d42a7717569483f6ce907200a/behavior/rules/persistence_registry_or_file_modification_from_suspicious_memory.toml).
 
 For complete capture of all or specific Windows security events, consider the [Custom Windows Event Logs](https://docs.elastic.co/en/integrations/winlog) integration. In particular, capture events such as [Windows event ID 4697](https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4697).
 
 
-## Kernel driver registration, deletion, and queries [_kernel_driver_registration_deletion_and_queries] 
+## Kernel driver registration, deletion, and queries [_kernel_driver_registration_deletion_and_queries]
 
 {{elastic-defend}} scans every driver as it is loaded, but it doesn’t generate an event each time.
 
@@ -52,7 +52,7 @@ Drivers are registered in the system as system services. You can capture this wi
 Also consider capturing Windows event ID 6 using {{winlogbeat}}'s [Sysmon module](beats://reference/winlogbeat/winlogbeat-module-sysmon.md).
 
 
-## System configuration file creation, modification, and deletion [_system_configuration_file_creation_modification_and_deletion] 
+## System configuration file creation, modification, and deletion [_system_configuration_file_creation_modification_and_deletion]
 
 {{elastic-defend}} tracks creation, modification, and deletion of all files on the system. However, as mentioned above, the data might be aggregated, truncated, or deduplicated to provide only what’s required for threat detection and prevention.
 

--- a/solutions/security/manage-elastic-defend/event-filters.md
+++ b/solutions/security/manage-elastic-defend/event-filters.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/event-filters.html
   - https://www.elastic.co/guide/en/serverless/current/security-event-filters.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/host-isolation-exceptions.md
+++ b/solutions/security/manage-elastic-defend/host-isolation-exceptions.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/host-isolation-exceptions.html
   - https://www.elastic.co/guide/en/serverless/current/security-host-isolation-exceptions.html
 applies_to:
@@ -17,7 +17,7 @@ Host isolation exceptions support IPv4 addresses, with optional classless inter-
 
 ::::{admonition} Requirements
 * You must have the **Host Isolation Exceptions** [privilege](/solutions/security/configure-elastic-defend/elastic-defend-feature-privileges.md) or the appropriate user role to access this feature.
-* Host isolation requires the appropriate [subscription](https://www.elastic.co/pricing) in {{stack}} or [project feature](/deploy-manage/deploy/elastic-cloud/project-settings.md) in {{serverless-short}}. 
+* Host isolation requires the appropriate [subscription](https://www.elastic.co/pricing) in {{stack}} or [project feature](/deploy-manage/deploy/elastic-cloud/project-settings.md) in {{serverless-short}}.
 ::::
 
 

--- a/solutions/security/manage-elastic-defend/optimize-elastic-defend.md
+++ b/solutions/security/manage-elastic-defend/optimize-elastic-defend.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/endpoint-artifacts.html
   - https://www.elastic.co/guide/en/serverless/current/security-optimize-edr.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/policies.md
+++ b/solutions/security/manage-elastic-defend/policies.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/policies-page-ov.html
   - https://www.elastic.co/guide/en/serverless/current/security-policies-page.html
 applies_to:

--- a/solutions/security/manage-elastic-defend/trusted-applications.md
+++ b/solutions/security/manage-elastic-defend/trusted-applications.md
@@ -1,5 +1,5 @@
 ---
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/security/current/trusted-apps-ov.html
   - https://www.elastic.co/guide/en/serverless/current/security-trusted-applications.html
 applies_to:

--- a/troubleshoot/deployments/cloud-enterprise/cloud-enterprise.md
+++ b/troubleshoot/deployments/cloud-enterprise/cloud-enterprise.md
@@ -3,7 +3,7 @@ navigation_title: "Elastic Cloud Enterprise"
 applies_to:
   deployment:
     ece: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-troubleshooting.html
 ---
 

--- a/troubleshoot/index.md
+++ b/troubleshoot/index.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Troubleshoot"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/get-support-help.html
   - https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/troubleshooting-and-faqs.html
   - https://www.elastic.co/guide/en/cloud/current/ec-get-help.html
@@ -14,8 +14,8 @@ This section contains troubleshooting resources and guidance to help you resolve
 
 If you can't find your issue here, explore the [additional resources](#troubleshoot-additional-resources) or [contact us](#contact-us).
 
-:::{note} 
-You might need to review troubleshooting content for more than one product or topic area. Most Elastic deployments use multiple components from the [Elastic Stack](/get-started/the-stack.md), plus a deployment orchestrator. Check all topics relevant to your infrastructure. 
+:::{note}
+You might need to review troubleshooting content for more than one product or topic area. Most Elastic deployments use multiple components from the [Elastic Stack](/get-started/the-stack.md), plus a deployment orchestrator. Check all topics relevant to your infrastructure.
 :::
 
 * [{{es}}](/troubleshoot/elasticsearch.md)
@@ -40,7 +40,7 @@ You might need to review troubleshooting content for more than one product or to
 
 ## Contact us [contact-us]
 
-If you have an [Elastic subscription](https://www.elastic.co/pricing), you can contact Elastic support for assistance. You can reach us in the following ways: 
+If you have an [Elastic subscription](https://www.elastic.co/pricing), you can contact Elastic support for assistance. You can reach us in the following ways:
 
 * **Through the [Elastic Support Portal](https://support.elastic.co/):** The Elastic Support Portal is the central place where you can access all of your cases, subscriptions, and licenses. Within a few hours after subscribing, you'll receive an email with instructions on how to log in to the Support Portal, where you can track both current and archived cases.
 
@@ -57,7 +57,7 @@ If you have an [Elastic subscription](https://www.elastic.co/pricing), you can c
 
 Try these tips when opening a support case:
 
-* Include the deployment ID that you want help with, especially if you have several deployments. 
+* Include the deployment ID that you want help with, especially if you have several deployments.
 
   You can find the deployment ID on the overview page for your cluster in the {{ecloud}} Console.
 

--- a/troubleshoot/ingest/logstash.md
+++ b/troubleshoot/ingest/logstash.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Logstash"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/troubleshooting.html
   - https://www.elastic.co/guide/en/logstash/current/ts-logstash.html
 applies_to:

--- a/troubleshoot/ingest/logstash/health-report-pipelines.md
+++ b/troubleshoot/ingest/logstash/health-report-pipelines.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Health report pipelines"
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/logstash/current/health-report-pipeline-status.html
   - https://www.elastic.co/guide/en/logstash/current/health-report-pipeline-flow-worker-utilization.html
 applies_to:

--- a/troubleshoot/monitoring/unavailable-nodes.md
+++ b/troubleshoot/monitoring/unavailable-nodes.md
@@ -3,7 +3,7 @@ navigation_title: "Unavailable nodes"
 applies_to:
   deployment:
     ess: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-scenario_why_is_my_node_unavailable.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/echscenario_why_is_my_node_unavailable.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-single-node-deployment-disk-used.html

--- a/troubleshoot/monitoring/unavailable-shards.md
+++ b/troubleshoot/monitoring/unavailable-shards.md
@@ -3,7 +3,7 @@ navigation_title: "Unavailable shards"
 applies_to:
   deployment:
     ess: all
-mapped_urls:
+mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-scenario_why_are_shards_unavailable.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/echscenario_why_are_shards_unavailable.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-analyze_shards_with-api.html


### PR DESCRIPTION
When I was updating some mapped pages earlier, I noticed we were inconsistently using `mapped_pages` and `mapped_urls`. It didn't matter for the way I was finding the URLs, but I think it might affect how the linking between old AsciiDoc pages and new pages works. 