### PR TITLE
Update troubleshoot/es/task-queue-backlog.md

### DIFF
--- a/troubleshoot/elasticsearch/task-queue-backlog.md
+++ b/troubleshoot/elasticsearch/task-queue-backlog.md
@@ -69,13 +69,13 @@ You can filter on a specific `action`, such as [bulk indexing](https://www.elast
 * Filter on [bulk index](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-bulk) actions:
 
     ```console
-    GET /_tasks?human&detailed&actions=indices:data/write/bulk
+    GET /_tasks?human&detailed&actions=indices:*write*
     ```
 
 * Filter on search actions:
 
     ```console
-    GET /_tasks?human&detailed&actions=indices:*/search
+    GET /_tasks?human&detailed&actions=indices:*search*
     ```
 
 


### PR DESCRIPTION
👋 baby edit again (sorry) to standardize task investigation to both bulk+individual for both ingest+searches on [this doc](https://www.elastic.co/docs/troubleshoot/elasticsearch/task-queue-backlog#diagnose-task-queue-long-running-node-tasks) to match Slow Logs parity