### PR TITLE
(typo) stack diags no sudo windows

### DIFF
--- a/troubleshoot/elasticsearch/diagnostic.md
+++ b/troubleshoot/elasticsearch/diagnostic.md
@@ -74,7 +74,7 @@ To capture an {{es}} diagnostic:
     **Windows**
 
     ```sh
-    sudo .\diagnostics.bat --type local --host localhost --port 9200 -u elastic -p --bypassDiagVerify --ssl --noVerify
+    .\diagnostics.bat --type local --host localhost --port 9200 -u elastic -p --bypassDiagVerify --ssl --noVerify
     ```
 
     ::::{tip}

--- a/troubleshoot/kibana/capturing-diagnostics.md
+++ b/troubleshoot/kibana/capturing-diagnostics.md
@@ -68,7 +68,7 @@ To run a {{kib}} diagnostic:
     **Windows**
 
     ```sh
-    sudo .\diagnostics.bat --type kibana-local --host localhost --port 5601 -u elastic -p --bypassDiagVerify --ssl --noVerify
+    .\diagnostics.bat --type kibana-local --host localhost --port 5601 -u elastic -p --bypassDiagVerify --ssl --noVerify
     ```
 
     ::::{tip}


### PR DESCRIPTION
👋 @theletterf , per your feedback for the LS diag [here](https://github.com/elastic/docs-content/pull/1726#discussion_r2163535652) removes the `sudo` typo from [ES Diag](https://www.elastic.co/docs/troubleshoot/elasticsearch/diagnostic#diagnostic-capture) and [KB Diag](https://www.elastic.co/docs/troubleshoot/kibana/capturing-diagnostics#kibana-diagnostic-capture) pages.