### PR TITLE
Update eck pdb docs

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/pod-disruption-budget.md
+++ b/deploy-manage/deploy/cloud-on-k8s/pod-disruption-budget.md
@@ -16,7 +16,7 @@ ECK manages either a single default PDB, or multiple PDBs per {{es}} resource ac
 
 ## Enterprise licensed customers
 
-A separate PDB is created for each type of nodeSet defined in the manifest allowing upgrade or maintenance operations to be more quickly executed. The PDB allows one {{es}} Pod to be taken down as long as the cluster has the health defined in the following table:
+A separate PDB is created for each type of nodeSet defined in the manifest allowing upgrade or maintenance operations to be more quickly executed. The PDBs allow one {{es}} Pod per nodeSet to simultaneously be taken down as long as the cluster has the health defined in the following table:
 
 | Role | Cluster Health Required | Notes |
 |------|------------------------|--------|

--- a/deploy-manage/deploy/cloud-on-k8s/pod-disruption-budget.md
+++ b/deploy-manage/deploy/cloud-on-k8s/pod-disruption-budget.md
@@ -12,7 +12,28 @@ products:
 
 A [Pod Disruption Budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) (PDB) allows you to limit the disruption to your application when its pods need to be rescheduled for some reason such as upgrades or routine maintenance work on the Kubernetes nodes.
 
-ECK manages a default PDB per {{es}} resource. It allows one {{es}} Pod to be taken down, as long as the cluster has a `green` health. Single-node clusters are not considered highly available and can always be disrupted.
+ECK manages either a single default PDB, or multiple PDBs per {{es}} resource according to the license available.
+
+## Enterprise licensed customers
+
+A separate PDB is created for each type of nodeSet defined in the manifest allowing upgrade or maintenance operations to be more quickly executed. The PDB allows one {{es}} Pod to be taken down as long as the cluster has the health defined in the following table:
+
+| Role | Cluster Health Required | Notes |
+|------|------------------------|--------|
+| Master | Yellow |  |
+| Data | Green | All Data roles are grouped together into a single PDB, except for data_frozen. |
+| Data Frozen | Yellow | Since the frozen tier are essentially stateless, managing searchable snapshots, additional disruptions are allowed. |
+| Ingest | Yellow |  |
+| ML | Yellow |  |
+| Coordinating | Yellow |  |
+| Transform | Yellow |  |
+| Remote Cluster Client | Yellow |  |
+
+Single-node clusters are not considered highly available and can always be disrupted.
+
+## Non-enterprise licensed customers
+
+It allows one {{es}} Pod to be taken down, as long as the cluster has a `green` health. Single-node clusters are not considered highly available and can always be disrupted.
 
 In the {{es}} specification, you can change the default behavior as follows:
 
@@ -34,7 +55,7 @@ spec:
           elasticsearch.k8s.elastic.co/cluster-name: quickstart
 ```
 
-::::{note} 
+::::{note}
 [`maxUnavailable`](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#arbitrary-controllers-and-selectors) cannot be used with an arbitrary label selector, therefore `minAvailable` is used in this example.
 ::::
 
@@ -81,6 +102,3 @@ spec:
 4. Pod disruption budget applies on all master nodes.
 5. Specify pod disruption budget to have 1 hot node available.
 6. Pod disruption budget applies on nodes of the same nodeset.
-
-
-


### PR DESCRIPTION
The following  https://github.com/elastic/cloud-on-k8s/pull/8780 is planned to be released with the ECK 3.2/Stack 9.2 release. How do we tag this specifically for that?