### PR TITLE
Update configuration-fleet.md

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
+++ b/deploy-manage/deploy/cloud-on-k8s/configuration-fleet.md
@@ -253,7 +253,7 @@ In order to run {{agent}} as a non-root user you must choose how you want to per
 1. Run {{agent}} with an `emptyDir` volume. This has the downside of not persisting data between restarts of the {{agent}} which can duplicate work done by the previous running Agent.
 2. Run {{agent}} with a `hostPath` volume in addition to a `DaemonSet` running as `root` that sets up permissions for the `agent` user.
 
-In addition to these decisions, if you are running {{agent}} in {{fleet}} mode as a non-root user, you must configure `certificate_authorities.ssl` in each `xpack.fleet.outputs` to trust the CA of the {{es}} Cluster.
+In addition to these decisions, if you are running {{agent}} in {{fleet}} mode as a non-root user, you must configure `ssl.certificate_authorities` in each `xpack.fleet.outputs` to trust the CA of the {{es}} Cluster.
 
 To run {{agent}} with an `emptyDir` volume.
 


### PR DESCRIPTION
fixed the typo: `certificate_authorities.ssl` to `ssl.certificate_authorities`.

The example config is in the bottom of the same [page](https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/configuration-fleet#k8s-elastic-agent-running-as-a-non-root-user), or check this [reference example](https://www.elastic.co/docs/reference/fleet/secure-connections#_encrypt_traffic_between_agents_fleet_server_and_es), too:

```
ssl.certificate_authorities: ["/path/to/your/elasticsearch-ca.crt"]
```