### PR TITLE
[observability] Hide EEM and inventory pages

### DIFF
--- a/reference/observability/elastic-entity-model.md
+++ b/reference/observability/elastic-entity-model.md
@@ -10,7 +10,6 @@ mapped_pages:
 This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 ::::
 
-
 The Elastic Entity Model consists of:
 
 * a data model and related entity indices

--- a/reference/observability/toc.yml
+++ b/reference/observability/toc.yml
@@ -3,5 +3,5 @@ toc:
   - file: fields-and-object-schemas.md
     children:
       - file: fields-and-object-schemas/metrics-app-fields.md
-  - file: elastic-entity-model.md
   - file: serverless/infrastructure-app-fields.md
+  - hidden: elastic-entity-model.md

--- a/solutions/observability/apps/inventory.md
+++ b/solutions/observability/apps/inventory.md
@@ -8,17 +8,13 @@ applies_to:
   serverless:
 ---
 
-
-
 # Inventory [inventory]
-
-
-Inventory provides a single place to observe the status of your entire ecosystem of hosts, containers, and services at a glance, even just from logs. From there, you can monitor and understand the health of your entities, check what needs attention, and start your investigations.
 
 ::::{note}
 The new Inventory requires the Elastic Entity Model (EEM). To learn more, refer to [Elastic Entity Model](/reference/observability/elastic-entity-model.md).
 ::::
 
+Inventory provides a single place to observe the status of your entire ecosystem of hosts, containers, and services at a glance, even just from logs. From there, you can monitor and understand the health of your entities, check what needs attention, and start your investigations.
 
 :::{image} /solutions/images/observability-inventory-catalog.png
 :alt: Inventory catalog

--- a/solutions/observability/apps/services.md
+++ b/solutions/observability/apps/services.md
@@ -20,13 +20,6 @@ In addition to health status, active alerts for each service are prominently dis
 :screenshot:
 :::
 
-% Stateful only for the following tip?
-
-::::{tip}
-Want to monitor service logs without instrumenting all your services? Learn about our [Inventory](../../../solutions/observability/apps/inventory.md).
-::::
-
-
 ## Service groups [service-groups]
 
 ::::{note}

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -142,7 +142,7 @@ toc:
                       - file: observability/apps/service-map.md
                       - file: observability/apps/service-overview.md
                       - file: observability/apps/mobile-service-overview.md
-                  - file: observability/apps/inventory.md
+                  - hidden: observability/apps/inventory.md
                   - file: observability/apps/drill-down-into-data.md
                     children:
                       - file: observability/apps/transactions-2.md


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/issues/4690

Hides the [EEM](https://www.elastic.co/guide/en/serverless/current/observability-elastic-entity-model.html) and [Inventory](https://www.elastic.co/guide/en/serverless/current/observability-inventory.html) pages from appearing in the table of contents and from search engines. However, the pages will still be published in case any users have explicitly enabled `entityCentricExperience`.