### PR TITLE
API releases link removed, blog link updated

### DIFF
--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -17,3 +17,4 @@ We recommend you upgrade to the latest Elastic version. To learn how to upgrade,
 To learn more about Elastic releases, use the following resources:
 * Join the [Elastic community forums](https://discuss.elastic.co/)
 * Check out the release announcements on the [Elastic Blog](https://www.elastic.co/blog/category/releases)
+* Reach out to [Elastic Support](https://www.elastic.co/support)

--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -12,11 +12,8 @@ Learn about the latest changes, issues, fixes, and deprecations for Elastic rele
 
 To view the changes in previous versions, go to [Release docs](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/8.18/new.html).
 
-For information about the latest changes to Elastic APIs, check [APIs changelog](https://www.elastic.co/docs/api/changes).
-
 We recommend you upgrade to the latest Elastic version. To learn how to upgrade, check [Upgrade](/deploy-manage/upgrade.md).
 
 To learn more about Elastic releases, use the following resources:
 * Join the [Elastic community forums](https://discuss.elastic.co/)
-* Check out the [Elastic Blog](https://www.elastic.co/blog)
-* Reach out to [Elastic Support](https://mail.google.com/mail/u/0/?fs=1&tf=cm&source=mailto&to=support@elastic.co)
+* Check out the release announcements on the [Elastic Blog](https://www.elastic.co/blog/category/releases)


### PR DESCRIPTION
A few changes to our release notes landing page:

- Text and link to release API doc removed, as we don't have that doc anymore.
- Link to blog post updated to link release announcement blog posts, as it's more accurate in the context of the doc.
- Changed the link to contact elastic support.



