### PR TITLE
Uses a snippet for the Agentless Integrations FAQ to resolve broken link

### DIFF
--- a/solutions/security/get-started/_snippets/agentless-integrations-faq.md
+++ b/solutions/security/get-started/_snippets/agentless-integrations-faq.md
@@ -1,0 +1,50 @@
+Frequently asked questions and troubleshooting steps for {{elastic-sec}}'s agentless CSPM integration.
+
+
+## When I make a new integration, when will I see the agent appear on the Integration Policies page? [_when_i_make_a_new_integration_when_will_i_see_the_agent_appear_on_the_integration_policies_page]
+
+After you create a new agentless integration, the new integration policy may show a button that says **Add agent** instead of the associated agent for several minutes during agent enrollment. No action is needed other than refreshing the page once enrollment is complete.
+
+
+## How do I troubleshoot an `Offline` agent? [_how_do_i_troubleshoot_an_offline_agent]
+
+For agentless integrations to successfully connect to {{elastic-sec}}, the {{fleet}} server host value must be the default. Otherwise, the agent status on the {{fleet}} page will be `Offline`, and logs will include the error `[elastic_agent][error] Cannot checkin in with fleet-server, retrying`.
+
+To troubleshoot this issue:
+
+1. Find **{{fleet}}** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md). Go to the **Settings** tab.
+2. Under **{{fleet}} server hosts**, click the **Actions** button for the policy named `Default`. This opens the Edit {{fleet}} Server flyout. The policy named `Default` should have the **Make this {{fleet}} server the default one** setting enabled. If not, enable it, then delete your integration and create it again.
+
+::::{note}
+If the **Make this {{fleet}} server the default one** setting was already enabled but problems persist, it’s possible someone changed the default {{fleet}} server’s **URL** value. In this case, contact Elastic Support to find out what the original **URL** value was, update the settings to match this value, then delete your integration and create it again.
+::::
+
+
+
+## How do I troubleshoot an `Unhealthy` agent? [_how_do_i_troubleshoot_an_unhealthy_agent]
+
+On the **{{fleet}}** page, the agent associated with an agentless integration has a name that begins with `agentless`. To troubleshoot an `Unhealthy` agent:
+
+* Confirm that you entered the correct credentials for the cloud provider you’re monitoring. The following is an example of an error log resulting from using incorrect AWS credentials:
+
+    ```
+    [elastic_agent.cloudbeat][error] Failed to update registry: failed to get AWS accounts: operation error Organizations: ListAccounts, get identity: get credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: XXX, api error AccessDenied: User: XXX is not authorized to perform: sts:AssumeRole on resource:XXX
+    ```
+
+
+For instructions on checking {{fleet}} logs, refer to [{{fleet}} troubleshooting](/troubleshoot/ingest/fleet/common-problems.md).
+
+
+## How do I delete an agentless integration? [_how_do_i_delete_an_agentless_integration]
+
+::::{note}
+Deleting your integration will remove all associated resources and stop data ingestion.
+::::
+
+
+When you create a new agentless CSPM integration, a new agent policy appears within the **Agent policies** tab on the **{{fleet}}** page, but you can’t use the **Delete integration** button on this page. Instead, you must delete the integration from the CSPM Integration’s **Integration policies** tab.
+
+1. Find **Integrations** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then search for and select `CSPM`.
+2. Go to the CSPM Integration’s **Integration policies** tab.
+3. Find the integration policy for the integration you want to delete. Click **Actions**, then **Delete integration**.
+4. Confirm by clicking **Delete integration** again.

--- a/solutions/security/get-started/agentless-integrations-faq.md
+++ b/solutions/security/get-started/agentless-integrations-faq.md
@@ -10,53 +10,5 @@ applies_to:
 
 # Agentless integrations FAQ [agentless-integration-troubleshooting]
 
