### PR TITLE
[Fleet] Update agent install steps for macOS aarch64

### DIFF
--- a/reference/fleet/install-standalone-elastic-agent.md
+++ b/reference/fleet/install-standalone-elastic-agent.md
@@ -116,7 +116,7 @@ To install and run {{agent}} standalone:
 
     :::::::
     
-    The commands shown are for Intel platforms, but ARM packages are also available. Refer to the {{agent}} [downloads page](https://www.elastic.co/downloads/elastic-agent) for the full list of available packages.
+    The commands shown are for either the Intel or ARM platform, but packages for both are available. Refer to the {{agent}} [downloads page](https://www.elastic.co/downloads/elastic-agent) for the full list of available packages.
 
 
 

--- a/reference/fleet/install-standalone-elastic-agent.md
+++ b/reference/fleet/install-standalone-elastic-agent.md
@@ -29,8 +29,8 @@ To install and run {{agent}} standalone:
 
     ::::::{tab-item} macOS
     ```shell subs=true
-    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{{stack-version}}-darwin-x86_64.tar.gz
-    tar xzvf elastic-agent-{{stack-version}}-darwin-x86_64.tar.gz
+    curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-{{stack-version}}-darwin-aarch64.tar.gz 
+    tar xzvf elastic-agent-{{stack-version}}-darwin-aarch64.tar.gz
     ```
     ::::::
 


### PR DESCRIPTION
In the Fleet UI, the install steps for macOS now default to aarch64 rather than x86_64.

<img width="548" alt="Screenshot 2025-04-29 at 4 45 07 PM" src="https://github.com/user-attachments/assets/482e9fd2-f651-41b4-a496-faacc48b52df" />



---

Closes: https://github.com/elastic/ingest-docs/issues/1649