### PR TITLE
Elastic Cloud email service limits added for ECH and Serverless

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md
+++ b/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md
@@ -240,15 +240,6 @@ When attempting to use an unavailable index setting, you'll receive this error:
 }
 ```
 
-## Elastic Cloud email service limits [cloud-email-service-limits]
-
-The following quotas apply to both {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
-
-* Email sending quota: 500 emails per 15min period.
-* Maximum number of recipients per message: 30 recipients per email (To, CC and BCC all count as recipients).
-* Maximum message size (including attachments): 10 MB per message (after base64 encoding).
-* The email-sender can't be customized (Any custom `From:` header will be removed).
-
 ## Learn more
 
 - [{{serverless-full}} roadmap](https://www.elastic.co/cloud/serverless/roadmap): See upcoming features and development plans for the Serverless platform

--- a/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md
+++ b/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md
@@ -240,6 +240,15 @@ When attempting to use an unavailable index setting, you'll receive this error:
 }
 ```
 
+## Elastic Cloud email service limits [cloud-email-service-limits]
+
+The following quotas apply to both {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
+
+* Email sending quota: 500 emails per 15min period.
+* Maximum number of recipients per message: 30 recipients per email (To, CC and BCC all count as recipients).
+* Maximum message size (including attachments): 10 MB per message (after base64 encoding).
+* The email-sender can't be customized (Any custom `From:` header will be removed).
+
 ## Learn more
 
 - [{{serverless-full}} roadmap](https://www.elastic.co/cloud/serverless/roadmap): See upcoming features and development plans for the Serverless platform

--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -81,7 +81,7 @@ Watcher encryption Key Setup is not supported.
 
 Changing the default throttle period is not possible. You can specify a throttle period per watch, however.
 
-Watcher comes preconfigured with a directly usable email account provided by Elastic. However, this account can’t be reconfigured and is subject to some limitations. For more information on the limits of the Elastic mail server, check the [cloud email service limits](../../../explore-analyze/alerts-cases/watcher/enable-watcher.md#cloud-email-service-limits)
+Watcher comes preconfigured with a directly usable email account provided by Elastic. However, this account can’t be reconfigured and is subject to some limitations. For more information on the limits of the Elastic mail server, check the [cloud email service limits](/deploy-manage/deploy/elastic-cloud/tools-apis.md#email-service-limits).
 
 Alternatively, a custom mail server can be configured as described in [Configuring a custom mail server](../../../explore-analyze/alerts-cases/watcher/enable-watcher.md#watcher-custom-mail-server)
 

--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -104,3 +104,16 @@ serverless: unavailable
 
 :::{include} /deploy-manage/deploy/_snippets/tpec.md
 :::
+
+## Elastic Cloud email service
+
+{{ecloud}} provides a built-in email service used by the preconfigured [email connector](kibana://reference/kibana/connectors-kibana/email-action-type.md), available in both {{ech}} deployments and {{serverless-full}} projects. This service can be used to send [alert](/explore-analyze/alerts-cases/alerts) notifications and is also supported in {{ech}} by [watcher](/explore-analyze/alerts-cases/watcher/enable-watcher.md).
+
+### Email service limits
+
+The following quotas apply to both {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
+
+* Email sending quota: 500 emails per 15min period.
+* Maximum number of recipients per message: 30 recipients per email (To, CC and BCC all count as recipients).
+* Maximum message size (including attachments): 10 MB per message (after base64 encoding).
+* The email-sender can't be customized (Any custom `From:` header will be removed).

--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -114,6 +114,6 @@ serverless: unavailable
 The following quotas apply to both {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
 
 * Email sending quota: 500 emails per 15min period.
-* Maximum number of recipients per message: 30 recipients per email (To, CC and BCC all count as recipients).
+* Maximum number of recipients per message: 30 recipients per email (To, CC, and BCC all count as recipients).
 * Maximum message size (including attachments): 10 MB per message (after base64 encoding).
 * The email-sender can't be customized (Any custom `From:` header will be removed).

--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -107,13 +107,13 @@ serverless: unavailable
 
 ## Elastic Cloud email service
 
-{{ecloud}} provides a built-in email service used by the preconfigured [email connector](kibana://reference/kibana/connectors-kibana/email-action-type.md), available in both {{ech}} deployments and {{serverless-full}} projects. This service can be used to send [alert](/explore-analyze/alerts-cases/alerts) notifications and is also supported in {{ech}} by [watcher](/explore-analyze/alerts-cases/watcher/enable-watcher.md).
+{{ecloud}} provides a built-in email service used by the preconfigured [email connector](kibana://reference/connectors-kibana/email-action-type.md), available in both {{ech}} deployments and {{serverless-full}} projects. This service can be used to send [alert](/explore-analyze/alerts-cases/alerts.md) notifications and is also supported in {{ech}} by [Watcher](/explore-analyze/alerts-cases/watcher/enable-watcher.md).
 
 ### Email service limits
 
 The following quotas apply to both {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
 
-* Email sending quota: 500 emails per 15min period.
+* Email sending quota: 500 emails per 15 minute period.
 * Maximum number of recipients per message: 30 recipients per email (To, CC, and BCC all count as recipients).
-* Maximum message size (including attachments): 10 MB per message (after base64 encoding).
+* Maximum message size (including attachments): 10 MB per message (after Base64 encoding).
 * The email-sender can't be customized (Any custom `From:` header will be removed).

--- a/explore-analyze/alerts-cases/watcher/enable-watcher.md
+++ b/explore-analyze/alerts-cases/watcher/enable-watcher.md
@@ -37,12 +37,7 @@ For more information on sending alerts by email, check [Email action](../../../e
 
 ## Cloud email service limits [cloud-email-service-limits]
 
-The following quotas apply when using the Elastic email service:
-
-* Email sending quota: 500 emails per 15min period
-* Maximum number of recipients per message: 30 recipients per email (To, CC and BCC all count as recipients).
-* Maximum message size (including attachments): 10 MB per message (after base64 encoding).
-* The email-sender can’t be customized (Any custom `From:` header will be removed)
+Refer to [Email service limits](/deploy-manage/deploy/elastic-cloud/tools-apis.md#email-service-limits).
 
 ## Advanced usage [advanced_usage]
 


### PR DESCRIPTION
As described in https://github.com/elastic/docs-content/issues/1952, email service limits are applicable to both ECH and Serverless deployments.

Currently the ECH limits are described in https://www.elastic.co/docs/explore-analyze/alerts-cases/watcher/enable-watcher#cloud-email-service-limits, and linked from https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/restrictions-known-problems#ec-restrictions-watcher.

I've added them [here](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2044/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings#cloud-email-service-limits).

I was doubting between that page and the [Elastic Cloud landing page](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2044/deploy-manage/deploy/elastic-cloud), but it didn't feel right to describe the email limits in such a general page.