### PR TITLE
Add mapping and redirect for hidden security tutorial

### DIFF
--- a/deploy-manage/security/self-setup.md
+++ b/deploy-manage/security/self-setup.md
@@ -5,6 +5,7 @@ applies_to:
     self: ga
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/manually-configure-security.html
+  - https://www.elastic.co/guide/en/elastic-stack/current/install-stack-demo-secure.html
 ---
 
 % scope: initial security setup in self-managed deployments, following the automatic or manual (minimal, basic, https) procedures

--- a/redirects.yml
+++ b/redirects.yml
@@ -3,3 +3,4 @@ redirects:
   'deploy-manage/security/manually-configure-security-in-self-managed-cluster.md': '!deploy-manage/security/self-setup.md'
   'deploy-manage/security/security-certificates-keys.md': '!deploy-manage/security/self-auto-setup.md'
   'deploy-manage/security/ece-traffic-filtering-through-the-api.md': 'deploy-manage/security/ec-traffic-filtering-through-the-api.md'
+  'deploy-manage/security/install-stack-demo-secure.md': '!deploy-manage/security/self-setup.md'


### PR DESCRIPTION
[This tutorial](https://github.com/elastic/docs-content/blob/main/raw-migrated-files/stack-docs/elastic-stack/install-stack-demo-secure.md) is hidden while we figure out what content is still needed from it (most of it is a duplicate, and it's only relevant to self-managed)

so I have mapped the page to the explanation of how to set up security in a self-managed environment and added a redirect.