### PR TITLE
Adds Logstash info to Security ingest page

### DIFF
--- a/solutions/security/get-started/ingest-data-to-elastic-security.md
+++ b/solutions/security/get-started/ingest-data-to-elastic-security.md
@@ -18,11 +18,12 @@ To ingest data, you can use:
 * The [{{agent}}](/reference/fleet/index.md) with the **{{elastic-defend}}** integration, which protects your hosts and sends logs, metrics, and endpoint security data to {{elastic-sec}}. See [Install {{elastic-defend}}](/solutions/security/configure-elastic-defend/install-elastic-defend.md).
 * The {{agent}} with integrations, which are available in the [Elastic Package Registry (EPR)](/reference/fleet/index.md#package-registry-intro). To install an integration that works with {{elastic-sec}}, go to the {{kib}} Home page or navigation menu and click **Add integrations**. On the Integrations page, click the **Security** category filter, then select an integration to view the installation instructions. For more information on integrations, refer to [{{integrations}}](https://docs.elastic.co/en/integrations).
 * **{{beats}}** shippers installed for each system you want to monitor.
+* **{{ls}}** which dynamically ingests, transforms, and ships your data regardless of format.
 * The {{agent}} to send data from Splunk to {{elastic-sec}}. See [Get started with data from Splunk](/solutions/observability/get-started/add-data-from-splunk.md).
 * Third-party collectors configured to ship ECS-compliant data. [](/reference/security/fields-and-object-schemas/siem-field-reference.md) provides a list of ECS fields used in {{elastic-sec}}.
 
 ::::{important}
-If you use a third-party collector to ship data to {{elastic-sec}}, you must map its fields to the [Elastic Common Schema (ECS)](ecs://reference/index.md). Additionally, you must add its index to the {{elastic-sec}} indices (update the **`securitySolution:defaultIndex`** [advanced setting](/solutions/security/get-started/configure-advanced-settings.md#update-sec-indices)).
+If you use a third-party collector — or {{ls}} without {{agent}} or {{beats}} — to ship data to {{elastic-sec}}, you must map its fields to the [Elastic Common Schema (ECS)](ecs://reference/index.md). Additionally, you must add its index to the {{elastic-sec}} indices (update the **`securitySolution:defaultIndex`** [advanced setting](/solutions/security/get-started/configure-advanced-settings.md#update-sec-indices)).
 
 {{elastic-sec}} uses the [`host.name`](ecs://reference/ecs-host.md) ECS field as the primary key for identifying hosts.
 


### PR DESCRIPTION
Fixes #[2910](https://github.com/elastic/security-docs/issues/2910)

Adds info about Logstash to the Security ingest landing page. 