### PR TITLE
Remove callout

### DIFF
--- a/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md
+++ b/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md
@@ -9,10 +9,6 @@ applies_to:
 
 In this quickstart guide, you'll learn how to use the Elastic Cloud Managed OTLP Endpoint to send logs, metrics, and traces to Elastic.
 
-::::{warning}
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
 ## What is the Elastic Cloud Managed OTLP endpoint?
 
 The Managed OTLP Endpoint is a fully managed offering exclusively for Elastic Cloud users (initially available in Elastic Cloud Serverless only) that simplifies OpenTelemetry data ingestion. It provides an endpoint for OpenTelemetry SDKs and Collectors to send telemetry data, with Elastic handling scaling, data processing, and storage.


### PR DESCRIPTION
Removes TA callout for Managed OTLP going GA for Serverless. On hold till 9.1 launches.