### PR TITLE
Update `stack-version` to 9.0.1

### DIFF
--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-zip-on-windows.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-zip-on-windows.md
@@ -40,7 +40,7 @@ On Windows, the {{es}} {{ml}} feature requires the Microsoft Universal C Runtime
 ## Step 1: Download and install the `.zip` package [install-windows]
 
 % link url manually set
-Download the `.zip` archive for {{es}} {{stack-version}} from: [https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{stack-version}}-windows-x86_64.zip](https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-9.0.0-windows-x86_64.zip)
+Download the `.zip` archive for {{es}} {{stack-version}} from: [https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{stack-version}}-windows-x86_64.zip](https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{stack-version}}-windows-x86_64.zip)
 
 Unzip it with your favorite unzip tool. This will create a folder called `elasticsearch-<version>`, which we will refer to as `%ES_HOME%`. In a terminal window, `cd` to the `%ES_HOME%` directory, for instance:
 

--- a/deploy-manage/deploy/self-managed/install-kibana-on-windows.md
+++ b/deploy-manage/deploy/self-managed/install-kibana-on-windows.md
@@ -20,7 +20,7 @@ applies_to:
 
 ## Step 1: Download and install the `.zip` package [install-windows]
 
-Download the .zip windows archive for {{kib}} {{stack-version}} from [https://artifacts.elastic.co/downloads/kibana/kibana-{{stack-version}}-windows-x86_64.zip](https://artifacts.elastic.co/downloads/kibana/kibana-9.0.0-windows-x86_64.zip)
+Download the .zip windows archive for {{kib}} {{stack-version}} from [https://artifacts.elastic.co/downloads/kibana/kibana-{{stack-version}}-windows-x86_64.zip](https://artifacts.elastic.co/downloads/kibana/kibana-{{stack-version}}-windows-x86_64.zip)
 
 Unzip it with your favorite unzip tool. This will create a folder called kibana-{{stack-version}}-windows-x86_64, which we will refer to as `$KIBANA_HOME`. In a terminal window, CD to the `$KIBANA_HOME` directory, for instance:
 

--- a/deploy-manage/deploy/self-managed/install-kibana-with-debian-package.md
+++ b/deploy-manage/deploy/self-managed/install-kibana-with-debian-package.md
@@ -88,7 +88,7 @@ shasum -a 512 kibana-{{stack-version}}-amd64.deb <1>
 sudo dpkg -i kibana-{{stack-version}}-amd64.deb
 ```
 
-1. 	Compare the SHA produced by shasum with the [published SHA](https://artifacts.elastic.co/downloads/kibana/kibana-9.0.0-amd64.deb.sha512).
+1. 	Compare the SHA produced by shasum with the [published SHA](https://artifacts.elastic.co/downloads/kibana/kibana-{{stack-version}}-amd64.deb.sha512).
 
 % version manually specified in the link above
 

--- a/docset.yml
+++ b/docset.yml
@@ -72,6 +72,10 @@ toc:
   - hidden: 404.md
 
 subs:
+  # Do NOT change `stack-version` substitution key.
+  # This may eventually be replaced with a site-wide strategy.
+  # Refer to https://github.com/elastic/docs-builder/issues/737.
+  stack-version: "9.0.1"
   subscriptions:   "https://www.elastic.co/subscriptions"
   ecloud:   "Elastic Cloud"
   ech:   "Elastic Cloud Hosted"
@@ -270,14 +274,11 @@ subs:
   fleet-server-issue:   "https://github.com/elastic/fleet-server/issues/"
   fleet-server-pull:   "https://github.com/elastic/fleet-server/pull/"
   kib-pull:   "https://github.com/elastic/kibana/pull/"
-  stack-version: "9.0.0"
   eck_version: "3.0.0"
   eck_release_branch: "3.0"
   eck_helm_minimum_version: "3.2.0"
   eck_resources_list: "Elasticsearch, Kibana, APM Server, Beats, Elastic Agent, Elastic Maps Server, and Logstash"
   eck_resources_list_short: "APM Server, Beats, Elastic Agent, Elastic Maps Server, and Logstash"
-  apm_server_version: "9.0.0"
-  version: "9.0.0"
   release-date: "2-April-2025"
   heroku: "Elasticsearch Add-on for Heroku"
   obs-ai-assistant: "Elastic AI Assistant for Observability and Search"

--- a/explore-analyze/alerts-cases/alerts/alerting-troubleshooting.md
+++ b/explore-analyze/alerts-cases/alerts/alerting-troubleshooting.md
@@ -191,7 +191,7 @@ This approach should be used only temporarily as a last resort to restore functi
 
 ## Limitations [alerting-limitations]
 
-The following limitations and known problems apply to the {{version}} release of the {{kib}} {{alert-features}}:
+The following limitations and known problems apply to the {{stack-version}} release of the {{kib}} {{alert-features}}:
 
 ### Alert visibility [_alert_visibility]
 

--- a/explore-analyze/machine-learning/anomaly-detection/ml-limitations.md
+++ b/explore-analyze/machine-learning/anomaly-detection/ml-limitations.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 # Limitations [ml-limitations]
 
-The following limitations and known problems apply to the {{version}} release of the Elastic {{ml-features}}. The limitations are grouped into four categories:
+The following limitations and known problems apply to the {{stack-version}} release of the Elastic {{ml-features}}. The limitations are grouped into four categories:
 
 * [Platform limitations](#ad-platform-limitations) are related to the platform that hosts the {{ml}} feature of the {{stack}}.
 * [Configuration limitations](#ad-config-limitations) apply to the configuration process of the {{anomaly-jobs}}.

--- a/explore-analyze/machine-learning/data-frame-analytics/ml-dfa-limitations.md
+++ b/explore-analyze/machine-learning/data-frame-analytics/ml-dfa-limitations.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 # Limitations [ml-dfa-limitations]
 
-The following limitations and known problems apply to the {{version}} release of the Elastic {{dfanalytics}} feature. The limitations are grouped into the following categories:
+The following limitations and known problems apply to the {{stack-version}} release of the Elastic {{dfanalytics}} feature. The limitations are grouped into the following categories:
 
 * [Platform limitations](#dfa-platform-limitations) are related to the platform that hosts the {{ml}} feature of the {{stack}}.
 * [Configuration limitations](#dfa-config-limitations) apply to the configuration process of the {{dfanalytics-jobs}}.

--- a/explore-analyze/machine-learning/nlp/ml-nlp-limitations.md
+++ b/explore-analyze/machine-learning/nlp/ml-nlp-limitations.md
@@ -8,7 +8,7 @@ mapped_pages:
 
 # Limitations [ml-nlp-limitations]
 
-The following limitations and known problems apply to the {{version}} release of the Elastic {{nlp}} trained models feature.
+The following limitations and known problems apply to the {{stack-version}} release of the Elastic {{nlp}} trained models feature.
 
 ## Document size limitations when using `semantic_text` fields [ml-nlp-large-documents-limit-10k-10mb]
 

--- a/explore-analyze/query-filter/languages/sql-jdbc.md
+++ b/explore-analyze/query-filter/languages/sql-jdbc.md
@@ -25,7 +25,7 @@ Maven dependency
 <dependency>
   <groupId>org.elasticsearch.plugin</groupId>
   <artifactId>x-pack-sql-jdbc</artifactId>
-  <version>{{version}}</version>
+  <version>{{stack-version}}</version>
 </dependency>
 ```
 
@@ -46,7 +46,7 @@ from [Maven Central Repository](https://search.maven.org/artifact/org.elasticsea
 Your driver must be compatible with your {{es}} version.
 
 ::::{important}
-The driver version cannot be newer than the {{es}} version. For example, {{es}} version 7.10.0 is not compatible with {{version}} drivers.
+The driver version cannot be newer than the {{es}} version. For example, {{es}} version 7.10.0 is not compatible with {{stack-version}} drivers.
 ::::
 
 

--- a/explore-analyze/query-filter/languages/sql-odbc-installation.md
+++ b/explore-analyze/query-filter/languages/sql-odbc-installation.md
@@ -42,7 +42,7 @@ When installing the MSI, the Windows Defender SmartScreen might warn about runni
 Your driver must be compatible with your {{es}} version.
 
 ::::{important}
-The driver version cannot be newer than the {{es}} version. For example, {{es}} version 7.10.0 is not compatible with {{version}} drivers.
+The driver version cannot be newer than the {{es}} version. For example, {{es}} version 7.10.0 is not compatible with {{stack-version}} drivers.
 ::::
 
 
@@ -53,7 +53,7 @@ The driver version cannot be newer than the {{es}} version. For example, {{es}} 
 
 ## Download the `.msi` package(s) [download]
 
-Download the `.msi` package for Elasticsearch SQL ODBC Driver {{version}} from: [https://www.elastic.co/downloads/odbc-client](https://www.elastic.co/downloads/odbc-client)
+Download the `.msi` package for Elasticsearch SQL ODBC Driver {{stack-version}} from: [https://www.elastic.co/downloads/odbc-client](https://www.elastic.co/downloads/odbc-client)
 
 There are two versions of the installer available:
 
@@ -82,7 +82,7 @@ Clicking **Next** will present the End User License Agreement. You will need to 
 The following screen allows you to customise the installation path for the Elasticsearch ODBC driver files.
 
 ::::{note}
-The default installation path is of the format: **%ProgramFiles%\Elastic\ODBCDriver\\{{version}}**
+The default installation path is of the format: **%ProgramFiles%\Elastic\ODBCDriver\\{{stack-version}}**
 ::::
 
 
@@ -128,19 +128,19 @@ The examples given below apply to installation of the 64 bit MSI package. To ach
 The `.msi` can also be installed via the command line. The simplest installation using the same defaults as the GUI is achieved by first navigating to the download directory, then running:
 
 ```sh subs=true
-msiexec.exe /i esodbc-{{version}}-windows-x86_64.msi /qn
+msiexec.exe /i esodbc-{{stack-version}}-windows-x86_64.msi /qn
 ```
 
 By default, `msiexec.exe` does not wait for the installation process to complete, since it runs in the Windows subsystem. To wait on the process to finish and ensure that `%ERRORLEVEL%` is set accordingly, it is recommended to use `start /wait` to create a process and wait for it to exit:
 
 ```sh subs=true
-start /wait msiexec.exe /i esodbc-{{version}}-windows-x86_64.msi /qn
+start /wait msiexec.exe /i esodbc-{{stack-version}}-windows-x86_64.msi /qn
 ```
 
 As with any MSI installation package, a log file for the installation process can be found within the `%TEMP%` directory, with a randomly generated name adhering to the format `MSI<random>.LOG`. The path to a log file can be supplied using the `/l` command line argument
 
 ```sh subs=true
-start /wait msiexec.exe /i esodbc-{{version}}-windows-x86_64.msi /qn /l install.log
+start /wait msiexec.exe /i esodbc-{{stack-version}}-windows-x86_64.msi /qn /l install.log
 ```
 
 Supported Windows Installer command line arguments can be viewed using:
@@ -156,12 +156,12 @@ msiexec.exe /help
 All settings exposed within the GUI are also available as command line arguments (referred to as *properties* within Windows Installer documentation) that can be passed to `msiexec.exe`:
 
 `INSTALLDIR`
-:   The installation directory. Defaults to _%ProgramFiles%\Elastic\ODBCDriver\\{{version}}_.
+:   The installation directory. Defaults to _%ProgramFiles%\Elastic\ODBCDriver\\{{stack-version}}_.
 
 To pass a value, simply append the property name and value using the format `<PROPERTYNAME>="<VALUE>"` to the installation command. For example, to use a different installation directory to the default one:
 
 ```sh subs=true
-start /wait msiexec.exe /i esodbc-{{version}}-windows-x86_64.msi /qn INSTALLDIR="c:\CustomDirectory"
+start /wait msiexec.exe /i esodbc-{{stack-version}}-windows-x86_64.msi /qn INSTALLDIR="c:\CustomDirectory"
 ```
 
 Consult the [Windows Installer SDK Command-Line Options](https://msdn.microsoft.com/en-us/library/windows/desktop/aa367988(v=vs.85).aspx) for additional rules related to values containing quotation marks.
@@ -191,11 +191,11 @@ Once opened, find the Elasticsearch ODBC Driver installation within the list of 
 Uninstallation can also be performed from the command line by navigating to the directory containing the `.msi` package and running:
 
 ```sh subs=true
-start /wait msiexec.exe /x esodbc-{{version}}-windows-x86_64.msi /qn
+start /wait msiexec.exe /x esodbc-{{stack-version}}-windows-x86_64.msi /qn
 ```
 
 Similar to the install process, a path for a log file for the uninstallation process can be passed using the `/l` command line argument
 
 ```sh subs=true
-start /wait msiexec.exe /x esodbc-{{version}}-windows-x86_64.msi /qn /l uninstall.log
+start /wait msiexec.exe /x esodbc-{{stack-version}}-windows-x86_64.msi /qn /l uninstall.log
 ```

--- a/explore-analyze/transforms/transform-limitations.md
+++ b/explore-analyze/transforms/transform-limitations.md
@@ -9,7 +9,7 @@ mapped_pages:
 
 # Limitations [transform-limitations]
 
-The following limitations and known problems apply to the {{version}} release of the Elastic {{transform}} feature. The limitations are grouped into the following categories:
+The following limitations and known problems apply to the {{stack-version}} release of the Elastic {{transform}} feature. The limitations are grouped into the following categories:
 
 * [Configuration limitations](#transform-config-limitations) apply to the configuration process of the {{transforms}}.
 * [Operational limitations](#transform-operational-limitations) affect the behavior of the {{transforms}} that are running.

--- a/explore-analyze/visualize/maps/maps-connect-to-ems.md
+++ b/explore-analyze/visualize/maps/maps-connect-to-ems.md
@@ -42,7 +42,7 @@ Headers for the Tile Service JSON manifest describing the basemaps available.
 ::::::{tab-item} Curl Example
 ::::{dropdown}
 ```bash subs=true
-curl -I 'https://tiles.maps.elastic.co/v9.0/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{version}}' \
+curl -I 'https://tiles.maps.elastic.co/v9.0/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{stack-version}}' \
 -H 'User-Agent: curl/7.81.0' \
 -H 'Accept: */*' \
 -H 'Accept-Encoding: gzip, deflate, br'
@@ -122,7 +122,7 @@ Headers for a vector tile asset in *protobuffer* format from the Tile Service.
 ::::::{tab-item} Curl Example
 ::::{dropdown}
 ```bash subs=true
-$ curl -I 'https://tiles.maps.elastic.co/data/v3/1/1/0.pbf?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{version}}' \
+$ curl -I 'https://tiles.maps.elastic.co/data/v3/1/1/0.pbf?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{stack-version}}' \
 -H 'User-Agent: curl/7.81.0' \
 -H 'Accept: */*' \
 -H 'Accept-Encoding: gzip, deflate, br'
@@ -285,7 +285,7 @@ Headers for the File Service JSON manifest that declares all the datasets availa
 ::::::{tab-item} Curl example
 ::::{dropdown}
 ```bash subs=true
-curl -I 'https://vector.maps.elastic.co/v9.0/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{version}}' \
+curl -I 'https://vector.maps.elastic.co/v9.0/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{stack-version}}' \
 -H 'User-Agent: curl/7.81.0' \
 -H 'Accept: */*' \
 -H 'Accept-Encoding: gzip, deflate, br'
@@ -376,7 +376,7 @@ Headers for a sample Dataset from the File Service in TopoJSON format.
 ::::::{tab-item} Curl example
 ::::{dropdown}
 ```bash subs=true
-curl -I 'https://vector.maps.elastic.co/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{version}}' \
+curl -I 'https://vector.maps.elastic.co/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={{stack-version}}' \
 -H 'User-Agent: curl/7.81.0' \
 -H 'Accept: */*' \
 -H 'Accept-Encoding: gzip, deflate, br'
@@ -485,20 +485,20 @@ If you cannot connect to Elastic Maps Service from the {{kib}} server or browser
 1. Pull the {{hosted-ems}} Docker image.
 
     ```bash subs=true
-    docker pull docker.elastic.co/elastic-maps-service/elastic-maps-server:{{version}}
+    docker pull docker.elastic.co/elastic-maps-service/elastic-maps-server:{{stack-version}}
     ```
 
 2. Optional: Install [Cosign](https://docs.sigstore.dev/system_config/installation/) for your environment. Then use Cosign to verify the {{es}} image’s signature.
 
     ```sh subs=true
     wget https://artifacts.elastic.co/cosign.pub
-    cosign verify --key cosign.pub docker.elastic.co/elastic-maps-service/elastic-maps-server:{{version}}
+    cosign verify --key cosign.pub docker.elastic.co/elastic-maps-service/elastic-maps-server:{{stack-version}}
     ```
 
     The `cosign` command prints the check results and the signature payload in JSON format:
 
     ```sh subs=true
-    Verification for docker.elastic.co/elastic-maps-service/elastic-maps-server:{{version}} --
+    Verification for docker.elastic.co/elastic-maps-service/elastic-maps-server:{{stack-version}} --
     The following checks were performed on each of these signatures:
       - The cosign claims were validated
       - Existence of the claims in the transparency log was verified offline
@@ -509,7 +509,7 @@ If you cannot connect to Elastic Maps Service from the {{kib}} server or browser
 
     ```bash subs=true
     docker run --rm --init --publish 8080:8080 \
-      docker.elastic.co/elastic-maps-service/elastic-maps-server:{{version}}
+      docker.elastic.co/elastic-maps-service/elastic-maps-server:{{stack-version}}
     ```
 
     Once {{hosted-ems}} is running, follow instructions from the webpage at `localhost:8080` to define a configuration file and optionally download a more detailed basemaps database.
@@ -564,7 +564,7 @@ One way to configure {{hosted-ems}} is to provide `elastic-maps-server.yml` via 
 ```yaml subs=true
 services:
   ems-server:
-    image: docker.elastic.co/elastic-maps-service/elastic-maps-server:{{version}}
+    image: docker.elastic.co/elastic-maps-service/elastic-maps-server:{{stack-version}}
     volumes:
       - ./elastic-maps-server.yml:/usr/src/app/server/config/elastic-maps-server.yml
 ```
@@ -584,7 +584,7 @@ These variables can be set with `docker-compose` like this:
 ```yaml subs=true
 services:
   ems-server:
-    image: docker.elastic.co/elastic-maps-service/elastic-maps-server:{{version}}
+    image: docker.elastic.co/elastic-maps-service/elastic-maps-server:{{stack-version}}
     environment:
       ELASTICSEARCH_HOST: http://elasticsearch.example.org
       ELASTICSEARCH_USERNAME: 'ems'

--- a/reference/fleet/running-on-kubernetes-standalone.md
+++ b/reference/fleet/running-on-kubernetes-standalone.md
@@ -51,8 +51,8 @@ You can find {{agent}} Docker images [here](https://www.docker.elastic.co/r/elas
 
 Download the manifest file:
 
-```sh
-curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/v9.0.0/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+```sh subs=true
+curl -L -O https://raw.githubusercontent.com/elastic/elastic-agent/v{{stack-version}}/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
 ```
 
 ::::{note}

--- a/solutions/observability/apm/apm-server-command-reference.md
+++ b/solutions/observability/apm/apm-server-command-reference.md
@@ -174,7 +174,7 @@ Also see [Global flags](#apm-global-flags).
 
 ```sh subs=true
 apm-server export config
-apm-server export template --es.version {{version}} --index myindexname
+apm-server export template --es.version {{stack-version}} --index myindexname
 ```
 
 ## `help` command [apm-help-command]

--- a/solutions/observability/apm/apm-server-information-api.md
+++ b/solutions/observability/apm/apm-server-information-api.md
@@ -51,7 +51,7 @@ curl --verbose -X GET http://127.0.0.1:8200
 
 Example APM Server information request with GET, with a [Secret token](/solutions/observability/apm/secret-token.md):
 
-```sh
+```sh subs=true
 curl -X GET http://127.0.0.1:8200/ \
   -H "Authorization: Bearer secret_token"
 
@@ -59,7 +59,7 @@ curl -X GET http://127.0.0.1:8200/ \
   "build_date": "2021-12-18T19:59:06Z",
   "build_sha": "24fe620eeff5a19e2133c940c7e5ce1ceddb1445",
   "publish_ready": true,
-  "version": "9.0.0"
+  "version": "{{stack-version}}"
 }
 ```
 

--- a/solutions/observability/apm/configure-kafka-output.md
+++ b/solutions/observability/apm/configure-kafka-output.md
@@ -135,7 +135,7 @@ output.kafka:
         message: "ERR"
 ```
 
-This configuration results in topics named _critical-{{version}}_, _error-{{version}}_, and _logs-{{version}}_.
+This configuration results in topics named _critical-{{stack-version}}_, _error-{{stack-version}}_, and _logs-{{stack-version}}_.
 
 ### `key` [_key]
 

--- a/solutions/observability/apm/configure-logstash-output.md
+++ b/solutions/observability/apm/configure-logstash-output.md
@@ -95,7 +95,7 @@ Every event sent to {{ls}} contains a special field called [`@metadata`](logstas
     ...
     "@metadata": {
       "beat": "apm-server", <1>
-      "version": "{{version}}" <2>
+      "version": "{{stack-version}}" <2>
     }
 }
 ```
@@ -218,7 +218,7 @@ The `proxy_use_local_resolver` option determines if {{ls}} hostnames are resolve
 
 #### `index` [apm-logstash-index]
 
-The index root name to write events to. The default is `apm-server`. For example `"apm"` generates `"[apm-]VERSION-YYYY.MM.DD"` indices (for example, _"apm-{{version}}-2017.04.26"_).
+The index root name to write events to. The default is `apm-server`. For example `"apm"` generates `"[apm-]VERSION-YYYY.MM.DD"` indices (for example, _"apm-{{stack-version}}-2017.04.26"_).
 
 ::::{note}
 This parameter’s value will be assigned to the `metadata.beat` field. It can then be accessed in {{ls}}'s output section as `%{[@metadata][beat]}`.

--- a/solutions/observability/apm/get-started-apm-server-binary.md
+++ b/solutions/observability/apm/get-started-apm-server-binary.md
@@ -36,32 +36,32 @@ $$$apm-deb$$$
 **deb:**
 
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{apm_server_version}}-amd64.deb
-sudo dpkg -i apm-server-{{apm_server_version}}-amd64.deb
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{stack-version}}-amd64.deb
+sudo dpkg -i apm-server-{{stack-version}}-amd64.deb
 ```
 
 $$$apm-rpm$$$
 **RPM:**
 
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{apm_server_version}}-x86_64.rpm
-sudo rpm -vi apm-server-{{apm_server_version}}-x86_64.rpm
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{stack-version}}-x86_64.rpm
+sudo rpm -vi apm-server-{{stack-version}}-x86_64.rpm
 ```
 
 $$$apm-linux$$$
 **Other Linux:**
 
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{apm_server_version}}-linux-x86_64.tar.gz
-tar xzvf apm-server-{{apm_server_version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{stack-version}}-linux-x86_64.tar.gz
+tar xzvf apm-server-{{stack-version}}-linux-x86_64.tar.gz
 ```
 
 $$$apm-mac$$$
 **Mac:**
 
 ```shell subs=true
-curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{apm_server_version}}-darwin-x86_64.tar.gz
-tar xzvf apm-server-{{apm_server_version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/apm-server/apm-server-{{stack-version}}-darwin-x86_64.tar.gz
+tar xzvf apm-server-{{stack-version}}-darwin-x86_64.tar.gz
 ```
 
 $$$apm-installing-on-windows$$$
@@ -775,10 +775,10 @@ To add the apm-server repository for APT:
     sudo apt-get install apt-transport-https
     ```
 
-1. Save the repository definition to `/etc/apt/sources.list.d/elastic-9.0.0.list`:
+1. Save the repository definition to `/etc/apt/sources.list.d/elastic-{{stack-version}}.list`:
 
-    ```shell
-    echo "deb https://artifacts.elastic.co/packages/9.0.0-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-9.0.0-prerelease.list
+    ```shell subs=true
+    echo "deb https://artifacts.elastic.co/packages/{{stack-version}}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{{stack-version}}-prerelease.list
     ```
 
     :::{warning}
@@ -815,10 +815,10 @@ To add the apm-server repository for YUM:
 
 1. Create a file with a .repo extension (for example, elastic.repo) in your /etc/yum.repos.d/ directory and add the following lines:
 
-    ```shell
-    [elastic-9.0.0]
-    name=Elastic repository for 9.0.0 packages
-    baseurl=https://artifacts.elastic.co/packages/9.0.0/yum
+    ```shell subs=true
+    [elastic-{{stack-version}}]
+    name=Elastic repository for {{stack-version}} packages
+    baseurl=https://artifacts.elastic.co/packages/{{stack-version}}/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1
@@ -853,27 +853,27 @@ Obtaining APM Server for Docker is as simple as issuing a `docker pull` command 
 
 1. Pull the Docker image:
 
-    ```shell
-    docker pull docker.elastic.co/apm/apm-server:9.0.0
+    ```shell subs=true
+    docker pull docker.elastic.co/apm/apm-server:{{stack-version}}
     ```
 
     Alternately, you can use the hardened [Wolfi](https://wolfi.dev/) image:
 
-    ```shell
-    docker pull docker.elastic.co/apm/apm-server-wolfi:9.0.0
+    ```shell subs=true
+    docker pull docker.elastic.co/apm/apm-server-wolfi:{{stack-version}}
     ```
 
 1. Verify the Docker image:
 
-    ```shell
+    ```shell subs=true
     wget https://artifacts.elastic.co/cosign.pub
-    cosign verify --key cosign.pub docker.elastic.co/apm/apm-server:9.0.0
+    cosign verify --key cosign.pub docker.elastic.co/apm/apm-server:{{stack-version}}
     ```
 
     The `cosign` command prints the check results and the signature payload in JSON format:
 
-    ```shell
-    Verification for docker.elastic.co/apm/apm-server:9.0.0 --
+    ```shell subs=true
+    Verification for docker.elastic.co/apm/apm-server:{{stack-version}} --
     The following checks were performed on each of these signatures:
       - The cosign claims were validated
       - Existence of the claims in the transparency log was verified offline
@@ -896,13 +896,13 @@ curl -L -O https://raw.githubusercontent.com/elastic/apm-server/master/apm-serve
 
 One way to configure APM Server on Docker is to provide `apm-server.docker.yml` via a volume mount. With `docker run`, the volume mount can be specified like this.
 
-```sh
+```sh subs=true
 docker run -d \
   -p 8200:8200 \
   --name=apm-server \
   --user=apm-server \
   --volume="$(pwd)/apm-server.docker.yml:/usr/share/apm-server/apm-server.yml:ro" \
-  docker.elastic.co/apm/apm-server:9.0.0 \
+  docker.elastic.co/apm/apm-server:{{stack-version}} \
   --strict.perms=false -e \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 ```
@@ -918,7 +918,7 @@ The `apm-server.docker.yml` downloaded earlier should be customized for your env
 
 It’s possible to embed your APM Server configuration in a custom image. Here is an example Dockerfile to achieve this:
 
-```dockerfile
-FROM docker.elastic.co/apm/apm-server:9.0.0
+```dockerfile subs=true
+FROM docker.elastic.co/apm/apm-server:{{stack-version}}
 COPY --chmod=0644 --chown=1000:1000 apm-server.yml /usr/share/apm-server/apm-server.yml
 ```

--- a/solutions/observability/apm/get-started-fleet-managed-apm-server.md
+++ b/solutions/observability/apm/get-started-fleet-managed-apm-server.md
@@ -156,8 +156,8 @@ See [Configure Kibana](kibana://reference/configuration-reference/general-settin
 Option 2: Use the {{fleet}} API
 :   Use the {{fleet}} API to install the APM integration. To be successful, this needs to be run against the {{kib}} API, not the {{es}} API.
 
-```yaml
-POST kbn:/api/fleet/epm/packages/apm/9.0.0
+```yaml subs=true
+POST kbn:/api/fleet/epm/packages/apm/{{stack-version}}
 { "force": true }
 ```
 

--- a/solutions/observability/apm/switch-an-elastic-cloud-cluster-to-apm-integration.md
+++ b/solutions/observability/apm/switch-an-elastic-cloud-cluster-to-apm-integration.md
@@ -15,7 +15,7 @@ applies_to:
 
 ## Upgrade the {{stack}} [apm-integration-upgrade-ess-1]
 
-Use the {{ecloud}} Console to upgrade the {{stack}} to version {{version}}. See the [Upgrade guide](/deploy-manage/upgrade/deployment-or-cluster.md) for details.
+Use the {{ecloud}} Console to upgrade the {{stack}} to version {{stack-version}}. See the [Upgrade guide](/deploy-manage/upgrade/deployment-or-cluster.md) for details.
 
 ## Switch to {{agent}} [apm-integration-upgrade-ess-2]
 

--- a/solutions/observability/apm/switch-to-elastic-apm-integration.md
+++ b/solutions/observability/apm/switch-to-elastic-apm-integration.md
@@ -20,7 +20,7 @@ The APM integration offers a number of benefits over the standalone method of ru
 * More granular data control
 * Errors and metrics data streams are shared with other data sources — which means better long-term integration with the logs and metrics apps
 * Removes template inheritance for {{ilm-init}} policies and makes use of new {{es}} index and component templates
-* Fixes _resource 'apm-{{version}}-$type' exists, but it is not an alias_ error
+* Fixes _resource 'apm-{{stack-version}}-$type' exists, but it is not an alias_ error
 
 **APM Integration**:
 

--- a/solutions/observability/infra-and-hosts/add-symbols-for-native-frames.md
+++ b/solutions/observability/infra-and-hosts/add-symbols-for-native-frames.md
@@ -14,8 +14,8 @@ To see function names and line numbers in traces of applications written in prog
 
 Click the appropriate link for your system to download the `symbtool` binary:
 
-* [x86_64](https://artifacts.elastic.co/downloads/prodfiler/symbtool-{{version}}-linux-x86_64.tar.gz)
-* [ARM64](https://artifacts.elastic.co/downloads/prodfiler/symbtool-{{version}}-linux-arm64.tar.gz)
+* [x86_64](https://artifacts.elastic.co/downloads/prodfiler/symbtool-{{stack-version}}-linux-x86_64.tar.gz)
+* [ARM64](https://artifacts.elastic.co/downloads/prodfiler/symbtool-{{stack-version}}-linux-arm64.tar.gz)
 
 ::::{note}
 The `symbtool` binary currently requires a Linux machine.

--- a/solutions/observability/infra-and-hosts/step-4-run-backend-applications.md
+++ b/solutions/observability/infra-and-hosts/step-4-run-backend-applications.md
@@ -500,15 +500,15 @@ docker logs pf-elastic-symbolizer
     For x86_64
 
     ```shell subs=true
-    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{{version}}-linux-x86_64.tar.gz" | tar xzf -
-    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{{version}}-linux-x86_64.tar.gz" | tar xzf -
+    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{{stack-version}}-linux-x86_64.tar.gz" | tar xzf -
+    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{{stack-version}}-linux-x86_64.tar.gz" | tar xzf -
     ```
 
     For ARM64
 
     ```shell subs=true
-    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{{version}}-linux-arm64.tar.gz" | tar xzf -
-    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{{version}}-linux-arm64.tar.gz" | tar xzf -
+    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-collector-{{stack-version}}-linux-arm64.tar.gz" | tar xzf -
+    wget -O- "https://artifacts.elastic.co/downloads/prodfiler/pf-elastic-symbolizer-{{stack-version}}-linux-arm64.tar.gz" | tar xzf -
     ```
 
 2. Copy the `pf-elastic-collector` and `pf-elastic-symbolizer` binaries to a directory in the machine’s `PATH`.

--- a/solutions/observability/logs/ecs-formatted-application-logs.md
+++ b/solutions/observability/logs/ecs-formatted-application-logs.md
@@ -76,36 +76,36 @@ Install {{filebeat}} on the server you want to monitor by running the commands t
 
 ::::::{tab-item} DEB
 ```sh subs=true
-curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-amd64.deb
-sudo dpkg -i filebeat-{{version}}-amd64.deb
+curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-amd64.deb
+sudo dpkg -i filebeat-{{stack-version}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 ```sh subs=true
-curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-x86_64.rpm
-sudo rpm -vi filebeat-{{version}}-x86_64.rpm
+curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-x86_64.rpm
+sudo rpm -vi filebeat-{{stack-version}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} macOS
 ```sh subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-darwin-x86_64.tar.gz
-tar xzvf filebeat-{{version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-darwin-x86_64.tar.gz
+tar xzvf filebeat-{{stack-version}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 ```sh subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-linux-x86_64.tar.gz
-tar xzvf filebeat-{{version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
+tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
-1. Download the [{{filebeat}} Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-windows-x86_64.zip).
+1. Download the [{{filebeat}} Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-windows-x86_64.zip).
 2. Extract the contents of the zip file into `C:\Program Files`.
-3. Rename the _filebeat-{{version}}-windows-x86\_64_ directory to _Filebeat_:
+3. Rename the _filebeat-{{stack-version}}-windows-x86\_64_ directory to _Filebeat_:
 4. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select **Run As Administrator**).
 5. From the PowerShell prompt, run the following commands to install {{filebeat}} as a Windows service:
 

--- a/solutions/observability/logs/plaintext-application-logs.md
+++ b/solutions/observability/logs/plaintext-application-logs.md
@@ -44,36 +44,36 @@ Install {{filebeat}} on the server you want to monitor by running the commands t
 
 ::::::{tab-item} DEB
 ```sh subs=true
-curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-amd64.deb
-sudo dpkg -i filebeat-{{version}}-amd64.deb
+curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-amd64.deb
+sudo dpkg -i filebeat-{{stack-version}}-amd64.deb
 ```
 ::::::
 
 ::::::{tab-item} RPM
 ```sh subs=true
-curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-x86_64.rpm
-sudo rpm -vi filebeat-{{version}}-x86_64.rpm
+curl -L -O https\://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-x86_64.rpm
+sudo rpm -vi filebeat-{{stack-version}}-x86_64.rpm
 ```
 ::::::
 
 ::::::{tab-item} macOS
 ```sh subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-darwin-x86_64.tar.gz
-tar xzvf filebeat-{{version}}-darwin-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-darwin-x86_64.tar.gz
+tar xzvf filebeat-{{stack-version}}-darwin-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Linux
 ```sh subs=true
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-linux-x86_64.tar.gz
-tar xzvf filebeat-{{version}}-linux-x86_64.tar.gz
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-linux-x86_64.tar.gz
+tar xzvf filebeat-{{stack-version}}-linux-x86_64.tar.gz
 ```
 ::::::
 
 ::::::{tab-item} Windows
-1. Download the [{{filebeat}} Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{version}}-windows-x86_64.zip).
+1. Download the [{{filebeat}} Windows zip file](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{stack-version}}-windows-x86_64.zip).
 2. Extract the contents of the zip file into `C:\Program Files`.
-3. Rename the _filebeat-{{version}}-windows-x86_64_ directory to _{{filebeat}}_.
+3. Rename the _filebeat-{{stack-version}}-windows-x86_64_ directory to _{{filebeat}}_.
 4. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select **Run As Administrator**).
 5. From the PowerShell prompt, run the following commands to install {{filebeat}} as a Windows service:
 

--- a/solutions/observability/uptime/get-started.md
+++ b/solutions/observability/uptime/get-started.md
@@ -39,7 +39,7 @@ If you’ve used the Elastic Synthetics integration to create monitors in the pa
 Elastic provides Docker images that you can use to run monitors. Start by pulling the {{heartbeat}} Docker image.
 
 ```sh subs=true
-docker pull docker.elastic.co/beats/heartbeat:{{version}}
+docker pull docker.elastic.co/beats/heartbeat:{{stack-version}}
 ```
 
 ## Configure [uptime-set-up-config]
@@ -89,7 +89,7 @@ docker run \
   --user=heartbeat \
   --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --cap-add=NET_RAW \
-  docker.elastic.co/beats/heartbeat:{{version}} heartbeat -e \
+  docker.elastic.co/beats/heartbeat:{{stack-version}} heartbeat -e \
   -E cloud.id={cloud-id} \
   -E cloud.auth=elastic:{cloud-pass}
 ```
@@ -104,7 +104,7 @@ docker run \
   --user=heartbeat \
   --volume="$PWD/heartbeat.yml:/usr/share/heartbeat/heartbeat.yml:ro" \
   --cap-add=NET_RAW \
-  docker.elastic.co/beats/heartbeat:{{version}} heartbeat -e \
+  docker.elastic.co/beats/heartbeat:{{stack-version}} heartbeat -e \
   -E output.elasticsearch.hosts=["localhost:9200"] \
   -E output.elasticsearch.username=elastic \
   -E output.elasticsearch.password=changeme

--- a/solutions/security/configure-elastic-defend/configure-offline-endpoints-air-gapped-environments.md
+++ b/solutions/security/configure-elastic-defend/configure-offline-endpoints-air-gapped-environments.md
@@ -184,7 +184,7 @@ Download the most recent artifact files from the Elastic global artifact server,
 Below is an example script that downloads all the global artifact updates. There are different artifact files for each version of {{elastic-endpoint}}. Change the value of the `ENDPOINT_VERSION` variable in the example script to match the deployed version of {{elastic-endpoint}}.
 
 ```sh subs=true
-export ENDPOINT_VERSION={{version}} && wget -P downloads/endpoint/manifest https://artifacts.security.elastic.co/downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip && zcat -q downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip | jq -r '.artifacts | to_entries[] | .value.relative_url' | xargs -I@ curl "https://artifacts.security.elastic.co@" --create-dirs -o ".@"
+export ENDPOINT_VERSION={{stack-version}} && wget -P downloads/endpoint/manifest https://artifacts.security.elastic.co/downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip && zcat -q downloads/endpoint/manifest/artifacts-$ENDPOINT_VERSION.zip | jq -r '.artifacts | to_entries[] | .value.relative_url' | xargs -I@ curl "https://artifacts.security.elastic.co@" --create-dirs -o ".@"
 ```
 
 This command will download files and directory structure that should be directly copied to the file server.
@@ -199,7 +199,7 @@ Each new global artifact update release increments a version identifier that you
 To confirm the latest version of the artifacts for a given {{elastic-endpoint}} version, check the published version. This example script checks the version:
 
 ```sh subs=true
-curl -s https://artifacts.security.elastic.co/downloads/endpoint/manifest/artifacts-{{version}}.zip | zcat -q | jq -r .manifest_version
+curl -s https://artifacts.security.elastic.co/downloads/endpoint/manifest/artifacts-{{stack-version}}.zip | zcat -q | jq -r .manifest_version
 ```
 
 Replace `https://artifacts.security.elastic.co` in the command above with your local mirror server to validate that the artifacts are served correctly.

--- a/troubleshoot/ingest/beats-loggingplugin/elastic-logging-plugin-for-docker.md
+++ b/troubleshoot/ingest/beats-loggingplugin/elastic-logging-plugin-for-docker.md
@@ -13,13 +13,13 @@ You can set the debug level to capture debugging output about the Elastic Loggin
 1. Disable the plugin:
 
     ```sh subs=true
-    docker plugin disable elastic/elastic-logging-plugin:{{version}}
+    docker plugin disable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 2. Set the debug level:
 
     ```sh subs=true
-    docker plugin set elastic/elastic-logging-plugin:{{version}} LOG_DRIVER_LEVEL=debug
+    docker plugin set elastic/elastic-logging-plugin:{{stack-version}} LOG_DRIVER_LEVEL=debug
     ```
 
     Where valid settings for `LOG_DRIVER_LEVEL` are `debug`, `info`, `warning`, or `error`.
@@ -27,7 +27,7 @@ You can set the debug level to capture debugging output about the Elastic Loggin
 3. Enable the plugin:
 
     ```sh subs=true
-    docker plugin enable elastic/elastic-logging-plugin:{{version}}
+    docker plugin enable elastic/elastic-logging-plugin:{{stack-version}}
     ```
 
 

--- a/troubleshoot/kibana/alerts.md
+++ b/troubleshoot/kibana/alerts.md
@@ -203,7 +203,7 @@ This approach should be used only temporarily as a last resort to restore functi
 
 ## Limitations [alerting-limitations]
 
-The following limitations and known problems apply to the {{version}} release of the {{kib}} {{alert-features}}:
+The following limitations and known problems apply to the {{stack-version}} release of the {{kib}} {{alert-features}}:
 
 
 ### Alert visibility [_alert_visibility]


### PR DESCRIPTION
This is a temporary solution until we have a solution for https://github.com/elastic/docs-builder/issues/737. I used the substitution key `stack-version` so we can easily search and replace across repos until there's a permanent, centralized solution. 