### PR TITLE
[ECE] Clarify supported Ubuntu version

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/configure-host-ubuntu.md
+++ b/deploy-manage/deploy/cloud-enterprise/configure-host-ubuntu.md
@@ -12,7 +12,7 @@ products:
 
 # Configure an Ubuntu host [ece-configure-hosts-ubuntu]
 
-The following instructions show you how to prepare your hosts on 20.04 LTS (Focal Fossa) and Ubuntu 22.04 LTS (Jammy Jellyfish).
+The following instructions show you how to prepare your hosts on Ubuntu.
 
 * [Install Docker 24.0](#ece-install-docker-ubuntu)
 * [Set up XFS quotas](#ece-xfs-setup-ubuntu)
@@ -22,15 +22,10 @@ The following instructions show you how to prepare your hosts on 20.04 LTS (Foca
 
 ## Install Docker [ece-install-docker-ubuntu]
 
-Install Docker LTS version 24.0 for Ubuntu 20.04 or 22.04.
+Install the compatible Docker version on Ubuntu.
 
 ::::{important}
 Make sure to use a combination of Linux distribution and Docker version that is supported, following our official [Support matrix](https://www.elastic.co/support/matrix#elastic-cloud-enterprise). Using unsupported combinations can cause multiple issues with you ECE environment, such as failures to create system deployments, to upgrade workload deployments, proxy timeouts, and more.
-::::
-
-
-::::{note}
-Docker 25 and higher are not compatible with ECE 3.7.
 ::::
 
 
@@ -55,7 +50,7 @@ Docker 25 and higher are not compatible with ECE 3.7.
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
-4. Install the correct version of the `docker-ce` package, for Ubuntu 20.04 LTS (Focal Fossa) or Ubuntu 22.04 LTS (Jammy Jellyfish):
+4. Install the correct version of the `docker-ce` package. Following is an example of installing Docker 24.0. If you decide to install a different Docker version, make sure to replace with the desired version in the commands below.
 
     ```sh
     sudo apt install -y docker-ce=5:24.0.* docker-ce-cli=5:24.0.* containerd.io


### PR DESCRIPTION
(This is the 2nd try of previously wrongly raised PR - https://github.com/elastic/docs-content/pull/1620)

## Description

Previously we specify Ubuntu (Operating system / OS) version directly like 20.04 or 22.04. 
However, we later also 24.04, and maybe in the future we will have even more versions. 

All the compatible and supported version could be found in our support matrix - https://www.elastic.co/support/matrix#elastic-cloud-enterprise. 

But writing the version directly to public doc page other than support matrix seems to be easily forgotten to update, and thus we are left behind in public doc page that it does not mention 24.04 now. 
=> This causes confusion on users, because it's telling different in between public ECE docs and support matrix. 

This was brought up by @rheppe in an internal discussion [here](https://elastic.slack.com/archives/C045W6699NH/p1748919036870519?thread_ts=1748559251.195289&cid=C045W6699NH). 

The rationale is that support matrix is the source of truth, per what we have confirmed with @Kushmaro. So we would like to update the public docs based on support matrix. 

## Additional Notes

- We removed note `Docker 25 and higher are not compatible with ECE 3.7.` because the current branch of docs is for ECE 4.0, and we can see from support matrix, it's supported.
- We also explicitly mentioned that, the command mentioned in `sudo apt install -y docker-ce=5:24.0.* docker-ce-cli=5:24.0.* containerd.io` is just an example of install Docker 24.0 on Ubuntu. We added this because per support matrix, ECE 4.0 also supports other docker versions, and we can see from the screenshots below, it's hard to make an exclusive list in the public doc page, thus it makes more logical sense to say "it's a command example".

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ca2f0c00-427c-46cf-b2fe-05e69a527e90" />


## Before / After PR merge

### Before

<img width="1225" alt="image" src="https://github.com/user-attachments/assets/94ff5f0d-136d-4382-935c-0bba1252ef6d" />


### After

No 20.04 or 22.04 version number present

<img width="1359" alt="image" src="https://github.com/user-attachments/assets/76ad92e3-a439-467a-8f19-75547c8910ba" />
