### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 /solutions/observability/get-started/       @elastic/ski-docs
 /solutions/search/                          @elastic/developer-docs
 /solutions/security/                        @elastic/experience-docs
+/solutions/security/get-started/            @elastic/ingest-docs @elastic/experience-docs
 /solutions/security/cloud/                  @elastic/ingest-docs
 
 /troubleshoot/                              @elastic/docs


### PR DESCRIPTION
Unfortunately, I think the easiest solution for the `get-started` dir is to add both ingest and exp docs. That's noisy, but it's a small number of files so hopefully it's okay. The other two options would be to either:

1. Separate the files into different dirs based on ownership (maybe this is preferable?)
2. Add file-specific rules for each file in the dir (this feels too difficult to maintain)
