### PR TITLE
Update frontmatter in ingest-pipelines sibling pages

### DIFF
--- a/manage-data/ingest/transform-enrich/ingest-pipelines-serverless.md
+++ b/manage-data/ingest/transform-enrich/ingest-pipelines-serverless.md
@@ -2,13 +2,10 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/ingest-pipelines.html
 applies_to:
-  stack: ga
   serverless: ga
 ---
 
 # Elasticsearch ingest pipelines (Serverless) [ingest-pipelines]
-
-This content applies to: [![Elasticsearch](/manage-data/images/serverless-es-badge.svg "")](../../../solutions/search.md) [![Observability](/manage-data/images/serverless-obs-badge.svg "")](../../../solutions/observability.md) [![Security](/manage-data/images/serverless-sec-badge.svg "")](../../../solutions/security/elastic-security-serverless.md)
 
 {{es}} ingest pipelines let you perform common transformations on your data before indexing. For example, you can use pipelines to remove fields, extract values from text, and enrich your data.
 

--- a/manage-data/ingest/transform-enrich/ingest-pipelines.md
+++ b/manage-data/ingest/transform-enrich/ingest-pipelines.md
@@ -3,7 +3,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html
 applies_to:
   stack: ga
-  serverless: ga
 ---
 
 # Elasticsearch ingest pipelines [ingest]


### PR DESCRIPTION
While fixing URLS in Kibana doc link service, I saw https://www.elastic.co/docs/manage-data/ingest/transform-enrich/ingest-pipelines-serverless and https://www.elastic.co/docs/manage-data/ingest/transform-enrich/ingest-pipelines seem to have incorrect applies_to frontmatter.  This PR fixes the frontmatter to match the titles. If they're later consolidated into a single page, the frontmatter can be updated again.