### PR TITLE
Update fleet/ls-output-settings.md

### DIFF
--- a/reference/fleet/ls-output-settings.md
+++ b/reference/fleet/ls-output-settings.md
@@ -24,7 +24,7 @@ input {
   elastic_agent {
     port => 5044
     enrich => none <1>
-    ssl => true
+    ssl_enabled => true
     ssl_certificate_authorities => ["<ca_path>"]
     ssl_certificate => "<server_cert_path>"
     ssl_key => "<server_cert_key_in_pkcs8>"
@@ -38,7 +38,7 @@ output {
     data_stream => "true"
     api_key => "<api_key>" <3>
     data_stream => true
-    ssl => true
+    ssl_enabled => true
     # cacert => "<elasticsearch_ca_path>"
   }
 }


### PR DESCRIPTION
Updated `ssl` to `ssl_enabled` in the example Logstash pipeline, to reflect the current expected settings.