### PR TITLE
Revert "Make rescore_vector generally available"

### DIFF
--- a/solutions/search/vector/knn.md
+++ b/solutions/search/vector/knn.md
@@ -915,7 +915,7 @@ All forms of quantization will result in some accuracy loss and as the quantizat
 * `int4` requires some rescoring for higher accuracy and larger recall scenarios. Generally, oversampling by 1.5x-2x recovers most of the accuracy loss.
 * `bbq` requires rescoring except on exceptionally large indices or models specifically designed for quantization. We have found that between 3x-5x oversampling is generally sufficient. But for fewer dimensions or vectors that do not quantize well, higher oversampling may be required.
 
-You can use the [`rescore_vector` option](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-search#operation-search-body-application-json-knn-rescore_vector) to automatically perform reranking. When a rescore `oversample` parameter is specified, the approximate kNN search will:
+You can use the `rescore_vector` [preview] option to automatically perform reranking. When a rescore `oversample` parameter is specified, the approximate kNN search will:
 
 * Retrieve `num_candidates` candidates per shard.
 * From these candidates, the top `k * oversample` candidates per shard will be rescored using the original vectors.


### PR DESCRIPTION
Reverts elastic/docs-content#995

Sorry @benwtrent we need to wait for 9.1.0 to merge this, I mistakenly thought we could flag things more granularly in the API reference, and then promptly forgot about this PR. We will probably soon have a current/next system in the new docs to simplify this process.