### PR TITLE
docs(eck): update k8s supported versions

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s.md
+++ b/deploy-manage/deploy/cloud-on-k8s.md
@@ -69,7 +69,7 @@ This section outlines the supported Kubernetes and {{stack}} versions for ECK. C
 
 ECK is compatible with the following Kubernetes distributions and related technologies:
 
-* Kubernetes 1.28-1.32
+* Kubernetes 1.28-1.33
 * OpenShift 4.14-4.18
 * Google Kubernetes Engine (GKE), Azure Kubernetes Service (AKS), and Amazon Elastic Kubernetes Service (EKS)
 * Helm: {{eck_helm_minimum_version}}+


### PR DESCRIPTION
## Context

This change aims to standardize Kubernetes-supported versions across various pieces of documentation.

## Implementation details

Document Kubernetes version compatibility as in https://github.com/elastic/cloud-on-k8s#elastic-cloud-on-kubernetes-eck.