### PR TITLE
Fix typo in reference/fleet/index.md

### DIFF
--- a/reference/fleet/index.md
+++ b/reference/fleet/index.md
@@ -29,7 +29,7 @@ As the following diagram illustrates, {{agent}} can monitor the host where it's 
 To learn about installation options, refer to [](/reference/fleet/install-elastic-agents.md).
 
 :::{note}
-Using {{fleet}} and {{agent}} {{serverless-full}}? Note these [restrictions](/reference/fleet/fleet-agent-serverless-restrictions.md).
+Using {{fleet}} and {{agent}} with {{serverless-full}}? Note these [restrictions](/reference/fleet/fleet-agent-serverless-restrictions.md).
 :::
 
 :::{tip}


### PR DESCRIPTION
This PR fixes a typo in reference/fleet/index.md.