### PR TITLE
[Release notes][Serverless & Sec 9.x] Add known issue to release notes for "Entity Risk Score documents eventually fail to persist

### DIFF
--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -18,11 +18,13 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents
 
-On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the default ingest pipeline for the risk scoring index (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) from being created when {{kib}} starts up. While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in an earlier {{serverless-short}} release) from being created when {{kib}} starts up. 
+
+While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 **Workaround**
 
-To resolve this issue, manually create the ingest pipeline in each space in which you have turned on entity risk scoring. This can be done using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
+To resolve this issue, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
 
 ```
 PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
@@ -43,7 +45,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After the above step is complete, risk scores should automatically begin to successfully persist during the entity risk engine's next run cycle. Details for the next run time are described on the  Entity risk score page. From the page, you can manually run the risk score again by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
 
 :::
 

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -20,7 +20,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in an earlier {{serverless-short}} release) from being created when {{kib}} starts up.
 
-While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
+While document persistence may initially succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 **Workaround**
 

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -18,7 +18,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents
 
-On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the default ingest pipeline for the risk scoring index (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the default ingest pipeline for the risk scoring index (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) from being created when {{kib}} starts up. While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
 
 **Workaround**
 

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -22,7 +22,7 @@ On May 30, 2025, it was discovered that the entity risk score feature eventually
 
 **Workaround**
 
-To resolve this issue, manually create the ingest pipeline in each space in which entity risk scoring is turned on. This can be done using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
+To resolve this issue, manually create the ingest pipeline in each space in which you have turned on entity risk scoring. This can be done using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
 
 ```
 PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -18,13 +18,13 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents
 
-On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in an earlier {{serverless-short}} release) from being created when {{kib}} starts up. 
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in an earlier {{serverless-short}} release) from being created when {{kib}} starts up.
 
 While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 **Workaround**
 
-To resolve this issue, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
+To resolve this issue, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the {{kib}} space ID.
 
 ```
 PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
@@ -45,7 +45,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**.
 
 :::
 

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -45,7 +45,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**.
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**.
 
 :::
 

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -16,7 +16,36 @@ Known issues are significant defects or limitations that may impact your impleme
 
 ## Active
 
-There are no active known issues. 
+:::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents
+
+On May 30, 2025, it was discovered that the entity risk score feature eventually stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the default ingest pipeline for the risk scoring index (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+
+**Workaround**
+
+To resolve this issue, manually create the ingest pipeline in each space in which entity risk scoring is turned on. This can be done using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
+
+```
+PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
+{
+  "_meta": {
+    "managed_by": "entity_analytics",
+    "managed": true
+  },
+  "description": "Pipeline for adding timestamp value to event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}
+```
+
+After the above step is complete, risk scores should automatically begin to successfully persist during the entity risk engine's next run cycle. Details for the next run time are described on the  Entity risk score page. From the page, you can manually run the risk score again by clicking **Run Engine**. 
+
+:::
 
 ## Resolved
 

--- a/release-notes/elastic-cloud-serverless/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/known-issues.md
@@ -18,7 +18,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents
 
-On May 30, 2025, it was discovered that the entity risk score feature eventually stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the default ingest pipeline for the risk scoring index (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was previously turned on. This is due to a bug that prevents the default ingest pipeline for the risk scoring index (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
 
 **Workaround**
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -20,7 +20,9 @@ Known issues are significant defects or limitations that may impact your impleme
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
-On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 and before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the default ingest pipeline for the risk scoring index in {{stack}} 8.18.0 (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) from being created when {{kib}} starts up. While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18) from being created when {{kib}} starts up. 
+
+While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 **NOTE:** This bug does not affect {{es}} clusters created in {{stack}} 8.18.0 or 9.0.0 and higher. It also won't affect you if you only turned on entity risk scoring in {{stack}} 8.18.0 or 9.0.0 and higher.
 
@@ -28,7 +30,7 @@ On May 30, 2025, it was discovered that the entity risk score feature may eventu
 
 To resolve this issue, apply the following workaround before or after upgrading to {{stack}} 9.0.0 or higher.  
 
-The first step is to manually create the ingest pipeline in each space in which you have turned on entity risk scoring. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
+First, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
 
 ```
 PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default
@@ -49,7 +51,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After the above step is complete, risk scores should automatically begin to successfully persist during the entity risk engine's next run cycle. Details for the next run time are described on the  Entity risk score page. From the page, you can manually run the risk score again by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
 
 :::
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -16,11 +16,11 @@ Known issues are significant defects or limitations that may impact your impleme
 
 % :::
 
-:::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents
+:::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents.
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
-On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18) from being created when {{kib}} starts up. 
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18) from being created when {{kib}} starts up.
 
 While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
@@ -28,9 +28,9 @@ While document persistence may initially appear to succeed, it will eventually f
 
 **Workaround**
 
