### PR TITLE
[KIBANA][9.x & Serv] Removes tech preview label from `alertuuid` action var 

### DIFF
--- a/explore-analyze/alerts-cases/alerts/rule-action-variables.md
+++ b/explore-analyze/alerts-cases/alerts/rule-action-variables.md
@@ -187,7 +187,7 @@ If the rule’s action frequency is not a summary of alerts, it passes the follo
 :   The ID of the alert that scheduled the action.
 
 `alert.uuid`
-:   A universally unique identifier for the alert. While the alert is active, the UUID value remains unchanged each time the rule runs. [preview]
+:   A universally unique identifier for the alert. While the alert is active, the UUID value remains unchanged each time the rule runs.
 
 #### Context [defining-rules-actions-variable-context]
 


### PR DESCRIPTION
Removed the tech preview label from the `alertuuid` action variable, as per request from @ymao1. 

Corresponding 8.x docs updated via: https://github.com/elastic/kibana/pull/226292