### PR TITLE
[Security] Edit deployment context for `unassigned` criticality level

### DIFF
--- a/solutions/security/advanced-entity-analytics/asset-criticality.md
+++ b/solutions/security/advanced-entity-analytics/asset-criticality.md
@@ -88,7 +88,7 @@ The file must contain three columns, with each entity record listed on a separat
     * `high_impact`
     * `medium_impact`
     * `low_impact`
-    * `unassigned` (available in {{serverless-short}} only)
+    * {applies_to}`stack: ga 9.1` `unassigned`
 
 
 The maximum file size is 1 MB.


### PR DESCRIPTION
Resolves https://github.com/elastic/docs-content/issues/1017. 
This enhancement was added in serverless in April, before new versioning labels were available, so deployment context was expressed using prose. Editing to use the appropriate versioning label. 