### PR TITLE
Fix typo in Elastic Agent 'size on disk'

### DIFF
--- a/reference/fleet/install-elastic-agents.md
+++ b/reference/fleet/install-elastic-agents.md
@@ -142,7 +142,7 @@ The disk requirements for {{agent}} vary by operating system and {{stack}} versi
 | Operating system | 8.13 | 8.14 | 8.15 | 8.18 | 9.0 |
 | --- | --- | --- | --- |
 | **Linux** | 1800 MB | 1018 MB | 1060 MB | 1.5 GB | 1.5 GB |
-| **macOS** | 1100 MB | 619 MB | 680 MB | 775 MB | 7755 MB |
+| **macOS** | 1100 MB | 619 MB | 680 MB | 775 MB | 775 MB |
 | **Windows** | 891 MB | 504 MB | 500 MB | 678 MB | 705 MB |
 
 During upgrades, double the disk space is required to store the new {{agent}} binary. After the upgrade completes, the original {{agent}} is removed from disk to free up the space.


### PR DESCRIPTION
Fixes a typo I made in https://github.com/elastic/docs-content/pull/1251, in the Elastic Agent install docs, changing size on disk from 7755 to 775 MB

<img width="609" alt="screen20" src="https://github.com/user-attachments/assets/37777a33-5f45-4460-bdc4-5d9cfc5a93c0" />
