### PR TITLE
[Security] Adds placeholder page for privileged user monitoring

### DIFF
--- a/solutions/security/advanced-entity-analytics/privileged-user-monitoring.md
+++ b/solutions/security/advanced-entity-analytics/privileged-user-monitoring.md
@@ -1,0 +1,13 @@
+---
+applies_to:
+  stack: preview 9.1
+  serverless:
+    security: preview 9.1
+products:
+  - id: security
+  - id: cloud-serverless
+---
+
+# Privileged user monitoring
+
+This page is a placeholder for future documentation.

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -654,5 +654,6 @@ toc:
               - file: security/advanced-entity-analytics/anomaly-detection.md
               - file: security/advanced-entity-analytics/optimizing-anomaly-results.md
               - file: security/advanced-entity-analytics/behavioral-detection-use-cases.md
+          - hidden: security/advanced-entity-analytics/privileged-user-monitoring.md
       - file: security/asset-management.md
       - file: security/apis.md


### PR DESCRIPTION
Adds a hidden placeholder page for privileged user monitoring to enable linking to the future doc from the product onboarding page. 