### PR TITLE
Remove 'Serverless' tag from ILM page

### DIFF
--- a/manage-data/lifecycle/index-lifecycle-management.md
+++ b/manage-data/lifecycle/index-lifecycle-management.md
@@ -5,7 +5,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-concepts.html
 applies_to:
   stack: ga
-  serverless: ga
 ---
 
 # Index lifecycle management


### PR DESCRIPTION
This removes the 'Serverless' tag from the [Index Lifecycle Management](https://www.elastic.co/docs/manage-data/lifecycle/index-lifecycle-management) landing page in the docs.

<img width="532" alt="screen" src="https://github.com/user-attachments/assets/21a9d25e-0ad8-4e6a-b1e7-87dede7d1d2d" />
