### PR TITLE
adding enterprise search comments and links to ECK 2.16 docs

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/managing-deployments-using-helm-chart.md
+++ b/deploy-manage/deploy/cloud-on-k8s/managing-deployments-using-helm-chart.md
@@ -80,6 +80,10 @@ helm install eck-stack-with-apm-server elastic/eck-stack \
     --values https://raw.githubusercontent.com/elastic/cloud-on-k8s/2.16/deploy/eck-stack/examples/apm-server/basic.yaml -n elastic-stack
 ```
 
+## Enterprise Search server along with Elasticsearch and Kibana [k8s-install-enterprise-search-elasticsearch-kibana-helm]
+
+Enterprise Search is not available in {{stack}} versions 9.0 and later. For an example deployment of {{es}}, {{kib}}, and an Enterprise Search server using the Helm chart, refer to the [previous ECK documentation](https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-stack-helm-chart.html).
+
 ## Install individual components of the Elastic Stack [k8s-eck-stack-individual-components] 
 
 You can install individual components in one of two ways using the provided Helm Charts.

--- a/deploy-manage/deploy/cloud-on-k8s/orchestrate-other-elastic-applications.md
+++ b/deploy-manage/deploy/cloud-on-k8s/orchestrate-other-elastic-applications.md
@@ -14,6 +14,10 @@ The following guides provide specific instructions for deploying and configuring
 * [Beats](beats.md)
 * [{{ls}}](logstash.md)
 
+::::{note}
+Enterprise Search is not available in {{stack}} versions 9.0 and later. To deploy or manage Enterprise Search in earlier versions, refer to the [previous ECK documentation](https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-enterprise-search.html).
+::::
+
 When orchestrating any of these applications, also consider the following topics:
 
 * [Elastic Stack Helm Chart](managing-deployments-using-helm-chart.md)

--- a/deploy-manage/security/k8s-network-policies.md
+++ b/deploy-manage/security/k8s-network-policies.md
@@ -433,3 +433,6 @@ spec:
       common.k8s.elastic.co/type: logstash
 ```
 
+## Isolating Enterprise Search [k8s-network-policies-enterprise-search-isolation]
+
+Enterprise Search is not available in {{stack}} versions 9.0 and later. For an example of Enterprise Search isolation using network policies, refer to the [previous ECK documentation](https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s_prerequisites.html#k8s-network-policies-enterprise-search-isolation).


### PR DESCRIPTION
ECK 3.0 still supports Enterprise Search for deployments running 8.x versions of Elastic Stack (and maybe even 7.17).

We had removed almost all references to Enterprise Search during the migration and that will look odd considering that some users might still run ECK-managed deployments with Enterprise Search.

This PR adds mentions to Enterprise Search in 3 different docs:

- Stack helm chart utilization
- Orchestrating other elastic stack applications
- Network policies examples

Another approach for this would be to bring back all content related to Enterprise Search from older docs, but maybe it's better this way.

@shainaraskas , @bmorelli25 : I'd need to know if the links I'm using for the older documents are correct in terms of destination.