### PR TITLE
[Security][9.x & Serverless] Don't modify index mappings for Alerts indices pt.2

### DIFF
--- a/reference/security/fields-and-object-schemas/alert-schema.md
+++ b/reference/security/fields-and-object-schemas/alert-schema.md
@@ -17,7 +17,7 @@ products:
 
 ::::{important}
 
-* System indices, such as the alerts indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures.
+* System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use runtime fields instead, which allow you to add fields to existing alert and event documents. Refer to [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) to learn more.
 * Users are advised NOT to use the `_source` field in alert documents, but rather to use the `fields` option in the search API to programmatically obtain the list of fields used in these documents. Learn more about [retrieving selected fields from a search](elasticsearch://reference/elasticsearch/rest-apis/retrieve-selected-fields.md).
 ::::
 

--- a/reference/security/fields-and-object-schemas/alert-schema.md
+++ b/reference/security/fields-and-object-schemas/alert-schema.md
@@ -18,7 +18,7 @@ products:
 ::::{important}
 
 * System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) instead, which allow you to add fields to existing alert and event documents.
-* Users are advised NOT to use the `_source` field in alert documents, but rather to use the `fields` option in the search API to programmatically obtain the list of fields used in these documents. Learn more about [retrieving selected fields from a search](elasticsearch://reference/elasticsearch/rest-apis/retrieve-selected-fields.md).
+* We recommend to NOT to use the `_source` field in alert documents, but rather to use the `fields` option in the search API to programmatically obtain the list of fields used in these documents. Learn more about [retrieving selected fields from a search](elasticsearch://reference/elasticsearch/rest-apis/retrieve-selected-fields.md).
 ::::
 
 

--- a/reference/security/fields-and-object-schemas/alert-schema.md
+++ b/reference/security/fields-and-object-schemas/alert-schema.md
@@ -17,7 +17,7 @@ products:
 
 ::::{important}
 
-* System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use runtime fields instead, which allow you to add fields to existing alert and event documents. Refer to [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) to learn more.
+* System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) instead, which allow you to add fields to existing alert and event documents.
 * Users are advised NOT to use the `_source` field in alert documents, but rather to use the `fields` option in the search API to programmatically obtain the list of fields used in these documents. Learn more about [retrieving selected fields from a search](elasticsearch://reference/elasticsearch/rest-apis/retrieve-selected-fields.md).
 ::::
 

--- a/solutions/security/detect-and-alert/about-detection-rules.md
+++ b/solutions/security/detect-and-alert/about-detection-rules.md
@@ -63,7 +63,7 @@ To access data views in {{stack}}, you must have the [required permissions](/exp
 
 ::::{important}
 
-System indices, such as the alerts indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures.
+System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use runtime fields instead, which allow you to add fields to existing alert and event documents. Refer to [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) to learn more.
 
 ::::
 

--- a/solutions/security/detect-and-alert/about-detection-rules.md
+++ b/solutions/security/detect-and-alert/about-detection-rules.md
@@ -63,7 +63,7 @@ To access data views in {{stack}}, you must have the [required permissions](/exp
 
 ::::{important}
 
-System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use runtime fields instead, which allow you to add fields to existing alert and event documents. Refer to [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) to learn more.
+System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) instead, which allow you to add fields to existing alert and event documents.
 
 ::::
 

--- a/solutions/security/detect-and-alert/query-alert-indices.md
+++ b/solutions/security/detect-and-alert/query-alert-indices.md
@@ -17,7 +17,7 @@ This page explains how you should query alert indices, for example, when buildin
 
 ::::{important}
 
-System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use runtime fields instead, which allow you to add fields to existing alert and event documents. Refer to [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) to learn more.
+System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) instead, which allow you to add fields to existing alert and event documents.
 
 ::::
 

--- a/solutions/security/detect-and-alert/query-alert-indices.md
+++ b/solutions/security/detect-and-alert/query-alert-indices.md
@@ -17,7 +17,7 @@ This page explains how you should query alert indices, for example, when buildin
 
 ::::{important}
 
-System indices, such as the alerts indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures.
+System indices, such as the alert indices, contain important configuration and internal data; do not change their mappings. Changes can lead to rule execution and alert indexing failures. Use runtime fields instead, which allow you to add fields to existing alert and event documents. Refer to [runtime fields](/solutions/security/get-started/create-runtime-fields-in-elastic-security.md) to learn more.
 
 ::::
 


### PR DESCRIPTION
Related to https://github.com/elastic/security-team/issues/12799. Updates note that lets users know that they should not modify alert index mappings. Redirects them to runtime fields instead.

Corresponding 8.x PR: https://github.com/elastic/security-docs/pull/6882