### PR TITLE
Update playground.md

### DIFF
--- a/solutions/search/rag/playground.md
+++ b/solutions/search/rag/playground.md
@@ -3,18 +3,14 @@ mapped_pages:
   - https://www.elastic.co/guide/en/serverless/current/elasticsearch-playground.html
   - https://www.elastic.co/guide/en/kibana/current/playground.html
 applies_to:
-  stack:
-  serverless:
+  stack: preview 9.0, beta 9.1
+  serverless: beta
 products:
   - id: cloud-serverless
   - id: kibana
 ---
 
 # Playground [playground]
-
-::::{warning}
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
 
 Use Playground to combine your Elasticsearch data with the power of large language models (LLMs) for retrieval augmented generation (RAG). The chat interface translates your natural language questions into {{es}} queries, retrieves the most relevant results from your {{es}} documents, and passes those documents to the LLM to generate tailored responses.
 


### PR DESCRIPTION
Updated Playground doc with applies_to tags and removed the on-page warning in lieu of the badges that accompany the tags.