### PR TITLE
Docs for Fleet advanced config in ECK

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
+++ b/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
@@ -146,8 +146,23 @@ By default, every reference targets all instances in your {{es}}, {{kib}} and {{
 
 ## Customize {{agent}} configuration [k8s-elastic-agent-fleet-configuration-custom-configuration]
 
-In contrast to {{agents}} in standalone mode, the configuration is managed through {{fleet}}, and it cannot be defined through `config` or `configRef` elements.
+In contrast to {{agents}} in standalone mode, the configuration is managed through {{fleet}}, and it cannot be defined through `config` or `configRef` elements with a few exceptions.
 
+One of those exceptions is the configuration of providers as described in [advanced Agent configuration managed by Fleet](/reference/fleet/advanced-kubernetes-managed-by-fleet.md). When {{agent}} is managed by {{fleet}} and is orchestrated by ECK, the configuration of providers can simply be done through the `.spec.config` element in the Agent resource {applies_to}`stack: 8.13`:
+
+```yaml
+apiVersion: agent.k8s.elastic.co/v1alpha1
+kind: Agent
+metadata:
+  name: elastic-agent
+spec:
+  config:
+    fleet:
+      enabled: true
+    providers.kubernetes:
+      add_resource_metadata:
+        deployment: true
+```
 
 ## Upgrade the {{agent}} specification [k8s-elastic-agent-fleet-configuration-upgrade-specification]
 

--- a/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
+++ b/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
@@ -148,7 +148,7 @@ By default, every reference targets all instances in your {{es}}, {{kib}} and {{
 
 In contrast to {{agents}} in standalone mode, the configuration is managed through {{fleet}}, and it cannot be defined through `config` or `configRef` elements with a few exceptions.
 
-One of those exceptions is the configuration of providers as described in [advanced Agent configuration managed by Fleet](/reference/fleet/advanced-kubernetes-managed-by-fleet.md). When {{agent}} is managed by {{fleet}} and is orchestrated by ECK, the configuration of providers can simply be done through the `.spec.config` element in the Agent resource {applies_to}`stack: ga 8.13`:
+One of those exceptions is the configuration of providers as described in [advanced Agent configuration managed by Fleet](/reference/fleet/advanced-kubernetes-managed-by-fleet.md). When {{agent}} is managed by {{fleet}} and is orchestrated by ECK, the configuration of providers can simply be done through the `.spec.config` element in the Agent resource as of {applies_to}`stack: ga 8.13`:
 
 ```yaml
 apiVersion: agent.k8s.elastic.co/v1alpha1

--- a/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
+++ b/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
@@ -148,7 +148,7 @@ By default, every reference targets all instances in your {{es}}, {{kib}} and {{
 
 In contrast to {{agents}} in standalone mode, the configuration is managed through {{fleet}}, and it cannot be defined through `config` or `configRef` elements with a few exceptions.
 
-One of those exceptions is the configuration of providers as described in [advanced Agent configuration managed by Fleet](/reference/fleet/advanced-kubernetes-managed-by-fleet.md). When {{agent}} is managed by {{fleet}} and is orchestrated by ECK, the configuration of providers can simply be done through the `.spec.config` element in the Agent resource {applies_to}`stack: 8.13`:
+One of those exceptions is the configuration of providers as described in [advanced Agent configuration managed by Fleet](/reference/fleet/advanced-kubernetes-managed-by-fleet.md). When {{agent}} is managed by {{fleet}} and is orchestrated by ECK, the configuration of providers can simply be done through the `.spec.config` element in the Agent resource {applies_to}`stack: ga 8.13`:
 
 ```yaml
 apiVersion: agent.k8s.elastic.co/v1alpha1

--- a/reference/fleet/advanced-kubernetes-managed-by-fleet.md
+++ b/reference/fleet/advanced-kubernetes-managed-by-fleet.md
@@ -106,5 +106,5 @@ volumes:
 
 1. By default the manifests for {{agent}} managed by {{fleet}} have `hostNetwork:true`. In order to support multiple installations of {{agent}}s in the same node you should set `hostNetwork:false`. See this relevant [example](https://github.com/elastic/elastic-agent/tree/main/docs/manifests/hostnetwork) as described in [{{agent}} Manifests in order to support Kube-State-Metrics Sharding](https://github.com/elastic/elastic-agent/blob/main/docs/elastic-agent-ksm-sharding.md).
 2. The volume `/usr/share/elastic-agent/state` must remain mounted in [elastic-agent-managed-kubernetes.yaml](https://github.com/elastic/elastic-agent/blob/main/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml), otherwise custom config map provided above will be overwritten.
-3. If {{agent}} is deployed via ECK, the configuration can be done through a Kubernetes custom resource. See [{{fleet}}-managed {{agent}} on ECK](/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md)
+3. If {{agent}} is deployed through ECK, you can define the provider configuration in the `spec.config` field of the Kubernetes custom resource. Refer to [{{fleet}}-managed {{agent}} on ECK](/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md) for details.
 

--- a/reference/fleet/advanced-kubernetes-managed-by-fleet.md
+++ b/reference/fleet/advanced-kubernetes-managed-by-fleet.md
@@ -106,4 +106,5 @@ volumes:
 
 1. By default the manifests for {{agent}} managed by {{fleet}} have `hostNetwork:true`. In order to support multiple installations of {{agent}}s in the same node you should set `hostNetwork:false`. See this relevant [example](https://github.com/elastic/elastic-agent/tree/main/docs/manifests/hostnetwork) as described in [{{agent}} Manifests in order to support Kube-State-Metrics Sharding](https://github.com/elastic/elastic-agent/blob/main/docs/elastic-agent-ksm-sharding.md).
 2. The volume `/usr/share/elastic-agent/state` must remain mounted in [elastic-agent-managed-kubernetes.yaml](https://github.com/elastic/elastic-agent/blob/main/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml), otherwise custom config map provided above will be overwritten.
+3. If {{agent}} is deployed via ECK, the configuration can by done through a Kubernetes custom resource. See [{{fleet}}-managed {{agent}} on ECK](/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md)
 

--- a/reference/fleet/advanced-kubernetes-managed-by-fleet.md
+++ b/reference/fleet/advanced-kubernetes-managed-by-fleet.md
@@ -106,5 +106,5 @@ volumes:
 
 1. By default the manifests for {{agent}} managed by {{fleet}} have `hostNetwork:true`. In order to support multiple installations of {{agent}}s in the same node you should set `hostNetwork:false`. See this relevant [example](https://github.com/elastic/elastic-agent/tree/main/docs/manifests/hostnetwork) as described in [{{agent}} Manifests in order to support Kube-State-Metrics Sharding](https://github.com/elastic/elastic-agent/blob/main/docs/elastic-agent-ksm-sharding.md).
 2. The volume `/usr/share/elastic-agent/state` must remain mounted in [elastic-agent-managed-kubernetes.yaml](https://github.com/elastic/elastic-agent/blob/main/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml), otherwise custom config map provided above will be overwritten.
-3. If {{agent}} is deployed via ECK, the configuration can by done through a Kubernetes custom resource. See [{{fleet}}-managed {{agent}} on ECK](/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md)
+3. If {{agent}} is deployed via ECK, the configuration can be done through a Kubernetes custom resource. See [{{fleet}}-managed {{agent}} on ECK](/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md)
 


### PR DESCRIPTION
This adds documentation for the feature implemented in https://github.com/elastic/cloud-on-k8s/pull/8623

Merge target is `eck-3.1.0` so that we can in preparation for the next ECK release merge all pertinent docs at once to main. 