### PR TITLE
Add Agent version info to Endpoint data volume page

### DIFF
--- a/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint.md
+++ b/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint.md
@@ -24,6 +24,10 @@ Each setting has several OS-specific variants, represented by `[linux|mac|window
 
 ## Network event deduplication [network-event-deduplication]
 
+:::{admonition} Added in 8.15.0
+This functionality was added in {{elastic-agent}} 8.15.0.
+:::
+
 When repeated network connections are detected from the same process, {{elastic-endpoint}} will not produce network events for subsequent connections. To disable or reduce deduplication of network events, use these advanced settings:
 
 `[linux|mac|windows].advanced.events.deduplicate_network_events`
@@ -34,6 +38,10 @@ When repeated network connections are detected from the same process, {{elastic-
 
 
 ## Data in `host.*` fields [host-fields]
+
+:::{admonition} Added in 8.18.0
+This functionality was added in {{elastic-agent}} 8.18.0.
+:::
 
 {{elastic-endpoint}} includes only a small subset of the data in the `host.*` fieldset in event documents. Full `host.*` information is still included in documents written to the `metrics-*` index pattern and in {{elastic-endpoint}} alerts. To override this behavior and include all `host.*` data for events, use this advanced setting:
 
@@ -47,6 +55,10 @@ Users should take note of how a lack of some `host.*` information may affect the
 
 
 ## Merged process and network events [merged-process-network]
+
+:::{admonition} Added in 8.18.0
+This functionality was added in {{elastic-agent}} 8.18.0.
+:::
 
 {{elastic-endpoint}} merges process `create`/`terminate` events (Windows) and `fork`/`exec`/`end` events (macOS/Linux) when possible. This means short-lived processes only generate a single event containing the details from when the process terminated. {{elastic-endpoint}} also merges network `connection/termination` events (Windows/macOS/Linux) when possible for short-lived connections. To disable this behavior, use these advanced settings:
 
@@ -63,6 +75,10 @@ Merged events can affect the results of [event filters](../manage-elastic-defend
 
 
 ## MD5 and SHA-1 hashes [md5-sha1-hashes]
+
+:::{admonition} Added in 8.18.0
+This functionality was added in {{elastic-agent}} 8.18.0.
+:::
 
 {{elastic-endpoint}} does not report MD5 and SHA-1 hashes in event data by default. These will still be reported if any [trusted applications](../manage-elastic-defend/trusted-applications.md), [blocklist entries](../manage-elastic-defend/blocklist.md), [event filters](../manage-elastic-defend/event-filters.md), or [Endpoint exceptions](../detect-and-alert/add-manage-exceptions.md#endpoint-rule-exceptions) require them. To include these hashes in all event data, use these advanced settings:
 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/1214 by adding Elastic Agent versioning info for the different functionalities doc'ed on the **Configure data volume for Elastic Endpoint** page.

Preview: [Configure data volume](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1344/solutions/security/configure-elastic-defend/configure-data-volume-for-elastic-endpoint)