### PR TITLE
Adds release notes for Observability 9.0.1

### DIFF
--- a/release-notes/elastic-observability/breaking-changes.md
+++ b/release-notes/elastic-observability/breaking-changes.md
@@ -17,7 +17,11 @@ Breaking changes can impact your Elastic applications, potentially disrupting no
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
-## 9.0.0 [elastic-observability-900-breaking-changes]
+## 9.0.1 [elastic-observability-9.0.1-breaking-changes]
+
+There are no breaking changes in Elastic {{observability}} 9.0.1.
+
+## 9.0.0 [elastic-observability-9.0.0-breaking-changes]
 
 ::::{dropdown} Profiling now defaults to 19Hz sampling frequency
 For more information, check [#202278]({{kib-pull}}202278).

--- a/release-notes/elastic-observability/deprecations.md
+++ b/release-notes/elastic-observability/deprecations.md
@@ -16,7 +16,11 @@ Review the deprecated functionality for Elastic {{observability}}. While depreca
 % **Action**<br> Steps for mitigating deprecation impact.
 % ::::
 
-## 9.0.0 [elastic-observability-900-deprecations]
+## 9.0.1 [elastic-observability-9.0.1-deprecations]
+
+There are no deprecations in Elastic {{observability}} 9.0.1.
+
+## 9.0.0 [elastic-observability-9.0.0-deprecations]
 
 ::::{dropdown} Removed Logs Explorer
 Logs Explorer has been removed. 

--- a/release-notes/elastic-observability/index.md
+++ b/release-notes/elastic-observability/index.md
@@ -19,9 +19,14 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elastic-observability-next-fixes]
 % *
 
-## 9.0.0 [elastic-observability-900-release-notes]
+## 9.0.1 [elastic-observability-9.0.1-release-notes]
 
-### Features and enhancements [elastic-observability-next-features-enhancements]
+### Fixes [elastic-observability-9.0.1-fixes]
+* Fixes an error that prevented query results from displaying and visualizing correctly in Bedrock [#218213]({{kib-pull}}218213)
+
+## 9.0.0 [elastic-observability-9.0.0-release-notes]
+
+### Features and enhancements [elastic-observability-9.0.0-features-enhancements]
 * Improves SLO navigation by separating details from the overview panel [#212826]({{kib-pull}}212826)
 * Enables the new Borealis theme [#210468]({{kib-pull}}210468)
 * Returns a 404 response only when the `screenshot_ref` is truly missing [#215241]({{kib-pull}}215241)
@@ -30,7 +35,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Enhances Synthetic SLOs by adding location context and correcting badge link behavior [#210695]({{kib-pull}}210695)
 * Updates the default sampling frequency to 19Hz [#202278]({{kib-pull}}202278)
 
-### Fixes [elastic-observability-900-fixes]
+### Fixes [elastic-observability-9.0.0-fixes]
 * Resolves an issue that prevented the chat feature from functioning correctly on the Alerts page [#197126]({{kib-pull}}197126)
 * Addresses a missing versioning issue in `inventory_view_saved_object` that could prevent the Observability Infrastructure Inventory view from loading post-upgrade [#207007]({{kib-pull}}207007)
 * Enables the use of wildcard filters in SLO queries [#213119]({{kib-pull}}213119)


### PR DESCRIPTION
Adds the release notes for Elastic Observability 9.0.1 and updates the link ID format.