### PR TITLE
Add Azure 'eastus' region

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/regions.md
+++ b/deploy-manage/deploy/elastic-cloud/regions.md
@@ -33,10 +33,6 @@ The following AWS regions are currently available:
 
 ## Microsoft Azure regions [regions-azure-regions]
 
-```yaml {applies_to}
-serverless: preview
-```
-
 The following Azure regions are currently available:
 
 | Region | Name |

--- a/release-notes/elastic-cloud-serverless/index.md
+++ b/release-notes/elastic-cloud-serverless/index.md
@@ -11,6 +11,11 @@ Review the changes, fixes, and more to {{serverless-full}}.
 
 For {{serverless-full}} API changes, refer to [APIs Changelog](https://www.elastic.co/docs/api/changes).
 
+## June 26, 2025 [serverless-changelog-06262025]
+
+### Features and enhancements [serverless-changelog-06172025-features-enhancements]
+* {{serverless-full}} is now available in the Microsoft Azure `eastus` [region](/deploy-manage/deploy/elastic-cloud/regions.md). 
+
 ## June 17, 2025 [serverless-changelog-06172025]
 
 ### Features and enhancements [serverless-changelog-06172025-features-enhancements]

--- a/release-notes/elastic-cloud-serverless/index.md
+++ b/release-notes/elastic-cloud-serverless/index.md
@@ -13,7 +13,7 @@ For {{serverless-full}} API changes, refer to [APIs Changelog](https://www.elast
 
 ## June 26, 2025 [serverless-changelog-06262025]
 
-### Features and enhancements [serverless-changelog-06172025-features-enhancements]
+### Features and enhancements [serverless-changelog-06262025-features-enhancements]
 * {{serverless-full}} is now available in the Microsoft Azure `eastus` [region](/deploy-manage/deploy/elastic-cloud/regions.md). 
 
 ## June 17, 2025 [serverless-changelog-06172025]


### PR DESCRIPTION
This: 
 - Adds the [Regions](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/regions) page to remove the "tech preview" marker for the new Azure region
 - Adds an entry in the [Serverless changelog](https://www.elastic.co/docs/release-notes/cloud-serverless) for the new region.

Closes: https://github.com/elastic/platform-docs-team/issues/623