### PR TITLE
[Security] Runscript for MS Defender + script picker

### DIFF
--- a/solutions/security/endpoint-response-actions.md
+++ b/solutions/security/endpoint-response-actions.md
@@ -253,7 +253,7 @@ For CrowdStrike, you must include one of the following parameters to identify th
 * `--Raw`: The full script content provided directly as a string.
 * `--CloudFile`: The name of the script stored in a cloud storage location.
 
-   {applies_to}`serverless: ga` When using this parameter, select from a list of saved custom scripts.
+   {applies_to}`stack: ga 9.1` When using this parameter, select from a list of saved custom scripts.
 
 * `--HostPath`: The absolute or relative file path of the script located on the host machine.
 
@@ -277,7 +277,7 @@ Examples:
 
 #### Microsoft Defender for Endpoint
 ```yaml {applies_to}
-serverless:
+stack: ga 9.1
 ```
 
 For Microsoft Defender for Endpoint, you must include the following parameter to identify the script you want to run:

--- a/solutions/security/endpoint-response-actions/configure-third-party-response-actions.md
+++ b/solutions/security/endpoint-response-actions/configure-third-party-response-actions.md
@@ -97,7 +97,7 @@ Expand a section below for your endpoint security system:
         * Microsoft Defender for Endpoint Fleet integration policy: Permission to read alert data (`Windows Defender ATP: Alert.Read.All`).
         * Microsoft Defender for Endpoint connector: Permission to read machine information as well as isolate and release a machine (`Windows Defender ATP: Machine.Read.All` and `Machine.Isolate`).
 
-    * To run a script on a host:
+    * {applies_to}`stack: ga 9.1` To run a script on a host:
     
         * Microsoft Defender for Endpoint connector: Permission to  manage live response library files as well as run live response on a specific machine (`Windows Defender ATP: Library.Manage` and `Machine.LiveResponse`)
 

--- a/solutions/security/endpoint-response-actions/third-party-response-actions.md
+++ b/solutions/security/endpoint-response-actions/third-party-response-actions.md
@@ -49,7 +49,7 @@ These response actions are supported for Microsoft Defender for Endpoint–enrol
 
     Refer to the instructions on [isolating](/solutions/security/endpoint-response-actions/isolate-host.md#isolate-a-host) and [releasing](/solutions/security/endpoint-response-actions/isolate-host.md#release-a-host) hosts for more details.
 
-* **Run a script on a host** with the [`runscript` response action](/solutions/security/endpoint-response-actions.md#microsoft-defender-for-endpoint).
+* {applies_to}`stack: ga 9.1` **Run a script on a host** with the [`runscript` response action](/solutions/security/endpoint-response-actions.md#microsoft-defender-for-endpoint).
 
 ## SentinelOne response actions [sentinelone-response-actions]
 


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/1498 and https://github.com/elastic/docs-content/issues/1532. 
Adds the appropriate 9.1 'applies' labels for the MS Defender `runscript` response action and the script picker functionality.

### Related PRs

MS Defender `runscript`:
* https://github.com/elastic/docs-content/pull/1820
* https://github.com/elastic/security-docs/pull/6903

Script picker:
* https://github.com/elastic/docs-content/pull/1650
* https://github.com/elastic/security-docs/pull/6896