### PR TITLE
Mention service risk on Entity Analytics dashboard page

### DIFF
--- a/solutions/security/dashboards/entity-analytics-dashboard.md
+++ b/solutions/security/dashboards/entity-analytics-dashboard.md
@@ -11,7 +11,7 @@ applies_to:
 # Entity Analytics dashboard
 
 
-The Entity Analytics dashboard provides a centralized view of emerging insider threats - including host risk, user risk, and anomalies from within your network. Use it to triage, investigate, and respond to these emerging threats.
+The Entity Analytics dashboard provides a centralized view of emerging insider threats—including host risk, user risk, service risk, and anomalies from within your network. Use it to triage, investigate, and respond to these emerging threats.
 
 ::::{admonition} Requirements
 In {{stack}}, a [Platinum subscription](https://www.elastic.co/pricing/) or higher is required.


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1225 by mentioning service risk in the intro paragraph on the Entity Analytics dashboard page. 

Preview: [Entity Analytics dashboard](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1323/solutions/security/dashboards/entity-analytics-dashboard)

8.18 PR: https://github.com/elastic/security-docs/pull/6803