### PR TITLE
Remove release notes for future versions

### DIFF
--- a/release-notes/fleet-elastic-agent/index.md
+++ b/release-notes/fleet-elastic-agent/index.md
@@ -26,18 +26,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [fleet-elastic-agent-next-fixes]
 % *
 
-## 9.0.2 [fleet-elastic-agent-9.0.2-release-notes]
-
-### Features and enhancements [fleet-elastic-agent-9.0.2-features-enhancements]
-
-* Updates Go version to v1.24.3 in {{fleet}} [#4891]({{fleet-server-pull}}4891)
-	
-* Updates Go version to v1.24.3 in {{agent}} [#8109]({{agent-pull}}8109)
-
-### Fixes [fleet-elastic-agent-9.0.2-fixes]
-
-* Improves the upgrade process for {{agent}} installed using DEB or RPM packages by copying the run directory from the previous installation into the new version's folder [#7999]({{agent-pull}}7999) [#3832]({{agent-issue}}3832)
-
 ## 9.0.1 [fleet-elastic-agent-9.0.1-release-notes]
 
 ### Features and enhancements [fleet-elastic-agent-9.0.1-features-enhancements]


### PR DESCRIPTION
Removes release notes for future versions. To be reverted when 9.0.2 is released. 