### PR TITLE
Fleet Server / Elastic Agent 9.0.4 release notes 

### DIFF
--- a/release-notes/fleet-elastic-agent/index.md
+++ b/release-notes/fleet-elastic-agent/index.md
@@ -32,20 +32,20 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 **Elastic Agent**
 
-* Add File Logs Only Motel Kube-Stack Configuration. [#8785]({{agent-pull}}8785)
+* Add file logs only motel kube-stack configuration. [#8785]({{agent-pull}}8785)
 
 ### Fixes [fleet-elastic-agent-9.0.4-fixes]
 
 **Elastic Agent**
 
-* Remove Incorrect Logging That Unprivileged Installations Are In Beta. [#8715]({{agent-pull}}8715) [#8689]({{agent-issue}}8689)
-* Ensure Standalone Elastic Agent Uses Log Level From Configuration Instead Of Persisted State. [#8784]({{agent-pull}}8784) [#8137]({{agent-issue}}8137)
-* Resolve Deadlocks In Runtime Checkin Communication. [#8881]({{agent-pull}}8881) [#7944]({{agent-issue}}7944)
-* Remove Init.d Support From Rpm Packages. [#8896]({{agent-pull}}8896) [#8840]({{agent-issue}}8840)
+* Remove incorrect logging that unprivileged installations are in beta. [#8715]({{agent-pull}}8715) [#8689]({{agent-issue}}8689)
+* Ensure standalone Elastic Agent uses log level from configuration instead of persisted state. [#8784]({{agent-pull}}8784) [#8137]({{agent-issue}}8137)
+* Resolve deadlocks in runtime checkin communication. [#8881]({{agent-pull}}8881) [#7944]({{agent-issue}}7944)
+* Remove init.d support from RPM packages. [#8896]({{agent-pull}}8896) [#8840]({{agent-issue}}8840)
 
 **Fleet Server**
 
-* Include The Base Error For Json Decode Error Responses. [#5069]({{fleet-server-pull}}5069)
+* Include the base error for JSON decode error responses. [#5069]({{fleet-server-pull}}5069)
 
 ## 9.0.3 [fleet-elastic-agent-9.0.3-release-notes]
 

--- a/release-notes/fleet-elastic-agent/index.md
+++ b/release-notes/fleet-elastic-agent/index.md
@@ -26,6 +26,27 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [fleet-elastic-agent-next-fixes]
 % *
 
+## 9.0.4 [fleet-elastic-agent-9.0.4-release-notes]
+
+### Features and enhancements [fleet-elastic-agent-9.0.4-features-enhancements]
+
+**Elastic Agent**
+
+* Add File Logs Only Motel Kube-Stack Configuration. [#8785]({{agent-pull}}8785)
+
+### Fixes [fleet-elastic-agent-9.0.4-fixes]
+
+**Elastic Agent**
+
+* Remove Incorrect Logging That Unprivileged Installations Are In Beta. [#8715]({{agent-pull}}8715) [#8689]({{agent-issue}}8689)
+* Ensure Standalone Elastic Agent Uses Log Level From Configuration Instead Of Persisted State. [#8784]({{agent-pull}}8784) [#8137]({{agent-issue}}8137)
+* Resolve Deadlocks In Runtime Checkin Communication. [#8881]({{agent-pull}}8881) [#7944]({{agent-issue}}7944)
+* Removed Init.d Support From Rpm Packages. [#8896]({{agent-pull}}8896) [#8840]({{agent-issue}}8840)
+
+**Fleet Server**
+
+* Include The Base Error For Json Decode Error Responses. [#5069]({{fleet-server-pull}}5069)
+
 ## 9.0.3 [fleet-elastic-agent-9.0.3-release-notes]
 
 ### Features and enhancements [fleet-elastic-agent-9.0.3-features-enhancements]

--- a/release-notes/fleet-elastic-agent/index.md
+++ b/release-notes/fleet-elastic-agent/index.md
@@ -41,7 +41,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Remove Incorrect Logging That Unprivileged Installations Are In Beta. [#8715]({{agent-pull}}8715) [#8689]({{agent-issue}}8689)
 * Ensure Standalone Elastic Agent Uses Log Level From Configuration Instead Of Persisted State. [#8784]({{agent-pull}}8784) [#8137]({{agent-issue}}8137)
 * Resolve Deadlocks In Runtime Checkin Communication. [#8881]({{agent-pull}}8881) [#7944]({{agent-issue}}7944)
-* Removed Init.d Support From Rpm Packages. [#8896]({{agent-pull}}8896) [#8840]({{agent-issue}}8840)
+* Remove Init.d Support From Rpm Packages. [#8896]({{agent-pull}}8896) [#8840]({{agent-issue}}8840)
 
 **Fleet Server**
 


### PR DESCRIPTION
Converts release notes generated in https://github.com/elastic/elastic-agent/pull/8977 and https://github.com/elastic/fleet-server/pull/5152 to Markdown and adds them to this repo. 

cc @pierrehilbert 