-To resolve this issue, apply the following workaround before or after upgrading to {{stack}} 9.0.0 or higher.  
+To resolve this issue, apply the following workaround before or after upgrading to {{stack}} 9.0.0 or higher.
 
-First, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the space ID. 
+First, manually create the ingest pipeline in each space that has entity risk scoring turned on. You can do this using a PUT request, which is described in the example below. When reviewing the example, note that `default` in the example ingest pipeline name below is the {{kib}} space ID.
 
 ```
 PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipeline-default

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -20,7 +20,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
-On May 30, 2025, it was discovered that the entity risk score feature eventually stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 and before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the default ingest pipeline for the risk scoring index in {{stack}} 8.18.0 (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 and before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the default ingest pipeline for the risk scoring index in {{stack}} 8.18.0 (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
 
 **NOTE:** This bug will not affect you if you created an {{es}} cluster in {{stack}} 8.18.0 or 9.0.0 and higher. It also does not affect you if didn’t enable entity risk scoring until {{stack}} 8.18.0 or 9.0.0 and higher.
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -20,7 +20,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
-On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18) from being created when {{kib}} starts up.
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {{stack}} 8.18.0+ or 9.0.0+. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18) from being created when {{kib}} starts up.
 
 While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -51,7 +51,7 @@ PUT /_ingest/pipeline/entity_analytics_create_eventIngest_from_timestamp-pipelin
 }
 ```
 
-After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the  Entity risk score page, where you can also manually run the risk score by clicking **Run Engine**. 
+After you complete this step, risk scores should automatically begin to successfully persist during the entity risk engine's next run. Details for the next run time are described on the **Entity risk score** page, where you can also manually run the risk score by clicking **Run Engine**. 
 
 :::
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -20,7 +20,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
-On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {{stack}} 8.18.0+ or 9.0.0+. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18) from being created when {{kib}} starts up.
+On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {{stack}} 8.18.0+ or 9.0.0+. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18.0) from being created when {{kib}} starts up.
 
 While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -16,7 +16,7 @@ Known issues are significant defects or limitations that may impact your impleme
 
 % :::
 
-:::{dropdown} In {{sec-serverless}}, the entity risk score feature may stop persisting risk score documents.
+:::{dropdown} The entity risk score feature may stop persisting risk score documents
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -20,9 +20,9 @@ Known issues are significant defects or limitations that may impact your impleme
 
 Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
-On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 and before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the default ingest pipeline for the risk scoring index in {{stack}} 8.18.0 (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) to be created when {{kib}} starts up. While document persistence may initially appear to succeed, it eventually fails after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
+On May 30, 2025, it was discovered that the entity risk score feature may eventually stop persisting risk score documents if risk scoring was turned on in {{stack}} 8.18.0 and before you upgraded to {{stack}} 9.0.0 or higher. This is due to a bug that prevents the default ingest pipeline for the risk scoring index in {{stack}} 8.18.0 (`entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>`) from being created when {{kib}} starts up. While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days, which is how long it takes for the risk score data stream to roll over and its underlying index’s settings to take on the new default pipeline.
 
-**NOTE:** This bug will not affect you if you created an {{es}} cluster in {{stack}} 8.18.0 or 9.0.0 and higher. It also does not affect you if didn’t enable entity risk scoring until {{stack}} 8.18.0 or 9.0.0 and higher.
+**NOTE:** This bug does not affect {{es}} clusters created in {{stack}} 8.18.0 or 9.0.0 and higher. It also won't affect you if you only turned on entity risk scoring in {{stack}} 8.18.0 or 9.0.0 and higher.
 
 **Workaround**
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -22,7 +22,7 @@ Applies to: {{stack}} 9.0.1, 9.0.1, 9.0.2
 
 On May 30, 2025, it was discovered that the entity risk score feature may stop persisting risk score documents if risk scoring was turned on before you upgraded to {{stack}} 8.18.0+ or 9.0.0+. This is due to a bug that prevents the `entity_analytics_create_eventIngest_from_timestamp-pipeline-<space_name>` ingest pipeline (which is set as a default pipeline for the risk scoring index in {{stack}} 8.18.0) from being created when {{kib}} starts up.
 
-While document persistence may initially appear to succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
+While document persistence may initially succeed, it will eventually fail after 0 to 30 days. This is how long it takes for the risk score data stream to roll over and apply its underlying index settings to the new default pipeline.
 
 **NOTE:** This bug does not affect {{es}} clusters created in {{stack}} 8.18.0 or 9.0.0 and higher. It also won't affect you if you only turned on entity risk scoring in {{stack}} 8.18.0 or 9.0.0 and higher.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1548 by adding a known issue about the risk score feature in Serverless and Security 9.x. 

Preview: 
- [Elastic Cloud Serverless known issues](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1550/release-notes/elastic-cloud-serverless/known-issues)
- [Security Serverless 9.x known issues](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1550/release-notes/elastic-security/known-issues)

**Corresponding PRs**
- 8.x: https://github.com/elastic/security-docs/pull/6866