### PR TITLE
Adds Serverless badge to Configure data volume for Elastic Endpoint page

### DIFF
--- a/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint.md
+++ b/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint.md
@@ -5,6 +5,8 @@ mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/security-endpoint-data-volume.html
 applies_to:
   stack: all
+  serverless:
+    security: all
 ---
 
 # Configure data volume for {{elastic-endpoint}} [endpoint-data-volume]


### PR DESCRIPTION
Contributes to https://github.com/elastic/security-docs/issues/5771.

Adds Serverless applies tag to the Configure data volume for Elastic Endpoint page. Confirmed with Dan Ferullo that this change is being released in Serverless at the same time 8.18 is released.

Preview: [Configure data volume](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1074/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint)