### PR TITLE
fix applies tags

### DIFF
--- a/cloud-account/add-a-login-method.md
+++ b/cloud-account/add-a-login-method.md
@@ -1,9 +1,10 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-change-login-method.html
-applies:
+applies_to:
   serverless: all
-  hosted: all
+  deployment:
+    ess: all
 ---
 
 # Add a login method [ec-change-login-method]

--- a/cloud-account/change-your-password.md
+++ b/cloud-account/change-your-password.md
@@ -1,9 +1,10 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-change-password.html
-applies:
+applies_to:
   serverless: all
-  hosted: all
+  deployment:
+    ess: all
 ---
 
 # Change your password [ec-change-password]

--- a/cloud-account/index.md
+++ b/cloud-account/index.md
@@ -2,9 +2,10 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-account-user-settings.html
   - https://www.elastic.co/guide/en/serverless/current/general-user-profile.html
-applies:
+applies_to:
   serverless: all
-  hosted: all
+  deployment:
+    ess: all
 ---
 
 # Manage your Cloud account and preferences

--- a/cloud-account/join-or-leave-an-organization.md
+++ b/cloud-account/join-or-leave-an-organization.md
@@ -2,9 +2,10 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-invite-users.html
   - https://www.elastic.co/guide/en/serverless/current/general-manage-organization.html
-applies:
+applies_to:
   serverless: all
-  hosted: all
+  deployment:
+    ess: all
 ---
 
 # Join or leave an organization

--- a/cloud-account/multifactor-authentication.md
+++ b/cloud-account/multifactor-authentication.md
@@ -1,9 +1,10 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-account-security-mfa.html
-applies:
+applies_to:
   serverless: all
-  hosted: all
+  deployment:
+    ess: all
 ---
 
 # Multifactor authentication [ec-account-security-mfa]

--- a/cloud-account/update-your-email-address.md
+++ b/cloud-account/update-your-email-address.md
@@ -1,9 +1,10 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-update-email-address.html
-applies:
+applies_to:
   serverless: all
-  hosted: all
+  deployment:
+    ess: all
 ---
 
 # Update your email address [ec-update-email-address]

--- a/manage-data/migrate/migrate-from-a-self-managed-cluster-with-a-self-signed-certificate-using-remote-reindex.md
+++ b/manage-data/migrate/migrate-from-a-self-managed-cluster-with-a-self-signed-certificate-using-remote-reindex.md
@@ -1,10 +1,10 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-remote-reindex.html
-applies:
+applies_to:
   serverless: unavailable
-  hosted: all
-  ece: unavailable
+  deployment:
+    ess: all
 navigation_title: Reindex from a self-managed cluster
 ---
 

--- a/manage-data/migrate/migrate-internal-indices.md
+++ b/manage-data/migrate/migrate-internal-indices.md
@@ -2,7 +2,6 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-migrate-data-internal.html
   - https://www.elastic.co/guide/en/cloud-heroku/current/ech-migrate-data-internal.html
-applies:
 applies_to:
   stack: ga
   deployment:

--- a/solutions/observability/incident-management/create-an-uptime-duration-anomaly-rule.md
+++ b/solutions/observability/incident-management/create-an-uptime-duration-anomaly-rule.md
@@ -2,7 +2,7 @@
 navigation_title: "Uptime duration anomaly"
 mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/duration-anomaly-alert.html
-applies:
+applies_to:
   stack: deprecated 8.15.0
   serverless: unavailable
 ---

--- a/solutions/search.md
+++ b/solutions/search.md
@@ -1,5 +1,5 @@
 ---
-applies:
+applies_to:
   stack:
   serverless:
 mapped_pages:


### PR DESCRIPTION
replaces invalid `applies` and `hosted` tags with valid `applies_to` and `ess` tags


before: https://www.elastic.co/docs/cloud-account/join-or-leave-an-organization
after: https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1263/cloud-account/join-or-leave-an-organization

part of https://github.com/elastic/docs-content/issues/1197