### PR TITLE
Fix superscripts in documentation

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
@@ -42,7 +42,7 @@ PUT _snapshot/my_read_only_url_repository
 :   (Optional, Boolean) If `true`, metadata files, such as index mappings and settings, are compressed in snapshots. Data files are not compressed. Defaults to `true`.
 
 `max_number_of_snapshots`
-:   (Optional, integer) Maximum number of snapshots the repository can contain. Defaults to `Integer.MAX_VALUE`, which is `2^31-1` or `2147483647`.
+:   (Optional, integer) Maximum number of snapshots the repository can contain. Defaults to `Integer.MAX_VALUE`, which is `2`^`31`^`-1` or `2147483647`.
 
 `max_restore_bytes_per_sec`
 :   (Optional, [byte value](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#byte-units)) Maximum snapshot restore rate per node. Defaults to unlimited. Note that restores are also throttled through [recovery settings](elasticsearch://reference/elasticsearch/configuration-reference/index-recovery-settings.md).

--- a/deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md
@@ -148,7 +148,7 @@ PUT _snapshot/my_fs_backup
 :   (Required, string) Location of the shared filesystem used to store and retrieve snapshots. This location must be registered in the `path.repo` setting on all master and data nodes in the cluster. Unlike `path.repo`, this setting supports only a single file path.
 
 `max_number_of_snapshots`
-:   (Optional, integer) Maximum number of snapshots the repository can contain. Defaults to `Integer.MAX_VALUE`, which is `2^31-1` or `2147483647`.
+:   (Optional, integer) Maximum number of snapshots the repository can contain. Defaults to `Integer.MAX_VALUE`, which is `2`^`31`^`-1` or `2147483647`.
 
 `max_restore_bytes_per_sec`
 :   (Optional, [byte value](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#byte-units)) Maximum snapshot restore rate per node. Defaults to unlimited. Note that restores are also throttled through [recovery settings](elasticsearch://reference/elasticsearch/configuration-reference/index-recovery-settings.md).

--- a/deploy-manage/tools/snapshot-and-restore/source-only-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/source-only-repository.md
@@ -53,7 +53,7 @@ PUT _snapshot/my_src_only_repository
 
 
 `max_number_of_snapshots`
-:   (Optional, integer) Maximum number of snapshots the repository can contain. Defaults to `Integer.MAX_VALUE`, which is `2^31-1` or `2147483647`.
+:   (Optional, integer) Maximum number of snapshots the repository can contain. Defaults to `Integer.MAX_VALUE`, which is `2`^`31`^`-1` or `2147483647`.
 
 `max_restore_bytes_per_sec`
 :   (Optional, [byte value](elasticsearch://reference/elasticsearch/rest-apis/api-conventions.md#byte-units)) Maximum snapshot restore rate per node. Defaults to unlimited. Note that restores are also throttled through [recovery settings](elasticsearch://reference/elasticsearch/configuration-reference/index-recovery-settings.md).

--- a/explore-analyze/query-filter/aggregations.md
+++ b/explore-analyze/query-filter/aggregations.md
@@ -294,4 +294,4 @@ For faster responses, {{es}} caches the results of frequently run aggregations i
 
 ## Limits for `long` values [limits-for-long-values]
 
-When running aggregations, {{es}} uses [`double`](elasticsearch://reference/elasticsearch/mapping-reference/number.md) values to hold and represent numeric data. As a result, aggregations on [`long`](elasticsearch://reference/elasticsearch/mapping-reference/number.md) numbers greater than `253` are approximate.
+When running aggregations, {{es}} uses [`double`](elasticsearch://reference/elasticsearch/mapping-reference/number.md) values to hold and represent numeric data. As a result, aggregations on [`long`](elasticsearch://reference/elasticsearch/mapping-reference/number.md) numbers greater than `2`^`53`^ are approximate.


### PR DESCRIPTION
Re-add and fix superscripts in the documentation.

Based on: https://github.com/elastic/docs-content/issues/1170