### PR TITLE
Update ECE docs to use version variable

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images.md
@@ -14,9 +14,9 @@ Versions of the {{stack}}, containing {{es}}, {{kib}}, and other products, are a
 
 The first table contains the stack versions that shipped with the 4.0 version of {{ece}}. You can also check the [most recent stack packs and Docker images](#ece-recent-download-list), which might have released after the 4.0 version of ECE, as well as the [full list of available stack packs and Docker images](#ece-full-download-list).
 
-| Docker images included with {{ece}} 4.0.1 |
+| Docker images included with {{ece}} {{ece_version}} |
 | --- |
-| docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1 |
+| docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}} |
 | docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0 |
 | docker.elastic.co/cloud-release/kibana-cloud:8.18.0 |
 | docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0 |

--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
@@ -16,7 +16,7 @@ To perform an offline installation without a private Docker registry, you have t
 1. On an internet-connected host that has Docker installed, download the [Available Docker Images](ece-install-offline-images.md). Note that for ECE version 4.0, if you want to use {{stack}} version 9.0 in your deployments, you need to download and make available both the version 8.x and version 9.x Docker images (the version 8.x images are required for system deployments).
 
     ```sh
-    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}}
     docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0
     docker pull docker.elastic.co/cloud-release/kibana-cloud:8.18.0
     docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0
@@ -26,15 +26,15 @@ To perform an offline installation without a private Docker registry, you have t
     docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:9.0.0
     ```
 
-    For example, for {{ece}} 4.0.1 and the {{stack}} versions it shipped with, you need:
+    For example, for {{ece}} {{ece_version}} and the {{stack}} versions it shipped with, you need:
 
-    * {{ece}} 4.0.1
+    * {{ece}} {{ece_version}}
     * {{es}} 9.0.0, {{kib}} 9.0.0, and APM 9.0.0
 
 2. Create .tar files of the images:
 
     ```sh
-    docker save -o ece.4.0.1.tar docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker save -o ece.{{ece_version}}.tar docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}}
     docker save -o es.8.18.0.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0
     docker save -o kibana.8.18.0.tar docker.elastic.co/cloud-release/kibana-cloud:8.18.0
     docker save -o apm.8.18.0.tar docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0
@@ -48,7 +48,7 @@ To perform an offline installation without a private Docker registry, you have t
 4. On each host, load the images into Docker, replacing `FILE_PATH` with the correct path to the .tar files:
 
     ```sh
-    docker load < FILE_PATH/ece.4.0.1.tar
+    docker load < FILE_PATH/ece.{{ece_version}}.tar
     docker load < FILE_PATH/es.8.18.0.tar
     docker load < FILE_PATH/kibana.8.18.0.tar
     docker load < FILE_PATH/apm.8.18.0.tar

--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-with-registry.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-with-registry.md
@@ -22,7 +22,7 @@ Installing ECE on multiple hosts with your own registry server is simpler, becau
 2. On an internet-connected host that has Docker installed, download the [Available Docker Images](ece-install-offline-images.md) and push them to your private Docker registry. Note that for ECE version 4.0, if you want to use {{stack}} version 9.0 in your deployments, you need to download and make available both the version 8.x and version 9.x Docker images.
 
     ```sh
-    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}}
     docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0
     docker pull docker.elastic.co/cloud-release/kibana-cloud:8.18.0
     docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0
@@ -32,9 +32,9 @@ Installing ECE on multiple hosts with your own registry server is simpler, becau
     docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:9.0.0
     ```
 
-    For example, for {{ece}} 4.0.1 and the {{stack}} versions it shipped with, you need:
+    For example, for {{ece}} {{ece_version}} and the {{stack}} versions it shipped with, you need:
 
-    * {{ece}} 4.0.1
+    * {{ece}} {{ece_version}}
     * {{es}} 9.0.0, {{kib}} 9.0.0, APM 9.0.0
 
     :::{important}
@@ -44,7 +44,7 @@ Installing ECE on multiple hosts with your own registry server is simpler, becau
 3. Tag the Docker images with your private registry URL by replacing `REGISTRY` with your actual registry address, for example `my.private.repo:5000`:
 
     ```sh
-    docker tag docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1 REGISTRY/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker tag docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}} REGISTRY/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}}
     docker tag docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0 REGISTRY/cloud-release/elasticsearch-cloud-ess:8.18.0
     docker tag docker.elastic.co/cloud-release/kibana-cloud:8.18.0 REGISTRY/cloud-release/kibana-cloud:8.18.0
     docker tag docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0 REGISTRY/cloud-release/elastic-agent-cloud:8.18.0
@@ -57,7 +57,7 @@ Installing ECE on multiple hosts with your own registry server is simpler, becau
 4. Push the Docker images to your private Docker registry, using the same tags from the previous step. Replace `REGISTRY` with your actual registry URL, for example `my.private.repo:5000`:
 
     ```sh
