### PR TITLE
Remove `cloud-status` reference

### DIFF
--- a/deploy-manage/cloud-organization/service-status.md
+++ b/deploy-manage/cloud-organization/service-status.md
@@ -17,7 +17,7 @@ applies_to:
 
 {{ech}} deployments and Serverless projects run on different cloud platforms, such as Amazon Web Services (AWS),  Google Cloud Platform (GCP), and Microsoft Azure. Like any service, it might undergo availability changes from time to time. When availability changes, Elastic makes sure to provide you with a current service status.
 
-To check current and past service availability, go to to the [Cloud Status](https://cloud-status.elastic.co/) page. Services are separated into {{ech}} services and [Serverless services](https://status.elastic.co/?section=serverless).
+To check current and past service availability, go to to the [Cloud Status](https://status.elastic.co/) page. Services are separated into {{ech}} services and [Serverless services](https://status.elastic.co/?section=serverless).
 
 ## Subscribe to updates [ec_subscribe_to_updates]
 
@@ -25,7 +25,7 @@ Don’t want to check the service status page manually? You can get notified abo
 
 To receive service status updates:
 
-1. Go to the [Cloud Status](https://cloud-status.elastic.co/) page and select **SUBSCRIBE TO UPDATES**.
+1. Go to the [Cloud Status](https://status.elastic.co/) page and select **SUBSCRIBE TO UPDATES**.
 2. Select one of the following methods to be notified of status updates:
 
     * Email
@@ -38,7 +38,7 @@ After you subscribe to updates, you are notified whenever a service status updat
 
 If you want to know about specific status updates, rather than all of them, you can adjust your preferences by using the following steps. These steps apply to both new signups and adjustments to an existing subscription.
 
-Go to the [Cloud Status](https://cloud-status.elastic.co/) page and select **SUBSCRIBE TO UPDATES**. Enter your email address and click **SUBSCRIBE VIA EMAIL**. You will be brought to a page with a list of regions and components.
+Go to the [Cloud Status](https://status.elastic.co/) page and select **SUBSCRIBE TO UPDATES**. Enter your email address and click **SUBSCRIBE VIA EMAIL**. You will be brought to a page with a list of regions and components.
 
 Here, you can customize your selections as needed, and then click **Save**.
 


### PR DESCRIPTION
https://elasticco.atlassian.net/browse/SRERE-882

As we no longer use cloud-status, updating the references to point to status.elastic.co