### PR TITLE
Add Rust client to the list of official clients

### DIFF
--- a/reference/elasticsearch-clients/index.md
+++ b/reference/elasticsearch-clients/index.md
@@ -19,6 +19,7 @@ products:
 - [Python](elasticsearch-py://reference/index.md)
   - [Eland](eland://reference/index.md): Python client and toolkit for DataFrames and machine learning
 - [Ruby](elasticsearch-ruby://reference/index.md)
+- [Rust](elasticsearch-rs://reference/index.md)
 
 ::::{tip}
 Learn how to [connect to your {{es}} endpoint](/solutions/search/search-connection-details.md).


### PR DESCRIPTION
When you visit https://www.elastic.co/docs/reference/elasticsearch-clients/, the official Rust client is not listed, despite being listed in the sidebar.

This PR adds the Rust client to the official client list.