### PR TITLE
Update links to ESQL reference docs

### DIFF
--- a/explore-analyze/query-filter/languages/esql-getting-started.md
+++ b/explore-analyze/query-filter/languages/esql-getting-started.md
@@ -232,7 +232,7 @@ FROM sample_data
 | EVAL duration_ms = event_duration/1000000.0
 ```
 
-`EVAL` supports several [functions](elasticsearch://reference/query-languages/esql/esql-functions-operators.md#esql-functions). For example, to round a number to the closest number with the specified number of digits, use the [`ROUND`](elasticsearch://reference/query-languages/esql/functions-operators/math-functions.md#esql-round) function:
+`EVAL` supports several [functions](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-eval). For example, to round a number to the closest number with the specified number of digits, use the [`ROUND`](elasticsearch://reference/query-languages/esql/functions-operators/math-functions.md#esql-round) function:
 
 ```esql
 FROM sample_data

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -39,9 +39,9 @@ After switching to {{esql}} mode, the query bar shows your previous KQL or Lucen
 from kibana_sample_data_logs | limit 10
 ```
 
-Every query starts with a [source command](elasticsearch://reference/query-languages/esql/esql-commands.md). In this query, the source command is [`FROM`](elasticsearch://reference/query-languages/esql/commands/source-commands.md#esql-from). `FROM` retrieves data from data streams, indices, or aliases. In this example, the data is retrieved from `kibana_sample_data_logs`.
+Every query starts with a [source command](elasticsearch://reference/query-languages/esql/esql-commands.md#esql-source-commands). In this query, the source command is [`FROM`](elasticsearch://reference/query-languages/esql/commands/source-commands.md#esql-from). `FROM` retrieves data from data streams, indices, or aliases. In this example, the data is retrieved from `kibana_sample_data_logs`.
 
-A source command can be followed by one or more [processing commands](elasticsearch://reference/query-languages/esql/esql-commands.md). In this query, the processing command is [`LIMIT`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-limit). `LIMIT` limits the number of rows that are retrieved.
+A source command can be followed by one or more [processing commands](elasticsearch://reference/query-languages/esql/esql-commands.md#esql-processing-commands). In this query, the processing command is [`LIMIT`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-limit). `LIMIT` limits the number of rows that are retrieved.
 
 ::::{tip}
 Click the **ES|QL help** button to open the in-product reference documentation for all commands and functions or to get recommended queries that will help you get started.


### PR DESCRIPTION
Connected to: https://github.com/elastic/docs-content/pull/1095

Update links to ESQL reference docs following up on https://github.com/elastic/elasticsearch/pull/126279 that splits the Functions and Operators page into separate pages, one for each group of similar functions and one for the operators.
Based on https://github.com/elastic/docs-content/issues/1072