### PR TITLE
Add note to clarify Serverless data storage implications

### DIFF
--- a/manage-data/lifecycle/data-tiers.md
+++ b/manage-data/lifecycle/data-tiers.md
@@ -15,6 +15,10 @@ products:
 
 A *data tier* is a collection of [nodes](elasticsearch://reference/elasticsearch/configuration-reference/node-settings.md) within a cluster that share the same [data node role](elasticsearch://reference/elasticsearch/configuration-reference/node-settings.md#node-roles), and a hardware profile that’s appropriately sized for the role. Elastic recommends that nodes in the same tier share the same hardware profile to avoid [hot spotting](/troubleshoot/elasticsearch/hotspotting.md).
 
+:::{admonition} Serverless manages data storage for you
+By abstracting cluster management tasks, {{serverless-full}} adjusts data storage and scaling based on your workload. Certain [project settings](/deploy-manage/deploy/elastic-cloud/project-settings.md) allow you to customize your data storage layers.
+:::
+
 ## Available data tiers [available-tier]
 
 The data tiers that you use, and the way that you use them, depends on the data’s [category](/manage-data/lifecycle.md). The following data tiers are can be used with each data category:


### PR DESCRIPTION
Fixes #1547 Adding a note to the [Data tiers](https://www.elastic.co/docs/manage-data/lifecycle/data-tiers) page to indicate that users of Serverless don't need to worry about data tiers.

This would be similar to the note on thev [stack settings](https://www.elastic.co/docs/deploy-manage/stack-settings) page.