### PR TITLE
Update check-es-running.md

### DIFF
--- a/deploy-manage/deploy/self-managed/_snippets/check-es-running.md
+++ b/deploy-manage/deploy/self-managed/_snippets/check-es-running.md
@@ -1,7 +1,7 @@
 You can test that your {{es}} node is running by sending an HTTPS request to port `9200` on `localhost`:
 
 ```sh subs=true
-curl --cacert {{es-conf}}{{slash}}certs{{slash}}http_ca.crt {{escape}} <1>
+curl --cacert {{es-conf}}{{slash}}certs{{slash}}http_ca.crt <1>
 -u elastic:$ELASTIC_PASSWORD https://localhost:9200 <2>
 ```
 1. `--cacert`: Path to the generated `http_ca.crt` certificate for the HTTP layer.


### PR DESCRIPTION
Typo in the curl command with "{{escape}}" appearing in the final result would result in an error running the command.

![ElasticSupport 2025-04-16 at 09 28 23](https://github.com/user-attachments/assets/3e5d310f-2807-4b01-9e79-b538710ad37a)
![ElasticSupport 2025-04-16 at 09 28 48](https://github.com/user-attachments/assets/735eecd1-0412-447a-b847-060bd2cf29b7)
