### PR TITLE
Fixing Automatic Import status to be GA

### DIFF
--- a/solutions/security/get-started/automatic-import.md
+++ b/solutions/security/get-started/automatic-import.md
@@ -3,9 +3,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/security/current/automatic-import.html
   - https://www.elastic.co/guide/en/serverless/current/security-automatic-import.html
 applies_to:
-  stack: preview
+  stack: all
   serverless:
-    security: preview
+    security: all
 products:
   - id: security
   - id: cloud-serverless


### PR DESCRIPTION
Automatic Import went GA in 8.18 / 9.0 so updating the docs to reflect that 

<img width="1885" alt="Screenshot 2025-05-27 at 11 26 59 AM" src="https://github.com/user-attachments/assets/59caafc4-9fef-4af3-95ae-da1c5558f7bb" />
