### PR TITLE
Security 9.0.4 release notes fix

### DIFF
--- a/release-notes/elastic-security/index.md
+++ b/release-notes/elastic-security/index.md
@@ -37,6 +37,8 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Updates a placeholder and validation message in the **Related Integrations** section of the rule upgrade flyout [#225775]({{kib-pull}}225775).
 * Excludes {{ml}} rules from installation and upgrade checks for users with Basic or Essentials licenses [#224676]({{kib-pull}}224676).
 * Allows using days as a time unit in rule schedules, fixing an issue where durations normalized to days were incorrectly displayed as 0 seconds [#224083]({{kib-pull}}224083).
+* Fixes a bug where unmodified prebuilt rules installed before v8.18 didn't appear in the **Upgrade** table when the **Unmodified** filter was selected [#227859]({{kib-pull}}227859).
+* Improves UI copy for the "bulk update with conflicts" modal [#227803]({{kib-pull}}227803).
 * Strips `originId` from connectors before rule import to ensure correct ID regeneration and prevent errors when migrating connector references on rules [#223454]({{kib-pull}}223454).
 * Fixes an issue that prevented the AI Assistant Knowledge Base settings UI from displaying [#225033]({{kib-pull}}225033).
 * Fixes a bug in {{elastic-defend}} where Linux network events would fail to load if IPv6 is not supported by the system.


### PR DESCRIPTION
A couple of Rule Management PRs were incorrectly picked up for the 9.1.0 RNs instead of 9.0.4. This PR adds them to the 9.0.4 RNs.