### PR TITLE
Update pw-env-var.md

### DIFF
--- a/deploy-manage/deploy/self-managed/_snippets/pw-env-var.md
+++ b/deploy-manage/deploy/self-managed/_snippets/pw-env-var.md
@@ -1,7 +1,7 @@
 We recommend storing the `elastic` password as an environment variable in your shell. For example:
 
 ```sh subs=true
-{{export}}ELASTIC_PASSWORD="your_password"
+{{export}} ELASTIC_PASSWORD="your_password"
 ```
 
 If you have password-protected the {{es}} keystore, you will be prompted to enter the keystore’s password. See [Secure settings](/deploy-manage/security/secure-settings.md) for more details.


### PR DESCRIPTION
Typo in the export command results in the command not working as written. Needs a space between export and the variable. 

Changed:
"exportELASTIC_PASSWORD="your_password""
to:
"export ELASTIC_PASSWORD="your_password"

![ElasticSupport 2025-04-16 at 09 23 36](https://github.com/user-attachments/assets/f4dc94e7-6cb6-4e95-a4ab-ec84d763d9f2)
