### PR TITLE
Update ec-vcpu-boost-instance.md

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/ec-vcpu-boost-instance.md
+++ b/deploy-manage/deploy/elastic-cloud/ec-vcpu-boost-instance.md
@@ -24,7 +24,7 @@ Based on the instance size, the vCPU resources assigned to your instance can be 
 
 ## What are vCPU credits? [ec_what_are_vcpu_credits]
 
-[vCPU](/reference/glossary/index.md#glossary-vcpu) credits enable a smaller instance to perform as if it were assigned the vCPU resources of a larger instance, but only for a limited time. vCPU credits are available only on smaller instances up to and including 8 GB of RAM.
+[vCPU](/reference/glossary/index.md#glossary-vcpu) credits enable a smaller instance to perform as if it were assigned the vCPU resources of a larger instance, but only for a limited time. vCPU credits are available only on smaller instances up to and including 12 GB of RAM.
 
 vCPU credits persist through cluster restarts, but they are tied to your existing instance nodes. Operations that create new instance nodes will lose existing vCPU credits. This happens when you resize your instance, or if Elastic performs system maintenance on your nodes.
 


### PR DESCRIPTION
Basically a quick typo fix. 
CPU credits/boosting was for instances up to 8GB, but was lifted to 12GB a while ago. The paragraph above reflects this already, but this one did still say 8GB.