### PR TITLE
Fix Incorrect ECE Version in Air-Gapped Setup Instructions

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
@@ -16,9 +16,9 @@ To perform an offline installation without a private Docker registry, you have t
 1. On an internet-connected host that has Docker installed, download the [Available Docker Images](ece-install-offline-images.md). Note that for ECE version 4.0, if you want to use {{stack}} version 9.0 in your deployments, you need to download and make available both the version 8.x and version 9.x Docker images (the version 8.x images are required for system deployments).
 
     ```sh subs=true
-    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{version.ece}}
-    docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0
-    docker pull docker.elastic.co/cloud-release/kibana-cloud:8.18.0
+    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.2
+    docker pull docker.elastic.co/cloud-release/kibana-cloud:8.18.2
     docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0
     docker pull docker.elastic.co/cloud-release/enterprise-search-cloud:8.18.0
     docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.0.0
@@ -35,8 +35,8 @@ To perform an offline installation without a private Docker registry, you have t
 
     ```sh subs=true
     docker save -o ece.{{version.ece}}.tar docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{version.ece}}
-    docker save -o es.8.18.0.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0
-    docker save -o kibana.8.18.0.tar docker.elastic.co/cloud-release/kibana-cloud:8.18.0
+    docker save -o es.8.18.0.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.2
+    docker save -o kibana.8.18.0.tar docker.elastic.co/cloud-release/kibana-cloud:8.18.2
     docker save -o apm.8.18.0.tar docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0
     docker save -o enterprise-search.8.18.0.tar docker.elastic.co/cloud-release/enterprise-search-cloud:8.18.0
     docker save -o es.9.0.0.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.0.0

--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
@@ -16,7 +16,7 @@ To perform an offline installation without a private Docker registry, you have t
 1. On an internet-connected host that has Docker installed, download the [Available Docker Images](ece-install-offline-images.md). Note that for ECE version 4.0, if you want to use {{stack}} version 9.0 in your deployments, you need to download and make available both the version 8.x and version 9.x Docker images (the version 8.x images are required for system deployments).
 
     ```sh subs=true
-    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1
+    docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{version.ece}}
     docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.2
     docker pull docker.elastic.co/cloud-release/kibana-cloud:8.18.2
     docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0


### PR DESCRIPTION
PR based on [this request](https://github.com/elastic/docs-content/issues/2392):

### What documentation page is affected

https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry

### What change would you like to see?

In the [air-gapped installation guide](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry), we instruct users to pull :

```
docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.1.0
docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.0
docker pull docker.elastic.co/cloud-release/kibana-cloud:8.18.0
docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.0
docker pull docker.elastic.co/cloud-release/enterprise-search-cloud:8.18.0
docker pull docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.0.0
docker pull docker.elastic.co/cloud-release/kibana-cloud:9.0.0
docker pull docker.elastic.co/cloud-release/elastic-agent-cloud:9.0.0
```
But there is Mismatch in Elasticsearch and Kibana Versions the doc specifies pulling version 8.18.0 of Elastic components, but the installer actually requires:

elasticsearch-cloud-ess:8.18.2

kibana-cloud:8.18.2

Also it says : `docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.1.0` but it supposed to be 
`docker pull docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:4.0.1`

### Additional info

_No response_
