### PR TITLE
Add "No data visible in Kibana" - EDOT troubleshooting

### DIFF
--- a/troubleshoot/ingest/opentelemetry/no-data-in-kibana.md
+++ b/troubleshoot/ingest/opentelemetry/no-data-in-kibana.md
@@ -1,0 +1,107 @@
+---
+navigation_title: No data visible in Kibana
+description: Learn what to check when no data (logs, metrics, traces) appears in Kibana after setting up EDOT.
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    edot_collector: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: edot-collector
+---
+
+# No logs, metrics, or traces visible in Kibana
+
+If the EDOT Collector or SDKs appear to be running, but you see no logs, metrics, or traces in the {{kib}} UI, try to use the solutions below to identify and resolve the issue. 
+
+## Symptoms
+
+* Collector process is consuming CPU/memory but no telemetry data is visible in {{kib}}
+* APM services don’t show up in {{kib}}
+* Dashboards appear empty or partially loaded
+* The Collector is running without crash logs
+
+## Causes
+
+This issue is typically caused by one or more of the following:
+
+* Incorrect export endpoint
+* Missing or invalid API key/token
+* Network issues, such as proxy misconfigurations
+* TLS verification failures
+* Misconfigured pipelines or disabled signals
+
+## Resolution
+
+Use the following checks to identify and fix common configuration or connectivity issues that can prevent telemetry data from reaching {{kib}}.
+
+### Check export endpoint
+
+Make sure the Collector is configured to send data to the correct Elastic endpoint. For example, if using AWS, the endpoint should match this structure:
+
+```yaml
+endpoint: https://<your-cluster-id>.apm.<region>.aws.elastic-cloud.com:443
+```
+
+If you’re using the managed OTLP endpoint, confirm the region and cluster ID are correct.
+
+### Verify authentication headers
+
+Ensure the Collector or SDK includes an API key in the `Authorization` header:
+
+```yaml
+headers:
+  Authorization: ApiKey <your-api-key>
+```
+
+If you’re using environment variables, confirm the key is set correctly in the runtime context.
+
+### Review logs for export errors
+
+Common log messages include:
+
+```
+permanent error: rpc error: code = Unavailable desc = connection refused
+```
+
+Also look for:
+
+* TLS handshake failures
+* Invalid character errors, which may indicate proxy or HTML redirect instead of JSON
+
+Increase verbosity using `--log-level=debug` for deeper insights. <!--Refer to [Enable debug logging]() for more information.-->
+
+### Test network connectivity
+
+You can validate connectivity using `curl`:
+
+```bash
+curl -v https://<endpoint> -H "Authorization: ApiKey <your-key>"
+```
+
+Or use `telnet` or `nc` to verify port 443 is reachable.
+
+<!--### Check proxy environment variables
+
+Ensure environment variables are correctly set in your deployment. Refer to [EDOT proxy settings]() for more information relevant to your configuration.
+
+In Kubernetes or container environments, pass these as `env:` entries.
+-->
+
+### Validate signal configuration
+
+Check that each pipeline is defined properly in your configuration:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [...]
+      exporters: [otlp]
+```
+
+If only logs are configured, metrics and traces will not be sent.

--- a/troubleshoot/ingest/opentelemetry/toc.yml
+++ b/troubleshoot/ingest/opentelemetry/toc.yml
@@ -13,3 +13,4 @@ toc:
       - file: edot-sdks/nodejs/index.md
       - file: edot-sdks/php/index.md
       - file: edot-sdks/python/index.md
+  - file: no-data-in-kibana.md


### PR DESCRIPTION
This PR introduces a new troubleshooting page under the EDOT documentation. The page helps users diagnose and resolve common issues when telemetry data (logs, metrics, traces) isn't appearing in Kibana, even when the EDOT Collector or SDKs appear to be running correctly.