### PR TITLE
Updates codeowners for Cloud Security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 /solutions/observability/get-started/       @elastic/ski-docs
 /solutions/search/                          @elastic/developer-docs
 /solutions/security/                        @elastic/experience-docs
+/solutions/security/cloud/                  @elastic/ingest-docs
 
 /troubleshoot/                              @elastic/docs
 /troubleshoot/deployments/                  @elastic/admin-docs


### PR DESCRIPTION
This PR adds the Ingest docs team as codeowners for Cloud Security files under `/solutions/security/cloud/`.