### PR TITLE
Add links to config resources

### DIFF
--- a/deploy-manage/deploy/self-managed/_snippets/config-file-format.md
+++ b/deploy-manage/deploy/self-managed/_snippets/config-file-format.md
@@ -1,4 +1,4 @@
-The configuration format is [YAML](https://yaml.org/). Here is an example of changing the path of the data and logs directories in {{es}}:
+The `elasticsearch.yml` configuration format is [YAML](https://yaml.org/). Here is an example of changing the path of the data and logs directories in {{es}}:
 
 ```yaml
 path:

--- a/deploy-manage/deploy/self-managed/_snippets/env-var-setting-subs.md
+++ b/deploy-manage/deploy/self-managed/_snippets/env-var-setting-subs.md
@@ -1,4 +1,4 @@
-Environment variables referenced with the `${...}` notation within the configuration file will be replaced with the value of the environment variable. For example:
+Environment variables referenced with the `${...}` notation within the `elasticsearch.yml` configuration file will be replaced with the value of the environment variable. For example:
 
 ```yaml
 node.name:    ${HOSTNAME}

--- a/deploy-manage/deploy/self-managed/configure-elasticsearch.md
+++ b/deploy-manage/deploy/self-managed/configure-elasticsearch.md
@@ -32,8 +32,8 @@ For a list of settings that must be configured before using your cluster in prod
 {{es}} has three configuration files:
 
 * `elasticsearch.yml` for configuring {{es}}
-* `jvm.options` for configuring {{es}} JVM settings
-* `log4j2.properties` for configuring {{es}} logging
+* `jvm.options` for configuring {{es}} [JVM settings](elasticsearch://reference/elasticsearch/jvm-settings.md)
+* `log4j2.properties` for configuring [{{es}} logging](/deploy-manage/monitor/logging-configuration/elasticsearch-log4j-configuration-self-managed.md)
 
 These files are located in the config directory, whose default location depends on whether the installation is from an archive distribution (`tar.gz` or `zip`) or a package distribution (Debian or RPM packages).
 


### PR DESCRIPTION
Add better connections from elasticsearch config page to jvm and logging docs

Also clarify when things are documenting specifically `elasticsearch.yml`

all changes in https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1340/deploy-manage/deploy/self-managed/configure-elasticsearch