### PR TITLE
Minor fixes in lifecycle docs

### DIFF
--- a/manage-data/lifecycle/index-lifecycle-management/policy-view-status.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-view-status.md
@@ -29,7 +29,7 @@ For any existing managed index in your cluster, you can access the ILM policy ap
 :::{tip}
 {{es}} comes with many built-in ILM policies. For standard Observability or Security use cases, you will have two {{ilm-init}} policies configured automatically: `logs@lifecycle` for logs and `metrics@lifecycle` for metrics.
 
-To learn how to create a specialized ILM policy for any data stream, such as those created when you install an Elastic Integration, refer to our tutorial [Customize built-in policies](/manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) [Customize built-in policies](/manage-data/lifecycle/index-lifecycle-management/tutorial-customize-built-in-policies.md).
+To learn how to create a specialized ILM policy for any data stream, such as those created when you install an Elastic Integration, refer to our tutorial [Customize built-in policies](/manage-data/lifecycle/index-lifecycle-management/tutorial-customize-built-in-policies.md).
 :::
 
 **To view the current lifecycle status for a datastream:**

--- a/manage-data/lifecycle/index-lifecycle-management/policy-view-status.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-view-status.md
@@ -29,7 +29,7 @@ For any existing managed index in your cluster, you can access the ILM policy ap
 :::{tip}
 {{es}} comes with many built-in ILM policies. For standard Observability or Security use cases, you will have two {{ilm-init}} policies configured automatically: `logs@lifecycle` for logs and `metrics@lifecycle` for metrics.
 
-To learn how to create a specialized ILM policy for any data stream, such as those created when you install an Elastic Integration, refer to our tutorial [Customize built-in policies](/manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md).
+To learn how to create a specialized ILM policy for any data stream, such as those created when you install an Elastic Integration, refer to our tutorial [Customize built-in policies](/manage-data/lifecycle/index-lifecycle-management/tutorial-automate-rollover.md) [Customize built-in policies](/manage-data/lifecycle/index-lifecycle-management/tutorial-customize-built-in-policies.md).
 :::
 
 **To view the current lifecycle status for a datastream:**

--- a/manage-data/lifecycle/index-lifecycle-management/rollover.md
+++ b/manage-data/lifecycle/index-lifecycle-management/rollover.md
@@ -39,7 +39,7 @@ When an index is rolled over, the previous index’s age is updated to reflect t
 
 ## Automatic rollover [ilm-automatic-rollover]
 
-{{ilm-init}} and the data stream lifecycle (in [preview]]) enable you to automatically roll over to a new index based on conditions like the index size, document count, or age. When a rollover is triggered, a new index is created, the write alias is updated to point to the new index, and all subsequent updates are written to the new index.
+{{ilm-init}} and the data stream lifecycle enable you to automatically roll over to a new index based on conditions like the index size, document count, or age. When a rollover is triggered, a new index is created, the write alias is updated to point to the new index, and all subsequent updates are written to the new index.
 
 ::::{tip}
 Rolling over to a new index based on size, document count, or age is preferable to time-based rollovers. Rolling over at an arbitrary time often results in many small indices, which can have a negative impact on performance and resource usage.


### PR DESCRIPTION
This fixes two super small glitches in the data lifecycle docs:

 - In the [Automatic rollover](https://www.elastic.co/docs/manage-data/lifecycle/index-lifecycle-management/rollover#ilm-automatic-rollover) section we have a non-working preview tag, which should just be removed.

 - In this new [View the lifecycle status of an index](https://www.elastic.co/docs/manage-data/lifecycle/index-lifecycle-management/policy-view-status) I included a link that points to the wrong tutorial.




