### PR TITLE
[Website]: attribute_delimiters.groups setting mislabeled in saml docs

### DIFF
--- a/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md
@@ -265,7 +265,7 @@ groups
 :   *(Recommended)* If you want to use your IdP’s concept of groups or roles as the basis for a user’s {{es}} privileges, you should map them with this attribute. The `groups` are passed directly to your [role mapping rules](/deploy-manage/users-roles/cluster-or-deployment-auth/saml.md#saml-role-mapping).
 
     :::{note}
-    Some IdPs are configured to send the `groups` list as a single value, comma-separated string. To map this SAML attribute to the `attributes.groups` setting in the {{es}} realm, you can configure a string delimiter using the `attribute_delimiters.group` setting.<br><br>For example, splitting the SAML attribute value `engineering,elasticsearch-admins,employees` on a delimiter value of `,` will result in `engineering`, `elasticsearch-admins`, and `employees` as the list of groups for the user.
+    Some IdPs are configured to send the `groups` list as a single value, comma-separated string. To map this SAML attribute to the `attributes.groups` setting in the {{es}} realm, you can configure a string delimiter using the `attribute_delimiters.groups` setting.<br><br>For example, splitting the SAML attribute value `engineering,elasticsearch-admins,employees` on a delimiter value of `,` will result in `engineering`, `elasticsearch-admins`, and `employees` as the list of groups for the user.
     ::::
 
 name


### PR DESCRIPTION
It is possible to set a delimiter for IdPs that pass groups as a, eg, a single comma-separated list by setting the  `xpack.security.authc.realms.saml.kibana_real.attribute_delimiters.groups` setting. However, the current docs call it `xpack.security.authc.realms.saml.kibana_real.attribute_delimiters.group` (https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/saml#saml-es-user-properties). 

<img width="882" height="392" alt="image" src="https://github.com/user-attachments/assets/c7c36508-ea4f-4e7c-ab0b-b8e07770acd2" />

This PR corrects that error.

Our old docs here have the correct setting as well https://www.elastic.co/guide/en/elasticsearch/reference/8.18/security-settings.html.