### PR TITLE
Specifies that agentless deployment is not supported on GovCloud

### DIFF
--- a/solutions/security/cloud/cloud-security-posture-management.md
+++ b/solutions/security/cloud/cloud-security-posture-management.md
@@ -21,7 +21,7 @@ This feature currently supports agentless and agent-based deployments on Amazon 
 * Minimum privileges vary depending on whether you need to read, write, or manage CSPM data and integrations. Refer to [CSPM privilege requirements](/solutions/security/cloud/cspm-privilege-requirements.md).
 * The CSPM integration is available to all {{ecloud}} users. On-premise deployments require an [Enterprise subscription](https://www.elastic.co/pricing).
 * CSPM only works in the `Default` {{kib}} space. Installing the CSPM integration on a different {{kib}} space will not work.
-* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported. [Click here to request support](https://github.com/elastic/kibana/issues/new/choose).
+* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. AWS GovCloud is only supported for agent-based deployments, agentless deployments do not work on this platform. Other government cloud platforms are not supported. [Click here to request support](https://github.com/elastic/kibana/issues/new/choose).
 
 ::::
 

--- a/solutions/security/cloud/get-started-with-cspm-for-aws.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-aws.md
@@ -21,7 +21,7 @@ This page explains how to get started monitoring the security posture of your cl
 * Minimum privileges vary depending on whether you need to read, write, or manage CSPM data and integrations. Refer to [CSPM privilege requirements](/solutions/security/cloud/cspm-privilege-requirements.md).
 * The CSPM integration is available to all {{ecloud}} users. On-premise deployments require an [Enterprise subscription](https://www.elastic.co/pricing).
 * CSPM only works in the `Default` {{kib}} space. Installing the CSPM integration on a different {{kib}} space will not work.
-* CSPM is supported only on AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. Other government cloud platforms are not supported. [Click here to request support](https://github.com/elastic/kibana/issues/new/choose).
+* CSPM supports the AWS, GCP, and Azure commercial cloud platforms, and AWS GovCloud. AWS GovCloud is only supported for agent-based deployments, agentless deployments do not work on this platform. Other government cloud platforms are not supported. [Click here to request support](https://github.com/elastic/kibana/issues/new/choose).
 * The user who gives the CSPM integration AWS permissions must be an AWS account `admin`.
 
 ::::


### PR DESCRIPTION
Fixes #1524 

Updates the CSPM for AWS page to reflect that agentless is not supported on AWS GovCloud.

Preview: 