### PR TITLE
Update agent-command-reference.md

### DIFF
--- a/reference/fleet/agent-command-reference.md
+++ b/reference/fleet/agent-command-reference.md
@@ -28,7 +28,7 @@ Note the following restrictions for running {{agent}} commands:
 * [help](#elastic-agent-help-command)
 * [inspect](#elastic-agent-inspect-command)
 * [install](#elastic-agent-install-command)
-* [otel](#elastic-agent-otel-command) [preview]
+* [otel](#elastic-agent-otel-command)
 * [privileged](#elastic-agent-privileged-command)
 * [restart](#elastic-agent-restart-command)
 * [run](#elastic-agent-run-command)


### PR DESCRIPTION
Remove `preview` tag for the `elastic-agent otel` command, since the EDOT Collector is now GA.