### PR TITLE
Debian pkg config file updated in snippet

### DIFF
--- a/deploy-manage/deploy/self-managed/_snippets/etc-elasticsearch.md
+++ b/deploy-manage/deploy/self-managed/_snippets/etc-elasticsearch.md
@@ -4,7 +4,7 @@ The `setgid` flag applies group permissions on the `/etc/elasticsearch` director
 
 {{es}} loads its configuration from the `/etc/elasticsearch/elasticsearch.yml` file by default. The format of this config file is explained in [](/deploy-manage/deploy/self-managed/configure-elasticsearch.md).
 
-The {{distro}} package also has a system configuration file (`/etc/sysconfig/elasticsearch`), which allows you to set the following parameters:
+The {{distro}} package also has a system configuration file ({{pkg-conf}}), which allows you to set the following parameters:
 
 | Parameter | Description |
 | --- | --- |
@@ -14,5 +14,5 @@ The {{distro}} package also has a system configuration file (`/etc/sysconfig/ela
 | `RESTART_ON_UPGRADE` | Configure restart on package upgrade, defaults to `false`. This means you will have to restart your {{es}} instance after installing a package  manually. The reason for this is to ensure, that upgrades in a cluster do not result in a continuous shard reallocation resulting in high network traffic and reducing the response times of your cluster. |
 
 ::::{note}
-Distributions that use `systemd` require that system resource limits be configured via `systemd` rather than via the `/etc/sysconfig/elasticsearch` file. See [Systemd configuration](/deploy-manage/deploy/self-managed/setting-system-settings.md#systemd) for more information.
+Distributions that use `systemd` require that system resource limits be configured via `systemd` rather than via the {{pkg-conf}} file. See [Systemd configuration](/deploy-manage/deploy/self-managed/setting-system-settings.md#systemd) for more information.
 ::::

--- a/deploy-manage/deploy/self-managed/_snippets/etc-elasticsearch.md
+++ b/deploy-manage/deploy/self-managed/_snippets/etc-elasticsearch.md
@@ -4,7 +4,13 @@ The `setgid` flag applies group permissions on the `/etc/elasticsearch` director
 
 {{es}} loads its configuration from the `/etc/elasticsearch/elasticsearch.yml` file by default. The format of this config file is explained in [](/deploy-manage/deploy/self-managed/configure-elasticsearch.md).
 
-The {{distro}} package also has a system configuration file ({{pkg-conf}}), which allows you to set the following parameters:
+The {{distro}} package also has a system configuration file at the following path:
+ 
+```txt subs=true
+{{pkg-conf}}
+```
+
+In this file, you can set the following parameters:
 
 | Parameter | Description |
 | --- | --- |

--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-debian-package.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-debian-package.md
@@ -13,6 +13,7 @@ sub:
   distro: Debian
   export: "export "
   escape: \
+  pkg-conf: /etc/default/elasticsearch
 ---
 
 # Install {{es}} with a Debian package [deb]

--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
@@ -12,6 +12,7 @@ sub:
   slash: /
   distro: RPM
   export: export
+  pkg-conf: /etc/sysconfig/elasticsearch
 ---
 
 # Install {{es}} with RPM [rpm]


### PR DESCRIPTION
Minor change to fix the package configuration file in the Debian installation guide, which was incorrectly set to the RPM based file.

@shainaraskas : As the content came from a reused snippet we have lost the code formatting. Let me know your preference here. If you want to not use the `snippet` for this block of content or if we keep using it and we lose the code formatting.

If we use \`{{pkg-conf}}\` the substitution doesn't work.

I'm going to write a docs-builder issue to see if we can support inline code blocks with substitutions.

Closes https://github.com/elastic/docs-content/issues/1430

