### PR TITLE
Add link from 'manage data' to Transforms page

### DIFF
--- a/manage-data/ingest/transform-enrich.md
+++ b/manage-data/ingest/transform-enrich.md
@@ -18,6 +18,8 @@ According to your use case, you may want to control the structure of your ingest
 
 Finally, to help ensure optimal query results, you may want to customize how text is analyzed and how text fields are defined inside {{es}}.
 
+Note that you can also perform transforms on existing {{es}} indices to pivot data into a summarized format, for example to break down web requests by geography or browser type. To learn more, refer to [Transforming data](../../explore-analyze/transforms.md).
+
 {{agent}} processors
 :   You can use [{{agent}} processors](/reference/fleet/agent-processors.md) to sanitize or enrich raw data at the source. Use {{agent}} processors if you need to control what data is sent across the wire, or if you need to enrich the raw data with information available on the host.
 


### PR DESCRIPTION
This updates [Transform and enrich data](https://www.elastic.co/docs/manage-data/ingest/transform-enrich), which is part of the "manage data" > "Ingestion" section, with a sentence and link to the "Transforms" pages, all about pivoting existing indices. 

---

<img width="659" alt="screen7" src="https://github.com/user-attachments/assets/171e5f33-7b40-480a-9f38-91d6cdabc6d2" />
