### PR TITLE
Add refresh_interval and analyzer request examples from old API ref

### DIFF
--- a/deploy-manage/production-guidance/optimize-performance/indexing-speed.md
+++ b/deploy-manage/production-guidance/optimize-performance/indexing-speed.md
@@ -64,7 +64,7 @@ PUT /my-index-000001/_settings
 
 While refresh is disabled, your newly indexed documents will not be visible to search operations. Only re-enable refreshing after your bulk indexing is complete and you need the data to be searchable.
 
-To restore the refresh interval, run the following request with your value:
+To restore the refresh interval, run the following request with your desired value:
 
 ```console
 PUT /my-index-000001/_settings

--- a/deploy-manage/production-guidance/optimize-performance/indexing-speed.md
+++ b/deploy-manage/production-guidance/optimize-performance/indexing-speed.md
@@ -46,6 +46,45 @@ This is the optimal configuration if you have no or very little search traffic (
 
 On the other hand, if your index experiences regular search requests, this default behavior means that {{es}} will refresh your index every 1 second. If you can afford to increase the amount of time between when a document gets indexed and when it becomes visible, increasing the [`index.refresh_interval`](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#index-refresh-interval-setting) to a larger value, e.g. `30s`, might help improve indexing speed.
 
+### Disable refresh interval
+
+To maximize indexing performance during large bulk operations, you can disable refreshing by setting the refresh interval to `-1`. This prevents {{es}} from performing any refreshes during the bulk indexing process.
+
+To disable the refresh interval, run the following request:
+
+```console
+PUT /my-index-000001/_settings
+{
+  "index" : {
+    "refresh_interval" : "-1"
+  }
+}
+```
+
+While refresh is disabled, your newly indexed documents will not be visible to search operations. Only re-enable refreshing after your bulk indexing is complete and you need the data to be searchable.
+
+To restore the refresh interval, run the following request with your value:
+
+```console
+PUT /my-index-000001/_settings
+{
+  "index" : {
+    "refresh_interval" : "5s" <1>
+  }
+}
+```
+
+1. For {{serverless-full}} deployments, `refresh_interval` must be either `-1`, or equal to or greater than `5s`
+
+When bulk indexing is complete, consider running a [force merge](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-forcemerge) {applies_to}`serverless: unavailable` to optimize search performance::
+
+```console
+POST /my-index-000001/_forcemerge?max_num_segments=5
+```
+
+::::{warning}
+Force merge is an expensive operation.
+::::
 
 ## Disable replicas for initial loads [_disable_replicas_for_initial_loads]
 

--- a/deploy-manage/production-guidance/optimize-performance/indexing-speed.md
+++ b/deploy-manage/production-guidance/optimize-performance/indexing-speed.md
@@ -60,6 +60,7 @@ PUT /my-index-000001/_settings
   }
 }
 ```
+% TEST[setup:my_index]
 
 While refresh is disabled, your newly indexed documents will not be visible to search operations. Only re-enable refreshing after your bulk indexing is complete and you need the data to be searchable.
 
@@ -73,6 +74,8 @@ PUT /my-index-000001/_settings
   }
 }
 ```
+% TEST[continued]
+
 
 1. For {{serverless-full}} deployments, `refresh_interval` must be either `-1`, or equal to or greater than `5s`
 
@@ -81,6 +84,7 @@ When bulk indexing is complete, consider running a [force merge](https://www.ela
 ```console
 POST /my-index-000001/_forcemerge?max_num_segments=5
 ```
+% TEST[continued]
 
 ::::{warning}
 Force merge is an expensive operation.

--- a/manage-data/data-store/text-analysis/specify-an-analyzer.md
+++ b/manage-data/data-store/text-analysis/specify-an-analyzer.md
@@ -201,7 +201,7 @@ PUT /my-index-000001/_settings
 ```
 % TEST[continued]
 
-```
+```console
 POST /my-index-000001/_open
 ```
 % TEST[continued]

--- a/manage-data/data-store/text-analysis/specify-an-analyzer.md
+++ b/manage-data/data-store/text-analysis/specify-an-analyzer.md
@@ -122,7 +122,6 @@ GET my-index-000001/_search
 }
 ```
 
-
 ## Specify the search analyzer for a field [specify-search-field-analyzer]
 
 When mapping an index, you can use the [`search_analyzer`](elasticsearch://reference/elasticsearch/mapping-reference/analyzer.md) mapping parameter to specify a search analyzer for each `text` field.
@@ -173,4 +172,42 @@ PUT my-index-000001
 }
 ```
 
+## Update analyzers on existing indices
+```yaml {applies_to}
+serverless: unavailable
+```
 
+You can only define new analyzers on closed indices. To add an analyzer, you must close the index, define the analyzer, and reopen the index.
+
+For example, the following commands add the `content` analyzer to the `my-index-000001` index:
+
+```console
+POST /my-index-000001/_close
+```
+% TEST[setup:my_index]
+
+```console
+PUT /my-index-000001/_settings
+{
+  "analysis" : {
+    "analyzer":{
+      "content":{
+        "type":"custom",
+        "tokenizer":"whitespace"
+      }
+    }
+  }
+}
+```
+% TEST[continued]
+
+```
+POST /my-index-000001/_open
+```
+% TEST[continued]
+
+::::{warning}
+You cannot close the write index of a data stream. To update the analyzer for a data stream's write index and future backing indices, update the analyzer in the [index template](/manage-data/data-store/data-streams/set-up-data-stream.md#create-index-template) used by the stream. Then [roll over the data stream](/manage-data/data-store/data-streams/use-data-stream.md#manually-roll-over-a-data-stream) to apply the new analyzer to the stream's write index and future backing indices. This affects searches and any new data added to the stream after the rollover. However, it does not affect the data stream's backing indices or their existing data.
+
+To change the analyzer for existing backing indices, you must create a new data stream and reindex your data into it. See [Use reindex to change mappings or settings](../data-streams/modify-data-stream.md#data-streams-use-reindex-to-change-mappings-settings).
+::::


### PR DESCRIPTION
Issue: https://github.com/elastic/docs-projects/issues/302


## URL previews:

- https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1697/deploy-manage/production-guidance/optimize-performance/indexing-speed#disable-refresh-interval
- https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/1697/manage-data/data-store/text-analysis/specify-an-analyzer#update-analyzers-on-existing-indices