### PR TITLE
Add link to EDOT troubleshooting docs on Ingest troubleshooting main page

### DIFF
--- a/troubleshoot/ingest.md
+++ b/troubleshoot/ingest.md
@@ -9,6 +9,7 @@ applies_to:
 
 Use the topics in this section to troubleshoot ingestion tools:
 
+* [](/troubleshoot/ingest/opentelemetry/index.md)
 * [](/troubleshoot/ingest/logstash.md)
 * [](/troubleshoot/ingest/fleet/fleet-elastic-agent.md)
 * [](/troubleshoot/ingest/beats-loggingplugin/elastic-logging-plugin-for-docker.md)

--- a/troubleshoot/ingest/opentelemetry/index.md
+++ b/troubleshoot/ingest/opentelemetry/index.md
@@ -11,7 +11,8 @@ products:
   - id: edot-sdk
 ---
 
-# Troubleshooting Elastic Distributions of OpenTelemetry (EDOT)
+# Troubleshoot Elastic Distributions of OpenTelemetry (EDOT)
+
 Find solutions to common issues in EDOT components and SDKs.
 
 - [EDOT Collector troubleshooting](/troubleshoot/ingest/opentelemetry/edot-collector/index.md)


### PR DESCRIPTION
Added a link to the EDOT troubleshooting documentation on the main page of the Ingest troubleshooting docs.