### PR TITLE
[Security] Update release notes ID format for automated URL generation

### DIFF
--- a/release-notes/elastic-security/breaking-changes.md
+++ b/release-notes/elastic-security/breaking-changes.md
@@ -4,7 +4,7 @@ navigation_title: "Breaking changes"
 # {{elastic-sec}} breaking changes [elastic-security-breaking-changes]
 Breaking changes can impact your Elastic applications, potentially disrupting normal operations. Before you upgrade, carefully review the {{elastic-sec}} breaking changes and take the necessary steps to mitigate any issues. To learn how to upgrade, check [Upgrade](/deploy-manage/upgrade.md).
 
-% ## Next version [elastic-security-nextversion-breaking-changes]
+% ## Next version [elastic-security-X.X.X-breaking-changes]
 
 % ::::{dropdown} Title of breaking change 
 % Description of the breaking change.

--- a/release-notes/elastic-security/deprecations.md
+++ b/release-notes/elastic-security/deprecations.md
@@ -7,7 +7,7 @@ Over time, certain Elastic functionality becomes outdated and is replaced or rem
 
 Review the deprecated functionality for {{elastic-sec}}. While deprecations have no immediate impact, we strongly encourage you update your implementation after you upgrade. To learn how to upgrade, check out [Upgrade](/deploy-manage/upgrade.md).
 
-% ## Next version
+% ## Next version [elastic-security-X.X.X-deprecations]
 
 % ::::{dropdown} Deprecation title
 % Description of the deprecation.

--- a/release-notes/elastic-security/index.md
+++ b/release-notes/elastic-security/index.md
@@ -4,7 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/security/current/release-notes.html
   - https://www.elastic.co/guide/en/security/current/whats-new.html
 ---
-# {{elastic-sec}} release notes [elastic-security-release-notes]
+# {{elastic-sec}} release notes [elastic-security-X.X.X-release-notes]
 
 Review the changes, fixes, and more in each version of {{elastic-sec}}.
 


### PR DESCRIPTION
Updates templates for the Security release notes to enforce the correct version format in section headers.

Related issue: https://github.com/elastic/docs-content/issues/1152