-Frequently asked questions and troubleshooting steps for {{elastic-sec}}'s agentless CSPM integration.
-
-
-## When I make a new integration, when will I see the agent appear on the Integration Policies page? [_when_i_make_a_new_integration_when_will_i_see_the_agent_appear_on_the_integration_policies_page]
-
-After you create a new agentless integration, the new integration policy may show a button that says **Add agent** instead of the associated agent for several minutes during agent enrollment. No action is needed other than refreshing the page once enrollment is complete.
-
-
-## How do I troubleshoot an `Offline` agent? [_how_do_i_troubleshoot_an_offline_agent]
-
-For agentless integrations to successfully connect to {{elastic-sec}}, the {{fleet}} server host value must be the default. Otherwise, the agent status on the {{fleet}} page will be `Offline`, and logs will include the error `[elastic_agent][error] Cannot checkin in with fleet-server, retrying`.
-
-To troubleshoot this issue:
-
-1. Find **{{fleet}}** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md). Go to the **Settings** tab.
-2. Under **{{fleet}} server hosts**, click the **Actions** button for the policy named `Default`. This opens the Edit {{fleet}} Server flyout. The policy named `Default` should have the **Make this {{fleet}} server the default one** setting enabled. If not, enable it, then delete your integration and create it again.
-
-::::{note}
-If the **Make this {{fleet}} server the default one** setting was already enabled but problems persist, it’s possible someone changed the default {{fleet}} server’s **URL** value. In this case, contact Elastic Support to find out what the original **URL** value was, update the settings to match this value, then delete your integration and create it again.
-::::
-
-
-
-## How do I troubleshoot an `Unhealthy` agent? [_how_do_i_troubleshoot_an_unhealthy_agent]
-
-On the **{{fleet}}** page, the agent associated with an agentless integration has a name that begins with `agentless`. To troubleshoot an `Unhealthy` agent:
-
-* Confirm that you entered the correct credentials for the cloud provider you’re monitoring. The following is an example of an error log resulting from using incorrect AWS credentials:
-
-    ```
-    [elastic_agent.cloudbeat][error] Failed to update registry: failed to get AWS accounts: operation error Organizations: ListAccounts, get identity: get credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: XXX, api error AccessDenied: User: XXX is not authorized to perform: sts:AssumeRole on resource:XXX
-    ```
-
-
-For instructions on checking {{fleet}} logs, refer to [{{fleet}} troubleshooting](/troubleshoot/ingest/fleet/common-problems.md).
-
-
-## How do I delete an agentless integration? [_how_do_i_delete_an_agentless_integration]
-
-::::{note}
-Deleting your integration will remove all associated resources and stop data ingestion.
-::::
-
-
-When you create a new agentless CSPM integration, a new agent policy appears within the **Agent policies** tab on the **{{fleet}}** page, but you can’t use the **Delete integration** button on this page. Instead, you must delete the integration from the CSPM Integration’s **Integration policies** tab.
-
-1. Find **Integrations** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then search for and select `CSPM`.
-2. Go to the CSPM Integration’s **Integration policies** tab.
-3. Find the integration policy for the integration you want to delete. Click **Actions**, then **Delete integration**.
-4. Confirm by clicking **Delete integration** again.
+:::{include} _snippets/agentless-integrations-faq.md
+:::

--- a/troubleshoot/security.md
+++ b/troubleshoot/security.md
@@ -16,3 +16,4 @@ This section covers common {{elastic-sec}} related issues and how to resolve the
 * [Troubleshoot detection rules](security/detection-rules.md)
 * [Troubleshoot {{elastic-defend}}](security/elastic-defend.md)
 * [Troubleshoot indicators of compromise](security/indicators-of-compromise.md)
+* [Agentless integrations FAQ](security/agentless-integrations.md)

--- a/troubleshoot/security/agentless-integrations.md
+++ b/troubleshoot/security/agentless-integrations.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+  stack: all
+  serverless:
+    security: all
+---
+
+# Agentless integrations FAQ [agentless-integration-troubleshoot]
+
+:::{include} /solutions/security/get-started/_snippets/agentless-integrations-faq.md
+:::

--- a/troubleshoot/toc.yml
+++ b/troubleshoot/toc.yml
@@ -137,6 +137,7 @@ toc:
       - file: security/detection-rules.md
       - file: security/elastic-defend.md
       - file: security/indicators-of-compromise.md
+      - file: security/agentless-integrations.md
   - file: ingest.md
     children:
       # - file: ingest/enterprise-search/crawls.md


### PR DESCRIPTION
Fixes a broken link to https://www.elastic.co/docs/troubleshoot/security/agentless-integrations.html by re-adding a page at that URL. Uses a snippet so the page can also exist in its [proper location](https://www.elastic.co/docs/solutions/security/get-started/agentless-integrations-faq). This is a temporary solution to make sure links from Google and other search engines work while the full redirect capabilities in V3 are pending.

Previews: 
[/troubleshoot/agentless-integrations.html](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1338/troubleshoot/security/agentless-integrations)
[/solutions/security/get-started/agentless-integrations-faq.html](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1338/solutions/security/get-started/agentless-integrations-faq)