-    docker push REGISTRY/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker push REGISTRY/cloud-enterprise/elastic-cloud-enterprise:{{ece_version}}
     docker push REGISTRY/cloud-release/elasticsearch-cloud-ess:8.18.0
     docker push REGISTRY/cloud-release/kibana-cloud:8.18.0
     docker push REGISTRY/cloud-release/elastic-agent-cloud:8.18.0

--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-enterprise.md
@@ -27,16 +27,16 @@ During the upgrade window, there might be a short period of time during which yo
 
 ## The upgrade version matrix [ece-upgrade-version-matrix]
 
-The following table shows the recommended upgrade paths from older {{ece}} versions to 4.0.1.
+The following table shows the recommended upgrade paths from older {{ece}} versions to {{ece_version}}.
 
 | Upgrade from | Recommended upgrade path to 4.0 |
 | --- | --- |
-| Any 3.x version | 1. Upgrade to 3.8.0<br>2. Upgrade to 4.0.1<br> |
-| 2.13 | 1. Upgrade to 3.8.0<br>2. Upgrade to 4.0.1<br> |
-| 2.5-2.12 | 1. Upgrade to 2.13.4<br>2. Upgrade to 3.8.0<br>3. Upgrade to 4.0.1<br> |
-| 2.0-2.4 | 1. Upgrade to 2.5.1<br>2. Upgrade to 2.13.4<br>3. Upgrade to 3.8.0<br>4. Upgrade to 4.0.1<br> |
+| Any 3.x version | 1. Upgrade to 3.8.0<br>2. Upgrade to {{ece_version}}<br> |
+| 2.13 | 1. Upgrade to 3.8.0<br>2. Upgrade to {{ece_version}}<br> |
+| 2.5-2.12 | 1. Upgrade to 2.13.4<br>2. Upgrade to 3.8.0<br>3. Upgrade to {{ece_version}}<br> |
+| 2.0-2.4 | 1. Upgrade to 2.5.1<br>2. Upgrade to 2.13.4<br>3. Upgrade to 3.8.0<br>4. Upgrade to {{ece_version}}<br> |
 
-If you have to upgrade to any of the intermediate versions, follow the upgrade instructions of the relevant release before upgrading to 4.0.1:
+If you have to upgrade to any of the intermediate versions, follow the upgrade instructions of the relevant release before upgrading to {{ece_version}}:
 - [ECE 2.5 Upgrade](https://www.elastic.co/guide/en/cloud-enterprise/2.5/ece-upgrade.html)
 - [ECE 2.13 Upgrade](https://www.elastic.co/guide/en/cloud-enterprise/2.13/ece-upgrade.html)
   
@@ -142,7 +142,7 @@ You can follow along while each container for {{ece}} is upgraded on the hosts t
 By default, ECE updates to the most current available version. If you want to upgrade to a specific ECE version, use the `--cloud-enterprise-version` option:
 
 ```sh
-bash <(curl -fsSL https://download.elastic.co/cloud/elastic-cloud-enterprise.sh) upgrade --user admin --pass $PASSWORD --cloud-enterprise-version 4.0.1
+bash <(curl -fsSL https://download.elastic.co/cloud/elastic-cloud-enterprise.sh) upgrade --user admin --pass $PASSWORD --cloud-enterprise-version {{ece_version}}
 ```
 
 

--- a/docset.yml
+++ b/docset.yml
@@ -274,6 +274,7 @@ subs:
   fleet-server-pull:   "https://github.com/elastic/fleet-server/pull/"
   kib-pull:   "https://github.com/elastic/kibana/pull/"
   stack-version: "9.0.0"
+  ece_version: "4.0.1"
   eck_version: "3.0.0"
   eck_release_branch: "3.0"
   eck_helm_minimum_version: "3.2.0"


### PR DESCRIPTION
This adds an `ece_version` variable to make life a little easier for us on ECE release days. In addition to updating the variable we also need to append the [default system deployment versions](https://github.com/elastic/docs-content/blob/main/deploy-manage/deploy/cloud-enterprise/default-system-deployment-versions.md?expand=1) table.

I've updated the ECE docs release issue template accordingly, via https://github.com/elastic/dev/pull/3187.

Closes: https://github.com/elastic/docs-content/issues/1789

@eedugon  I know you mentioned that you were willing to do this, but since I had the release bump PRs in front of me I figured I'd just push the changes myself. Hope that's okay. :-) 