### PR TITLE
Remove `ess` apply labels from LDAP, PKI, and AD authentication pages

### DIFF
--- a/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
@@ -4,7 +4,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-ad.html
 applies_to:
   deployment:
+    self:
     ece:
+    eck:
 navigation_title: "Active Directory"
 ---
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory.md
@@ -4,10 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-ad.html
 applies_to:
   deployment:
-    self:
-    ess:
     ece:
-    eck:
 navigation_title: "Active Directory"
 ---
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
@@ -4,7 +4,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-ldap.html
 applies_to:
   deployment:
+    self:
     ece:
+    eck:
 navigation_title: LDAP
 ---
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/ldap.md
@@ -4,10 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-securing-clusters-ldap.html
 applies_to:
   deployment:
-    self:
-    ess:
     ece:
-    eck:
 navigation_title: LDAP
 ---
 

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/pki.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/pki.md
@@ -4,7 +4,6 @@ mapped_pages:
 applies_to:
   deployment:
     self:
-    ess:
     ece:
     eck:
 ---


### PR DESCRIPTION
This fixes the `applies_to` tagging for [LDAP user authentication](https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/ldap) and [Active Directory user authentication](https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/active-directory) to apply to ECE only (rather than ECE, hosted, self, and K8s).

Added the [PKI page](https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/pki) too.

