### PR TITLE
Clarify free instance description

### DIFF
--- a/deploy-manage/cloud-organization/billing/billing-faq.md
+++ b/deploy-manage/cloud-organization/billing/billing-faq.md
@@ -99,7 +99,7 @@ $$$faq-included$$$What is included in my paid {{ech}} deployment?
 
     * Free 1GB RAM {{kib}} instance
     * Free 1GB RAM Machine Learning node
-    * Free 1GB RAM APM server
+    * Free 1GB RAM APM / Integrations Server instance
     * A free allowance for [data transfer and snapshot storage costs](#faq-dts)
 
     Note that if you go above the free tier of Kibana/ML/APM (for example, a 2GB {{kib}} instance), you will be charged in full for the size of that instance.


### PR DESCRIPTION
Clarify free instance description.

## Description

### [1]
In stack >= 8.0, we introduced Integrations Server which also free to use 1GB. 

<img width="442" height="68" alt="Image" src="https://github.com/user-attachments/assets/1726019e-81e6-4e5f-b0ae-3a6796197949" />

Added this. 


### [2]
In stack < 8.0, we have "APM". 
The accurate term is "APM & Fleet". 
<img width="423" height="53" alt="Image" src="https://github.com/user-attachments/assets/15fce0fe-e0d1-4c88-8b61-ec7772ce08df" />


It's documented as "APM server".
https://www.elastic.co/docs/deploy-manage/cloud-organization/billing/billing-faq#faq-included 

If we say "APM & Fleet / Integrations Server", it will cause confusion because of mixed `&` and `/` presence.

We want to keep the understanding at most while reduce the confusion. Based on this thought, I rewrote it to "APM / Integrations Server".

## Preview

https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2049/deploy-manage/cloud-organization/billing/billing-faq#faq-included

cc @jmoon-elastic