### PR TITLE
ECE redirect fix - APM Settings

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm.md
+++ b/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm.md
@@ -2,6 +2,7 @@
 navigation_title: APM user settings
 mapped_pages:
   - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-apm-settings.html
+  - https://www.elastic.co/guide/en/cloud-enterprise/current/ece-apm-settings.html
 applies_to:
   deployment:
     ece: all


### PR DESCRIPTION
Adds https://www.elastic.co/guide/en/cloud-enterprise/current/ece-apm-settings.html to the appropriate doc as a mapped_page.

This is part of the work for https://github.com/elastic/docs-projects/issues/494

In a parallel activity we will request the redirect of that page to https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/edit-stack-settings-apm

