### PR TITLE
[Security][Serverless] `enableVisualizationsInFlyout` advanced setting removed from Serverless

### DIFF
--- a/solutions/security/get-started/configure-advanced-settings.md
+++ b/solutions/security/get-started/configure-advanced-settings.md
@@ -132,6 +132,10 @@ Including data from cold and frozen [data tiers](/manage-data/lifecycle/data-tie
 
 ## Access the event analyzer and Session View from the event or alert details flyout [visualizations-in-flyout]
 
+::::{note}
+Available in {{stack}} 9.0.0 only.
+::::
+
 The `securitySolution:enableVisualizationsInFlyout` setting allows you to access the event analyzer and Session View in the **Visualize** [tab](/solutions/security/detect-and-alert/view-detection-alert-details.md#expanded-visualizations-view) on the alert or event details flyout.
 
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1464 by updating the Serverless docs for the `enableVisualizationsInFlyout` advanced setting.

Preview: Access the event analyzer and Session View from the event or alert details flyout 

Corresponding 9.1 PR: TBD