### PR TITLE
Add note about keyword ignore_above logsdb setting

### DIFF
--- a/manage-data/data-store/data-streams/logs-data-stream.md
+++ b/manage-data/data-store/data-streams/logs-data-stream.md
@@ -143,7 +143,7 @@ By default, `logsdb` index mode sets `ignore_malformed` to `true`. With this set
 
 ### `ignore_above` [logs-db-ignore-above]
 
-In `logsdb` index mode, the `index.mapping.ignore_above` setting is applied by default at the index level to ensure efficient storage and indexing of large keyword fields.The index-level default for `ignore_above` is 8191 *characters.* Using UTF-8 encoding, this results in a limit of 32764 bytes, depending on character encoding.
+In `logsdb` index mode, the `index.mapping.ignore_above` setting is applied by default at the index level to ensure efficient storage and indexing of large keyword fields. This applies to all members of the keyword type family (keyword, constant_keyword, and wildcard). The index-level default for `ignore_above` is 8191 *characters.* Using UTF-8 encoding, this results in a limit of 32764 bytes, depending on character encoding.
 
 The mapping-level `ignore_above` setting takes precedence. If a specific field has an `ignore_above` value defined in its mapping, that value overrides the index-level `index.mapping.ignore_above` value. This default behavior helps to optimize indexing performance by preventing excessively large string values from being indexed.
 


### PR DESCRIPTION
Specifies that the setting applies to all members of the keyword family.