### PR TITLE
[Observability][9.1, 9.2, & Serverless] Docs new `context.grouping` variable added to Obs rules

### DIFF
--- a/solutions/observability/incident-management/create-an-elasticsearch-query-rule.md
+++ b/solutions/observability/incident-management/create-an-elasticsearch-query-rule.md
@@ -195,6 +195,9 @@ The following variables are specific to this rule type. You can also specify [va
 `context.date`
 :   The date, in ISO format, that the rule met the condition. Example: `2022-02-03T20:29:27.732Z`.
 
+`context.grouping` {applies_to}`stack: ga 9.1`
+:   The object containing groups that are reporting data.
+
 `context.hits`
 :   The most recent documents that matched the query. Using the [Mustache](https://mustache.github.io/) template array syntax, you can iterate over these hits to get values from the {{es}} documents into your actions.
 

--- a/solutions/observability/incident-management/create-an-error-count-threshold-rule.md
+++ b/solutions/observability/incident-management/create-an-error-count-threshold-rule.md
@@ -128,6 +128,9 @@ The following variables are specific to this rule type. You can also specify [va
 `context.errorGroupingName`
 :   The error grouping name the alert is created for.
 
+`context.grouping` {applies_to}`stack: ga 9.1`
+:   The object containing groups that are reporting data.
+
 `context.interval`
 :   The length and unit of time period where the alert conditions were met.
 

--- a/solutions/observability/incident-management/create-an-inventory-rule.md
+++ b/solutions/observability/incident-management/create-an-inventory-rule.md
@@ -138,6 +138,9 @@ The following variables are specific to this rule type. You can also specify [va
 `context.group`
 :   Name of the group reporting data.
 
+`context.grouping` {applies_to}`stack: ga 9.2`
+:   The object containing groups that are reporting data.
+
 `context.host`
 :   The host object defined by ECS if available in the source.
 

--- a/solutions/observability/incident-management/create-an-slo-burn-rate-rule.md
+++ b/solutions/observability/incident-management/create-an-slo-burn-rate-rule.md
@@ -132,6 +132,9 @@ The following variables are specific to this rule type. You can also specify [va
 `context.burnRateThreshold`
 :   The burn rate threshold value.
 
+`context.grouping` {applies_to}`stack: ga 9.1`
+:   The object containing groups that are reporting data.
+
 `context.longWindow`
 :   The window duration with the associated burn rate value.
 

--- a/solutions/observability/incident-management/create-custom-threshold-rule.md
+++ b/solutions/observability/incident-management/create-custom-threshold-rule.md
@@ -219,6 +219,9 @@ The following variables are specific to this rule type. You can also specify [va
 :   The container object defined by ECS if available in the source.
 
 `context.group`
+:   The array of objects containing groups that are reporting data.
+
+`context.grouping` {applies_to}`stack: ga 9.1`
 :   The object containing groups that are reporting data.
 
 `context.host`

--- a/solutions/observability/incident-management/create-failed-transaction-rate-threshold-rule.md
+++ b/solutions/observability/incident-management/create-failed-transaction-rate-threshold-rule.md
@@ -122,6 +122,9 @@ The following variables are specific to this rule type. You can also specify [va
 `context.environment`
 :   The transaction type the alert is created for.
 
+`context.grouping` {applies_to}`stack: ga 9.1`
+:   The object containing groups that are reporting data.
+
 `context.interval`
 :   The length and unit of time period where the alert conditions were met.
 

--- a/solutions/observability/incident-management/create-latency-threshold-rule.md
+++ b/solutions/observability/incident-management/create-latency-threshold-rule.md
@@ -126,6 +126,9 @@ The following variables are specific to this rule type. You can also specify [va
 `context.environment`
 :   The transaction type the alert is created for.
 
+`context.grouping` {applies_to}`stack: ga 9.1`
+:   The object containing groups that are reporting data.
+
 `context.interval`
 :   The length and unit of time period where the alert conditions were met.
 

--- a/solutions/observability/incident-management/create-log-threshold-rule.md
+++ b/solutions/observability/incident-management/create-log-threshold-rule.md
@@ -159,6 +159,9 @@ The following variables are specific to this rule type. You an also specify [var
 `context.alertDetailsUrl`
 :   Link to the alert troubleshooting view for further context and details. This will be an empty string if the `server.publicBaseUrl` is not configured.
 
+`context.grouping` {applies_to}`stack: ga 9.2`
+:   The object containing groups that are reporting data.
+
 `context.interval`
 :   The length and unit of time period where the alert conditions were met.
 

--- a/solutions/observability/incident-management/create-metric-threshold-rule.md
+++ b/solutions/observability/incident-management/create-metric-threshold-rule.md
@@ -143,6 +143,9 @@ The following variables are specific to this rule type. You an also specify [var
 `context.groupByKeys`
 :   The object containing groups that are reporting data.
 
+`context.grouping` {applies_to}`stack: ga 9.2`
+:   The object containing groups that are reporting data.
+
 `context.host`
 :   The host object defined by ECS if available in the source.
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2195 by adding docs for the new `context.grouping` action variable that was added to the following Elasticsearch and Observability rules.

**Var available for the following rules in 9.1:**
- [Custom threshold](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-custom-threshold-rule#observability-create-custom-threshold-alert-rule-add-actions) 
- [SLO burn rate](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-an-slo-burn-rate-rule#observability-create-slo-burn-rate-alert-rule-add-actions) 
- [Elasticsearch query](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-an-elasticsearch-query-rule#observability-create-elasticsearch-query-rule-add-actions) 
- [APM Latency threshold](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-latency-threshold-rule#observability-create-latency-threshold-alert-rule-add-actions) 
- [APM Failed transaction rate threshold](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-failed-transaction-rate-threshold-rule#observability-create-failed-transaction-rate-threshold-alert-rule-add-actions)
- [APM Error count threshold](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-an-error-count-threshold-rule#observability-create-error-count-threshold-alert-rule-add-actions)

**Var available for the following rules in 9.2:**
- [Metric threshold](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-metric-threshold-rule#_action_variables_6)
- [Log threshold](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-log-threshold-rule#_action_variables_5)
- [Inventory](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2336/solutions/observability/incident-management/create-an-inventory-rule#action-types-infrastructure)

**Corresponding 8.19 docs**:
- Observability: https://github.com/elastic/observability-docs/pull/4921
- Kibana: https://github.com/elastic/kibana/pull/230120
