### PR TITLE
Add OTel data stream routing page

### DIFF
--- a/solutions/observability/apm/data-stream-routing.md
+++ b/solutions/observability/apm/data-stream-routing.md
@@ -1,0 +1,18 @@
+---
+mapped_pages:
+applies_to:
+  stack:
+  serverless:
+---
+
+# Data stream routing [apm-open-telemetry-data-stream-routing]
+
+APM already [supports routing APM data to user-defined data stream names](/solutions/observability/apm/data-streams.md#apm-data-stream-rerouting) via the [`reroute` processor](elasticsearch://reference/enrich-processor/reroute-processor.md). However, for users ingesting OTLP data, there is an alternative without having to create new ingest pipelines.
+
+## Setting data stream attributes
+
+To automatically route OTLP data, set the `data_stream.dataset` and `data_stream.namespace` attributes. These attributes will be mapped to the respective [ECS fields](ecs://reference/ecs-data_stream.md).
+
+The `data_stream` attributes can be set in either the resource-level, scope-level, span-level or span-event-level, and they are parsed in increasing order of precedence. In other words, a span event `data_stream` attributes will override the span `data_stream` attributes. This also implies that the `data_stream` attributes are inherited from previous levels, i.e. if a span does not specify the `data_stream` attributes, it will use the scope's.
+
+For more guidance on how to set resource attributes in OpenTelemetry, see [setting resource attributes](/solutions/observability/apm/attributes.md#setting-resource-attributes).

--- a/solutions/observability/apm/data-stream-routing.md
+++ b/solutions/observability/apm/data-stream-routing.md
@@ -13,6 +13,6 @@ Elastic APM supports [routing APM data](/solutions/observability/apm/data-stream
 
 To automatically route OTLP data, set the `data_stream.dataset` and `data_stream.namespace` attributes. These attributes map to the respective [ECS fields](ecs://reference/ecs-data_stream.md).
 
-You can set the `data_stream` attributes in either the resource-level, scope-level, span-level or span-event-level, and they are parsed in increasing order of precedence. For example, span event `data_stream` attributes override the span `data_stream` attributes. This implies that `data_stream` attributes are inherited from previous levels. If a span doesn't specify `data_stream` attributes, it uses the scope attributes.
+You can set the `data_stream` attributes at resource level, scope level, span level, or span event level. Elastic parses the attributes in increasing order of precedence. For example, span event `data_stream` attributes override the span `data_stream` attributes. This implies that `data_stream` attributes are inherited from previous levels. If a span doesn't specify `data_stream` attributes, it uses the scope attributes.
 
 For guidance on how to set resource attributes in OpenTelemetry, refer to [setting resource attributes](/solutions/observability/apm/attributes.md#setting-resource-attributes).

--- a/solutions/observability/apm/data-stream-routing.md
+++ b/solutions/observability/apm/data-stream-routing.md
@@ -7,12 +7,12 @@ applies_to:
 
 # Data stream routing [apm-open-telemetry-data-stream-routing]
 
-APM already [supports routing APM data to user-defined data stream names](/solutions/observability/apm/data-streams.md#apm-data-stream-rerouting) via the [`reroute` processor](elasticsearch://reference/enrich-processor/reroute-processor.md). However, for users ingesting OTLP data, there is an alternative without having to create new ingest pipelines.
+Elastic APM supports [routing APM data](/solutions/observability/apm/data-streams.md#apm-data-stream-rerouting) to user-defined data stream names using the [`reroute` processor](elasticsearch://reference/enrich-processor/reroute-processor.md). However, you can also ingest OTLP data without having to create new ingest pipelines.
 
 ## Setting data stream attributes
 
-To automatically route OTLP data, set the `data_stream.dataset` and `data_stream.namespace` attributes. These attributes will be mapped to the respective [ECS fields](ecs://reference/ecs-data_stream.md).
+To automatically route OTLP data, set the `data_stream.dataset` and `data_stream.namespace` attributes. These attributes map to the respective [ECS fields](ecs://reference/ecs-data_stream.md).
 
-The `data_stream` attributes can be set in either the resource-level, scope-level, span-level or span-event-level, and they are parsed in increasing order of precedence. In other words, a span event `data_stream` attributes will override the span `data_stream` attributes. This also implies that the `data_stream` attributes are inherited from previous levels, i.e. if a span does not specify the `data_stream` attributes, it will use the scope's.
+You can set the `data_stream` attributes in either the resource-level, scope-level, span-level or span-event-level, and they are parsed in increasing order of precedence. For example, span event `data_stream` attributes override the span `data_stream` attributes. This implies that `data_stream` attributes are inherited from previous levels. If a span doesn't specify `data_stream` attributes, it uses the scope attributes.
 
-For more guidance on how to set resource attributes in OpenTelemetry, see [setting resource attributes](/solutions/observability/apm/attributes.md#setting-resource-attributes).
+For guidance on how to set resource attributes in OpenTelemetry, refer to [setting resource attributes](/solutions/observability/apm/attributes.md#setting-resource-attributes).

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -132,6 +132,7 @@ toc:
                       - file: observability/apm/collect-metrics.md
                       - file: observability/apm/limitations.md
                       - file: observability/apm/attributes.md
+                      - file: observability/apm/data-stream-routing.md
                   - file: observability/apm/apm-k8s-attacher.md
                   - file: observability/apm/monitor-aws-lambda-functions.md
                   - file: observability/apm/jaeger.md


### PR DESCRIPTION
This PR adds a new page under APM OTel to describe data stream routing.

Closes https://github.com/elastic/apm-server/issues/16204.