### PR TITLE
[Fleet] unhealthy remote ES warning can be ignored

### DIFF
--- a/reference/fleet/remote-elasticsearch-output.md
+++ b/reference/fleet/remote-elasticsearch-output.md
@@ -61,6 +61,10 @@ The remote {{es}} cluster is now configured.
 
 If you have chosen not to automatically synchronize integrations, you need to make sure that for any integrations that have been [added to your {{agent}} policy](/reference/fleet/add-integration-to-policy.md), the integration assets have been installed on the remote {{es}} cluster. Refer to [Install and uninstall {{agent}} integration assets](/reference/fleet/install-uninstall-integration-assets.md) for the steps.
 
+::::{note}
+When you use a remote {{es}} output, {{fleet-server}} performs a test to ensure connectivity to the remote cluster. The result of that connectivity test is used to report the ES Remote output as healthy or unhealthy on the **Fleet** > **Settings** > **Outputs** page, under the **Status** column. In some cases, the remote {{es}} output used for data from {{agent}} may be reachable only by those agents and not by {{fleet-server}}, so the unhealthy state and an associated `Unable to connect` error that appears on the UI can be ignored.
+::::
+
 ## Automatic integrations synchronization
 
 ```{applies_to}


### PR DESCRIPTION
This adds a note to the Fleet "Remote Elasticsearch Output" page indicating that warning about unhealthy state can be ignored in cases where Fleet Server can't connect to the remote cluster used only for agent data.


Please see: [Docs preview](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1307/reference/fleet/remote-elasticsearch-output#configuration)
Closes: https://github.com/elastic/docs-content/issues/1201

---

<img width="658" alt="screen" src="https://github.com/user-attachments/assets/4d5fa455-1ee7-4c66-b29b-2ffb4c038e12" />

