### PR TITLE
Small ES|QL editor changes for 9.1

### DIFF
--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -15,7 +15,7 @@ The Elasticsearch Query Language, {{esql}}, makes it easier to explore your data
 The examples on this page use the {{kib}} sample web logs in Discover and Lens to explore the data and create visualizations. You can also install it by following [Add sample data](../index.md#gs-get-data-into-kibana).
 
 ::::{tip}
-For the complete {{esql}} documentation, refer to the [{{esql}} documentation](../query-filter/languages/esql.md). For a more detailed overview of {{esql}} in {{kib}}, refer to [Use {{esql}} in Kibana](../query-filter/languages/esql-kibana.md).
+For the complete {{esql}} documentation, including all supported commands, functions, and operators, refer to the [{{esql}} reference](elasticsearch://reference/query-languages/esql/esql-syntax-reference.md). For a more detailed overview of {{esql}} in {{kib}}, refer to [Use {{esql}} in Kibana](../query-filter/languages/esql-kibana.md).
 
 ::::
 
@@ -133,11 +133,4 @@ FROM kibana_sample_data_ecommerce
 :::{image} /explore-analyze/images/kibana-esql-custom-time-series.png
 :alt: ESQL query with a custom time field enabled
 :::
-
-
-### ES|QL and LOOKUP JOINs
-
-The ES|QL editor supports [`LOOKUP JOIN`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-lookup-join) commands and suggests lookup mode indices and join condition fields.
-
-![Using the LOOKUP JOIN command to autocomplete an ES|QL query](https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blte43a30a93241d650/67c23670045f5839e5bfd1e4/lookup-join-demo.gif)
 

--- a/explore-analyze/images/keyboard.svg
+++ b/explore-analyze/images/keyboard.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 3h16v11H0V3Zm15 10V4H1v9h14ZM2 5h2v1H2V5Zm2 7v-1H2v1h2Zm10-1v1h-2v-1h2Zm-3 1v-1H5v1h6ZM5 5h1v1H5V5ZM3 7H2v1h1V7Zm3 0h1v1H6V7ZM3 9H2v1h1V9Zm3 0h1v1H6V9Zm2-4H7v1h1V5ZM4 7h1v1H4V7Zm5 0H8v1h1V7Zm1 0h1v1h-1V7ZM5 9H4v1h1V9Zm3 0h1v1H8V9Zm3 0h-1v1h1V9ZM9 5h1v1H9V5Zm3 0h-1v1h1V5Zm1 0h1v1h-1V5Zm1 2h-2v3h2V7Z" />
+</svg>

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -20,6 +20,9 @@ More specifically, {{esql}} is a powerful tool in Kibana that can help you with 
 
 This guide shows you how to use {{esql}} in Kibana. To follow along with the queries, load the "Sample web logs" sample data set by selecting **Sample Data** from the **Integrations** page in {{kib}}, selecting **Other sample data sets**, and clicking **Add data** on the **Sample web logs** card.
 
+:::{tip}
+Find the complete list of supported commands, functions, and operators in the [{{esql}} reference](elasticsearch://reference/query-languages/esql/esql-syntax-reference.md).
+:::
 
 ## Enable or disable {{esql}} [esql-kibana-enable]
 
@@ -38,7 +41,7 @@ To get started with {{esql}}, go to **Discover**. Next, select **Try ES|QL** fro
 After switching to {{esql}} mode, the query bar shows your previous KQL or Lucene query converted into {{esql}}. If the query was empty, it shows a sample query. For example:
 
 ```esql
-from kibana_sample_data_logs | limit 10
+FROM kibana_sample_data_logs | LIMIT 10
 ```
 
 Every query starts with a [source command](elasticsearch://reference/query-languages/esql/esql-commands.md#esql-source-commands). In this query, the source command is [`FROM`](elasticsearch://reference/query-languages/esql/commands/source-commands.md#esql-from). `FROM` retrieves data from data streams, indices, or aliases. In this example, the data is retrieved from `kibana_sample_data_logs`.
@@ -123,7 +126,7 @@ In the **Starred** tab, find all the queries you have previously starred.
 :::
 
 
-### Organizing the query results [esql-kibana-results-table]
+### Organize the query results [esql-kibana-results-table]
 
 For the example query, the results table shows 10 rows. Omitting the `LIMIT` command, the results table defaults to up to 1000 rows. Using `LIMIT`, you can increase the limit to up to 10,000 rows.
 
@@ -201,6 +204,25 @@ FROM kibana_sample_data_logs
 | WHERE timestamp > NOW() - 15minutes
 ```
 
+### LOOKUP JOINs
+
+The ES|QL editor supports [`LOOKUP JOIN`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-lookup-join) commands and suggests lookup mode indices and join condition fields.
+
+![Using the LOOKUP JOIN command to autocomplete an ES|QL query](https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blte43a30a93241d650/67c23670045f5839e5bfd1e4/lookup-join-demo.gif)
+
+
+### Keyboard shortcuts
+
+The ES|QL editor supports several shortcuts to help you write and run your queries faster:
+
+| Mac           | Windows/Linux  | Description                 |
+|---------------|----------------|-----------------------------|
+| `Cmd + Enter` | `Ctrl + Enter` | Run a query                 |
+| `Cmd + /`     | `Ctrl + /`     | Comment or uncomment a line |
+
+:::{tip}
+You can find the list of shortcuts directly from the editor. Look for the ![keyboard](../../images/keyboard.svg "keyboard =2%") icon.
+:::
 
 ## Analyze and visualize data [esql-kibana-visualizations]
 


### PR DESCRIPTION
Batching a few changes for the various ES|QL editor improvements that don't require a lot of docs.
The main need here for newly supported commands and functions is to make the ES|QL reference quicker to find for anyone reading these docs.

- Adding a direct link to the ES|QL syntax docs from a few pages
- Adding a section about keyboard shortcuts supported by the editor
- Moving the LOOKUP_JOIN section from Discover docs to ES|QL editor docs as it's not Discover specific, and to prepare for future improvements around this command (file upload...)

closes: https://github.com/elastic/docs-content/issues/1677
closes: https://github.com/elastic/docs-content/issues/1678
closes: https://github.com/elastic/docs-content/issues/1680
closes: https://github.com/elastic/docs-content/issues/1681

Other ES|QL-related docs content changes are in the works and will be treated separately:
- https://github.com/elastic/docs-content/issues/1810
- https://github.com/elastic/docs-content/issues/1679
- https://github.com/elastic/docs-content/issues/1669