### PR TITLE
Task backlog | Long running search

### DIFF
--- a/troubleshoot/elasticsearch/task-queue-backlog.md
+++ b/troubleshoot/elasticsearch/task-queue-backlog.md
@@ -75,7 +75,7 @@ You can filter on a specific `action`, such as [bulk indexing](https://www.elast
 * Filter on search actions:
 
     ```console
-    GET /_tasks?human&detailed&actions=indices:data/write/search
+    GET /_tasks?human&detailed&actions=indices:*/search
     ```
 
 


### PR DESCRIPTION
👋 howdy, team!  I had a typo, sorry. Searches aren't sub-from-writes, so replacing with an asterisk.