### PR TITLE
Replace "Instance" with  "Elastic Cloud resource"

### DIFF
--- a/deploy-manage/users-roles.md
+++ b/deploy-manage/users-roles.md
@@ -84,7 +84,7 @@ You can't manage users and roles for {{eck}} clusters at the orchestrator level.
 serverless: all
 ```
 
-As an extension of the [predefined instance access roles](/deploy-manage/users-roles/cloud-organization/user-roles.md#ec_instance_access_roles) offered for {{serverless-short}} projects, you can create custom roles at the project level to provide more granular control, and provide users with only the access they need within specific projects.
+As an extension of the [predefined {{ecloud}} resource access roles](/deploy-manage/users-roles/cloud-organization/user-roles.md#ec_instance_access_roles) offered for {{serverless-short}} projects, you can create custom roles at the project level to provide more granular control, and provide users with only the access they need within specific projects.
 
 [Learn more about custom roles for {{serverless-full}} projects](/deploy-manage/users-roles/serverless-custom-roles.md).
 

--- a/deploy-manage/users-roles/_snippets/org-vs-deploy-sso.md
+++ b/deploy-manage/users-roles/_snippets/org-vs-deploy-sso.md
@@ -6,7 +6,7 @@ The option that you choose depends on your requirements:
 | --- | --- | --- |
 | **Management experience** | Manage authentication and role mapping centrally for all deployments in the organization | Configure SSO for each deployment individually |
 | **Authentication protocols** | SAML only | Multiple protocols, including LDAP, OIDC, and SAML |
-| **Role mapping** | [Organization-level roles and instance access roles](../../../deploy-manage/users-roles/cloud-organization/user-roles.md), Serverless project [custom roles](/deploy-manage/users-roles/serverless-custom-roles.md) | [Built-in](../../../deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md) and [custom](../../../deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md) stack-level roles |
+| **Role mapping** | [Organization-level roles and {{ecloud}} resource access roles](../../../deploy-manage/users-roles/cloud-organization/user-roles.md), Serverless project [custom roles](/deploy-manage/users-roles/serverless-custom-roles.md) | [Built-in](../../../deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md) and [custom](../../../deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md) stack-level roles |
 | **User experience** | Users interact with Cloud | Users interact with the deployment directly |
 
 If you want to avoid exposing users to the {{ecloud}} Console, or have users who only interact with some deployments, then you might prefer users to interact with your deployment directly.

--- a/deploy-manage/users-roles/cloud-organization/manage-users.md
+++ b/deploy-manage/users-roles/cloud-organization/manage-users.md
@@ -13,7 +13,7 @@ applies_to:
 
 $$$general-assign-user-roles$$$
 
-You can invite users to join your organization to allow them to interact with all or specific instances, projects and settings. After they're invited, you can manage the users in your organization.
+You can invite users to join your organization to allow them to interact with all or specific {{ecloud}} resources and settings. After they're invited, you can manage the users in your organization.
 
 Alternatively, [configure {{ecloud}} SAML SSO](../../../deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md) to enable your organization members to join the {{ecloud}} organization automatically.
 

--- a/deploy-manage/users-roles/cloud-organization/user-roles.md
+++ b/deploy-manage/users-roles/cloud-organization/user-roles.md
@@ -34,26 +34,26 @@ To edit the roles assigned to a user:
 There are two types of roles you can assign to users:
 
 * **Oranization-level roles:** These roles apply to the entire organization and are not specific to any serverless project or hosted deployment.
-* **Instance access roles:** These roles are specific to each serverless project or hosted deployment.
+* **{{ecloud}} resource access roles:** These roles are specific to each serverless project or hosted deployment.
 
 ### Organization-level roles [ec_organization_level_roles]
 
-* **Organization owner**: The role assigned by default to the user who created the organization. Organization owners have all privileges to instances ({{ech}} deployments and {{serverless-full}} projects), users, organization-level details and properties, billing details and subscription levels. They are also able to sign on to deployments with superuser privileges.
+* **Organization owner**: The role assigned by default to the user who created the organization. Organization owners have all privileges to {{ecloud}} resources including {{ech}} deployments and {{serverless-full}} projects, as well as users, organization-level details and properties, billing details and subscription levels. They are also able to sign on to deployments with superuser privileges.
 * **Billing admin**: Can manage an organization’s billing details such as credit card information, subscription and invoice history. Cannot manage other organization or deployment details and properties.
 
-### Instance access roles [ec_instance_access_roles]
+### {{ecloud}} resource access roles [ec_instance_access_roles]
 
-You can set instance access roles at two levels:
+You can set {{ecloud}} resource access roles at two levels:
 
-* **Globally**, for all {{ech}} deployments, or for all {{serverless-full}} projects of the time type ({{es-serverless}}, {{observability}}, or {{elastic-sec}}). In this case, the role will also apply to new deployments, or projects of the specified type type, created later.
+* **Globally**, for all {{ech}} deployments, or for all {{serverless-full}} projects of the same type ({{es-serverless}}, {{observability}}, or {{elastic-sec}}). In this case, the role will also apply to new deployments, or projects of the specified type type, created later.
 * **Individually**, for specific deployments or projects only. To do that, you have to leave the **Role for all hosted deployments** field, or the **Role for all** for the project type, blank.
 
-{{ech}} deployments and {{serverless-full}} projects each have a set of predefined instance access roles available:
+{{ech}} deployments and {{serverless-full}} projects each have a set of predefined {{ecloud}} resource access roles available:
 
 * [{{ech}} predefined roles](#ech-predefined-roles)
 * [{{serverless-full}} predefined roles](#general-assign-user-roles-table)
 
-If you're using {{serverless-full}}, you can optionally [create custom roles in a project](/deploy-manage/users-roles/cloud-organization/user-roles.md). All custom roles grant the same access as the `Viewer` instance access role with regards to {{ecloud}} privileges. To grant more {{ecloud}} privileges, assign more roles. Users receive a union of all their roles' privileges.To assign a custom role to users, go to **Instance access roles** and select it from the list under the specific project it was created in.
+If you're using {{serverless-full}}, you can optionally [create custom roles in a project](/deploy-manage/users-roles/cloud-organization/user-roles.md). All custom roles grant the same access as the `Viewer` {{ecloud}} resource access role with regards to {{ecloud}} privileges. To grant more {{ecloud}} privileges, assign more roles. Users receive a union of all their roles' privileges.To assign a custom role to users, go to **{{ecloud}} resource access roles** and select it from the list under the specific project it was created in.
 
 ## {{ech}} predefined roles [ech-predefined-roles]
 
@@ -114,7 +114,7 @@ This list describes the scope of the different roles:
 
 * **Organization owner**: This role is always scoped to administer all deployments.
 * **Billing admin**: This role does not refer to any deployment.
-* **Instance access roles**, including **Admin**: These roles can be scoped to either all deployments or projects, or specific deployments, project types, or projects.
+* **{{ecloud}} resource access roles**, including **Admin**: These roles can be scoped to either all deployments or projects, or specific deployments, project types, or projects.
 
 Members are only able to see the role assignments of other members under the organization they belong to, for role assignments they are able to manage. Members with the **Organization owner** role assigned are able to see the role assignments of every member of their organization.
 

--- a/deploy-manage/users-roles/serverless-custom-roles.md
+++ b/deploy-manage/users-roles/serverless-custom-roles.md
@@ -9,11 +9,11 @@ applies_to:
 
 # Serverless project custom roles [custom-roles]
 
-Built-in [organization-level roles](/deploy-manage/users-roles/cloud-organization/user-roles.md#ec_organization_level_roles) and [instance access roles](/deploy-manage/users-roles/cloud-organization/user-roles.md#ec_instance_access_roles) are great for getting started with {{serverless-full}}, and for system administrators who do not need more restrictive access.
+Built-in [organization-level roles](/deploy-manage/users-roles/cloud-organization/user-roles.md#ec_organization_level_roles) and [{{ecloud}} resource access roles](/deploy-manage/users-roles/cloud-organization/user-roles.md#ec_instance_access_roles) are great for getting started with {{serverless-full}}, and for system administrators who do not need more restrictive access.
 
 As an administrator, you can also create roles for users with the access they need within specific projects. For example, you might create a `marketing_user` role, which you then assign to all users in your marketing department. This role would grant access to all of the necessary data and features for this team to be successful, without granting them access they don’t require.
 
-All custom roles grant the same access as the `Viewer` instance access role with regards to {{ecloud}} privileges. To grant more {{ecloud}} privileges, assign more roles. Users receive a union of all their roles' privileges.
+All custom roles grant the same access as the `Viewer` {{ecloud}} resource access role with regards to {{ecloud}} privileges. To grant more {{ecloud}} privileges, assign more roles. Users receive a union of all their roles' privileges.
 
 Roles are a collection of privileges that enable users to access project features and data. When you create a custom role, you can assign {{es}} [cluster](#custom-roles-es-cluster-privileges) and [index](#custom-roles-es-index-privileges) privileges and [{{kib}}](#custom-roles-kib-privileges) privileges.
 


### PR DESCRIPTION
part of https://github.com/elastic/docs-content/issues/1134

the only place I see the term being used is in the context of instance access roles. this PR is pending the final strings being set