### PR TITLE
Update ECK monitoring doc for connecting to an external monitoring elasticsearch cluster

### DIFF
--- a/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
@@ -116,7 +116,9 @@ If Logs stack monitoring is configured for a Beat, and custom container argument
 
 ## Connect to an external monitoring {{es}} cluster [k8s_connect_to_an_external_monitoring_elasticsearch_cluster]
 
-If you want to connect to a monitoring {{es}} cluster not managed by ECK, you can reference a Secret instead of an {{es}} cluster in the `monitoring` section through the `secretName` attribute:
+If you want to connect to a monitoring {{es}} cluster not managed by ECK, you can reference a Secret instead of an {{es}} cluster in the `monitoring` section through the `secretName` attribute.
+
+Next example sends cluster metrics to a remote monitoring cluster not managed by ECK, whereas cluster logs are sent to a remote cluster handled by ECK.
 
 ```yaml
 apiVersion: elasticsearch.k8s.elastic.co/v1

--- a/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
@@ -145,7 +145,7 @@ spec:
 ```
 
 1. The `secretName` and `name` attributes are mutually exclusive, you have to choose one or the other.
-2. The `namespace` and `serviceName` attributes can only be used in conjunction with `name`, not with `secretName` and only to reference clusters managed by the same ECK instance.
+2. The `namespace` and `serviceName` attributes can only be used in conjunction with `name`, not with `secretName`, and only to reference clusters managed by the same ECK instance.
 
 The referenced Secret must contain the following connection information:
 

--- a/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
@@ -118,7 +118,7 @@ If Logs stack monitoring is configured for a Beat, and custom container argument
 
 If you want to connect to a monitoring {{es}} cluster not managed by ECK, you can reference a Secret instead of an {{es}} cluster in the `monitoring` section through the `secretName` attribute.
 
-Next example sends cluster metrics to a remote monitoring cluster not managed by ECK, whereas cluster logs are sent to a remote cluster handled by ECK.
+The next example sends cluster metrics to a remote monitoring cluster not managed by ECK, whereas cluster logs are sent to a remote cluster handled by ECK:
 
 ```yaml
 apiVersion: elasticsearch.k8s.elastic.co/v1

--- a/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
+++ b/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md
@@ -145,7 +145,7 @@ spec:
 ```
 
 1. The `secretName` and `name` attributes are mutually exclusive, you have to choose one or the other.
-2. The `namespace` and `serviceName` attributes can only be used in conjunction with `name`, not with `secretName`.
+2. The `namespace` and `serviceName` attributes can only be used in conjunction with `name`, not with `secretName` and only to reference clusters managed by the same ECK instance.
 
 The referenced Secret must contain the following connection information:
 


### PR DESCRIPTION
The example for "Connect to an external monitoring elasticsearch cluster" can lead to confusion or seem to be incorrect (because `secretName` is used only for metrics and not for logs), so I added a small explanation about what the config in the example does.