### PR TITLE
[Security] Enable endpoint actions in events

### DIFF
--- a/solutions/security/endpoint-response-actions.md
+++ b/solutions/security/endpoint-response-actions.md
@@ -40,12 +40,8 @@ Launch the response console from any of the following places in {{elastic-sec}}:
 * **Endpoints** page → **Actions** menu (**…**) → **Respond**
 * Endpoint details flyout → **Take action** → **Respond**
 * Alert details flyout → **Take action** → **Respond**
-
-  ::::{note}
-  In {{serverless-short}}, you can also launch the response console from the event details flyout (event details flyout → **Take action** → **Respond**).
-  ::::
-  
 * Host details page → **Respond**
+* {applies_to}`stack: ga 9.1` Event details flyout → **Take action** → **Respond** 
 
 To perform an action on the endpoint, enter a [response action command](/solutions/security/endpoint-response-actions.md#response-action-commands) in the input area at the bottom of the console, then press **Return**. Output from the action is displayed in the console.
 

--- a/solutions/security/endpoint-response-actions/isolate-host.md
+++ b/solutions/security/endpoint-response-actions/isolate-host.md
@@ -49,9 +49,9 @@ All actions executed on a host are tracked in the host’s response actions hist
 
 ## Isolate a host [isolate-a-host]
 
-::::{dropdown} Isolate a host from an event (Serverless only) or a detection alert
-1. Open an event ({{serverless-short}} only) or a detection alert:
-    * From the event analyzer view: Click an event. ({{serverless-short}} only)
+::::{dropdown} Isolate a host from an event or a detection alert
+1. Do one of the following:
+    * {applies_to}`stack: ga 9.1` From the event analyzer view: Click an event. 
     * From the Alerts table or Timeline: Click **View details** (![View details icon](/solutions/images/security-view-details-icon.png "title =20x20")).
     * From a case with an attached alert: Click **Show alert details** (**>**).
 
@@ -120,9 +120,9 @@ After the host is successfully isolated, an **Isolated** status is added to the 
 
 ## Release a host [release-a-host]
 
-::::{dropdown} Release a host from an event (Serverless only) or detection alert
-1. Open an event ({{serverless-short}} only) or a detection alert:
-    * From the event analyzer view: Click an event. ({{serverless-short}} only)
+::::{dropdown} Release a host from an event or detection alert
+1. Do one of the following:
+    * {applies_to}`stack: ga 9.1` From the event analyzer view: Click an event.
     * From the Alerts table or Timeline: Click **View details** (![View details icon](/solutions/images/security-view-details-icon.png "title =20x20")).
     * From a case with an attached alert: Click **Show alert details** (**>**).
 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/674 by documenting that endpoint actions are available for events.

Previews:
* [Endpoint response actions](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2042/solutions/security/endpoint-response-actions)
* [Isolate a host](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2042/solutions/security/endpoint-response-actions/isolate-host)