### PR TITLE
Removes applies_to tag for Serverless on Watcher page

### DIFF
--- a/explore-analyze/alerts-cases/watcher/enable-watcher.md
+++ b/explore-analyze/alerts-cases/watcher/enable-watcher.md
@@ -3,7 +3,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/cloud/current/ec-watcher.html
 applies_to:
   stack: ga
-  serverless: ga
 products:
   - id: cloud-hosted
 ---


### PR DESCRIPTION
It seems that the tag was added by mistake as according to the [comparison page](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings#elasticsearch), it's not avaialble in Serverless.