### PR TITLE
Add link to shared FS troubleshooting from system config page

### DIFF
--- a/deploy-manage/deploy/self-managed/important-system-configuration.md
+++ b/deploy-manage/deploy/self-managed/important-system-configuration.md
@@ -25,6 +25,10 @@ The following settings **must** be considered before going to production:
 For examples of applying the relevant settings in a Docker environment, refer to [](/deploy-manage/deploy/self-managed/install-elasticsearch-docker-prod.md).
 :::
 
+:::{tip}
+If you plan to use shared filesystem repositories, there are a few things to be aware of. Refer to [](/deploy-manage/tools/snapshot-and-restore/shared-file-system-repository.md) for guidance and troubleshooting tips.
+:::
+
 ::::{admonition} Use dedicated hosts
 :::{include} _snippets/dedicated-hosts.md
 :::


### PR DESCRIPTION
This adds a tip on the [Important system configuration](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/important-system-configuration) page to the shared file system page, since users may encounter some difficulty with that specific scenario.

Requested by @tailorzed 

---

<img width="647" alt="screen" src="https://github.com/user-attachments/assets/3188a557-c612-418b-b6c1-9e98bb7e5d3b" />
