### PR TITLE
Missing `apt update` call

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/configure-host-ubuntu.md
+++ b/deploy-manage/deploy/cloud-enterprise/configure-host-ubuntu.md
@@ -53,7 +53,7 @@ Make sure to use a supported combination of Linux distribution and container eng
 4. Install the correct version of the `docker-ce` package. The following is an example of installing Docker 27.0. If you decide to install a different Docker version, make sure to replace with the desired version in the commands below.
 
     ```sh
-    sudo apt install -y docker-ce=5:27.0.* docker-ce-cli=5:27.0.* containerd.io
+    sudo apt update && sudo apt install -y docker-ce=5:27.0.* docker-ce-cli=5:27.0.* containerd.io
     ```
 
 


### PR DESCRIPTION
when you just run it as in the docs, it can't find the docker-ce stuff yet since we only added the repo but didn't run `apt update`.

```
elastic@kahr-apm-blog-micro-20250804-200852:/home/philipp$ sudo mkdir -m 0755 -p /etc/apt/keyrings
curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
elastic@kahr-apm-blog-micro-20250804-200852:/home/philipp$ echo \
  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
elastic@kahr-apm-blog-micro-20250804-200852:/home/philipp$ sudo apt install -y docker-ce=5:27.0.* docker-ce-cli=5:27.0.* containerd.io
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package docker-ce is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '5:27.0.*' for 'docker-ce' was not found
E: Unable to locate package docker-ce-cli
E: Unable to locate package containerd.io
E: Couldn't find any package by glob 'containerd.io'
```