### PR TITLE
Adds field for serverless release date to docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/internal-request.yaml
+++ b/.github/ISSUE_TEMPLATE/internal-request.yaml
@@ -69,6 +69,14 @@ body:
       default: 0
     validations:
       required: true
+  - type: input
+    id: release-serverless
+    attributes:
+      label: Serverless release
+      description: When do you expect the feature to be promoted and available in the _**serverless production environment**_?
+      placeholder: The week of April 1, 2024
+    validations:
+      required: true    
   - type: dropdown
     id: collaboration
     attributes:


### PR DESCRIPTION
Adds a field to the "Internal documentation request" issue template to allow stakeholders to specify a serverless release date/week for new features.