### PR TITLE
ECE redirect fix - Migrate to podman

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/migrate-to-podman-5.md
+++ b/deploy-manage/deploy/cloud-enterprise/migrate-to-podman-5.md
@@ -1,4 +1,6 @@
 ---
+mapped_pages:
+  - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-podman-5-migration.html
 applies_to:
   deployment:
     ece: all


### PR DESCRIPTION
Adds https://www.elastic.co/guide/en/cloud-enterprise/current/ece-podman-5-migration.html to the appropriate doc as a mapped_page.

This is part of the work for https://github.com/elastic/docs-projects/issues/494

In a parallel activity we will request the redirect of that page to https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/migrate-to-podman-5


