### PR TITLE
[Internal][Security]: Building block rule actions

### DIFF
--- a/solutions/security/detect-and-alert/about-building-block-rules.md
+++ b/solutions/security/detect-and-alert/about-building-block-rules.md
@@ -18,6 +18,10 @@ Create building block rules when you do not want to see their generated alerts i
 * A record of low-risk alerts without producing noise in the Alerts table.
 * Rules that execute on the alert indices (`.alerts-security.alerts-<kibana space>`). You can then use building block rules to create hidden alerts that act as a basis for an *ordinary* rule to generate visible alerts.
 
+::::{tip}
+Add [rule notifications](/solutions/security/detect-and-alert/create-detection-rule.md#rule-notifications) to building block rules to notify you when building block alerts are generated. 
+::::
+
 
 ## Set up rules that run on alert indices [security-building-block-rules-set-up-rules-that-run-on-alert-indices]
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2334 by clarifying that you can add rule notifications to building block rules.

[Preview](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2370/solutions/security/detect-and-alert/about-building-block-rules)

**Corresponding 8.19 docs**:
- https://github.com/elastic/security-docs/pull/7013