### PR TITLE
[Security] Remove enableVisualizationsInFlyout setting

### DIFF
--- a/solutions/security/get-started/configure-advanced-settings.md
+++ b/solutions/security/get-started/configure-advanced-settings.md
@@ -132,9 +132,10 @@ Including data from cold and frozen [data tiers](/manage-data/lifecycle/data-tie
 
 ## Access the event analyzer and Session View from the event or alert details flyout [visualizations-in-flyout]
 
-::::{note}
-Available in {{stack}} 9.0.0 only.
-::::
+```{applies_to}
+stack: removed 9.1
+serverless: removed
+```
 
 The `securitySolution:enableVisualizationsInFlyout` setting allows you to access the event analyzer and Session View in the **Visualize** [tab](/solutions/security/detect-and-alert/view-detection-alert-details.md#expanded-visualizations-view) on the alert or event details flyout.
 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/1464 by tagging the `enableVisualizationsInFlyout` advanced setting as removed in serverless and 9.1.

Preview: [Access the event analyzer and Session View from the event or alert details flyout](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2041/solutions/security/get-started/configure-advanced-settings#visualizations-in-flyout)