### PR TITLE
Document external EDR script picker for CrodwStrike in serverless

### DIFF
--- a/solutions/security/endpoint-response-actions.md
+++ b/solutions/security/endpoint-response-actions.md
@@ -252,6 +252,9 @@ Run a script on a host. You must include one of the following parameters to iden
 
 * `--Raw`: The full script content provided directly as a string.
 * `--CloudFile`: The name of the script stored in a cloud storage location.
+
+   {applies_to}`serverless: ga` When using this parameter, select from a list of saved custom scripts.
+
 * `--HostPath`: The absolute or relative file path of the script located on the host machine.
 
 You can also use these optional parameters:


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1498 by documenting the scripts picker functionality for the `runscript` response action for Crodwstrike in serverless docs. Doc updates for 8.19 and 9.1 will be handled separately.

Preview:

