### PR TITLE
add guide link

### DIFF
--- a/get-started/versioning-availability.md
+++ b/get-started/versioning-availability.md
@@ -120,7 +120,7 @@ To access our previous documentation system, which contains the documentation fo
 
 You can access the previous version of a specific page, where available, by clicking the **View previous version** link in the sidebar. 
 
-The following products versions are documented on this site:
+The following product versions are documented on this site:
 
 #### Core products and deployment methods
 

--- a/get-started/versioning-availability.md
+++ b/get-started/versioning-availability.md
@@ -116,9 +116,9 @@ For contributors and those interested in the technical details, see the [Elastic
 
 In April 2025, we released our new documentation site. This site includes documentation for our latest product versions.
 
-You can access the previous version of a page, where available, by clicking the **View previous version** link in the sidebar. 
+To access our previous documentation system, which contains the documentation for releases prior to those listed below, go to [elastic.co/guide](https://elastic.co/guide).
 
-% not sure about curator
+You can access the previous version of a specific page, where available, by clicking the **View previous version** link in the sidebar. 
 
 The following products versions are documented on this site:
 


### PR DESCRIPTION
as discussed, adding a link to the top of /guide for people to access our old documentation system

<img width="611" alt="image" src="https://github.com/user-attachments/assets/43ebba11-5e67-480c-a966-93d5042a484d" />
