### PR TITLE
CSPM/KSPM namespace support

### DIFF
--- a/solutions/security/cloud/_snippets/cspm-dashboard.md
+++ b/solutions/security/cloud/_snippets/cspm-dashboard.md
@@ -21,9 +21,9 @@ The Cloud Security Posture dashboard shows:
 
 ## Cloud Security Posture dashboard UI [cloud-posture-dashboard-UI]
 
-At the top of the dashboard, you can switch between the cloud accounts and Kubernetes cluster views.
+At the top right of the dashboard, you can filter the data by which namespace of the findings index it's saved in. At the top left of the dashboard, you can switch between the cloud accounts and Kubernetes cluster views. 
 
-The top section of either view summarizes your overall cloud security posture (CSP) by aggregating data from all monitored resources. The summary cards on the left show the number of cloud accounts or clusters evaluated, and the number of resources evaluated. You can click **Enroll more accounts** or **Enroll more clusters** to deploy to additional cloud assets. Click **View all resources** to open the [Findings page](/solutions/security/cloud/findings-page-2.md).
+The summary section summarizes your overall cloud security posture (CSP) by aggregating data from all monitored resources. The summary cards on the left show the number of cloud accounts or clusters evaluated, and the number of resources evaluated. You can click **Enroll more accounts** or **Enroll more clusters** to deploy to additional cloud assets. Click **View all resources** to open the [Findings page](/solutions/security/cloud/findings-page-2.md).
 
 The remaining summary cards show your overall compliance score, and your compliance score for each CIS section. Click **View all failed findings** to view all failed findings, or click a CIS section name to view failed findings from only that section on the Findings page.
 
@@ -48,4 +48,7 @@ A cluster will disappear as soon as the KSPM integration fetches data while that
 
 ::::
 
+::::{dropdown} How do I organize security posture data by namespace?
+You can configure a CSPM or KSPM integration to send its data to a particular namespace by going to **Configure integration -> Advanced options**, then entering the desired namespace under `Namespace`.
 
+::::

--- a/solutions/security/cloud/get-started-with-cspm-for-aws.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-aws.md
@@ -39,8 +39,13 @@ You can set up CSPM for AWS either by enrolling a single cloud account, or by en
 3. Click **Add Cloud Security Posture Management (CSPM)**.
 4. Select **AWS**, then either **AWS Organization** to onboard multiple accounts, or **Single Account** to onboard an individual account.
 5. Give your integration a name that matches the purpose or team of the AWS account/organization you want to monitor, for example, `dev-aws-account`.
-6. Click **Advanced options**, then select **Agentless (BETA)**.
-7. Next, you’ll need to authenticate to AWS. Two methods are available:
+6. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+7. Under **Deployment options** select **Agentless**.
+8. Next, you’ll need to authenticate to AWS. Two methods are available:
 
     1. Option 1: Direct access keys/CloudFormation (Recommended). Under **Preferred method**, select **Direct access keys**. Expand the **Steps to Generate AWS Account Credentials** section, then follow the displayed instructions to automatically create the necessary credentials using CloudFormation.
 
@@ -50,7 +55,7 @@ You can set up CSPM for AWS either by enrolling a single cloud account, or by en
 
     2. Option 2: Temporary keys. To authenticate using temporary keys, refer to the instructions for [temporary keys](/solutions/security/cloud/get-started-with-cspm-for-aws.md#cspm-use-temp-credentials).
 
-8. Once you’ve selected an authentication method and provided all necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
+9. Once you’ve selected an authentication method and provided all necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
 ## Agent-based deployment [cspm-aws-agent-based]
 
@@ -62,6 +67,12 @@ You can set up CSPM for AWS either by enrolling a single cloud account, or by en
 3. Click **Add Cloud Security Posture Management (CSPM)**.
 4. Select **AWS**, then either **AWS Organization** to onboard multiple accounts, or **Single Account** to onboard an individual account.
 5. Give your integration a name that matches the purpose or team of the AWS account/organization you want to monitor, for example, `dev-aws-account`.
+6. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+7. Under **Deployment options** select **Agent-based**. 
 
 
 ### Set up cloud account access [cspm-set-up-cloud-access-section]

--- a/solutions/security/cloud/get-started-with-cspm-for-azure.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-azure.md
@@ -38,9 +38,15 @@ You can set up CSPM for Azure by by enrolling an Azure organization (management 
 2. Search for `CSPM`, then click on the result.
 3. Click **Add Cloud Security Posture Management (CSPM)**.
 4. Select **Azure**, then either **Azure Organization** to onboard your whole organization, or **Single Subscription** to onboard an individual subscription.
-5. Give your integration a name that matches the purpose or team of the Azure subscription/organization you want to monitor, for example, `dev-azure-account`.
-6. Click **Advanced options**, then select **Agentless (BETA)**.
-7. Next, you’ll need to authenticate to Azure by providing a **Client ID**, **Tenant ID**, and **Client Secret**. To learn how to generate them, refer to [Service principal with client secret](/solutions/security/cloud/get-started-with-cspm-for-azure.md#cspm-azure-client-secret).
+5. Give your integration a name and description that match the purpose or team of the Azure subscription/organization you want to monitor, for example, `dev-azure-account`.
+6. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+
+7. Under **Deployment options**, select **Agentless**.
+7. Under **Setup Access**, authenticate to Azure by providing a **Client ID**, **Tenant ID**, and **Client Secret**. To learn how to generate them, refer to [Service principal with client secret](/solutions/security/cloud/get-started-with-cspm-for-azure.md#cspm-azure-client-secret).
 8. Once you’ve provided the necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
 ## Agent-based deployment [cspm-azure-agent-based]
@@ -53,6 +59,12 @@ You can set up CSPM for Azure by by enrolling an Azure organization (management 
 3. Click **Add Cloud Security Posture Management (CSPM)**.
 4. Under **Configure integration**, select **Azure**, then select either **Azure Organization** or **Single Subscription**, depending on which resources you want to monitor.
 5. Give your integration a name that matches the purpose or team of the Azure resources you want to monitor, for example, `azure-CSPM-dev-1`.
+6. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+7. Under **Deployment options** select **Agent-based**.
 
 
 ### Set up cloud account access [cspm-set-up-cloud-access-section-azure]

--- a/solutions/security/cloud/get-started-with-cspm-for-gcp.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-gcp.md
@@ -37,11 +37,16 @@ You can set up CSPM for GCP either by enrolling a single project, or by enrollin
 1. Find **Integrations** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. Search for `CSPM`, then click on the result.
 3. Click **Add Cloud Security Posture Management (CSPM)**.
-4. Select **GCP**, then either **GCP Organization** to onboard your whole organization, or **Single Project** to onboard an individual account.
-5. Give your integration a name that matches the purpose or team of the GCP subscription/organization you want to monitor, for example, `dev-gcp-account`.
-6. Under **Deployment Options**, select **Agentless**.
-7. Next, you’ll need to authenticate to GCP. Expand the **Steps to Generate GCP Account Credentials** section, then follow the instructions that appear to automatically create the necessary credentials using Google Cloud Shell.
-8. Once you’ve provided the necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
+4. Under **Configure integration**, select **GCP**, then either **GCP Organization** to onboard your whole organization, or **Single Project** to onboard an individual account.
+5. Give your integration a name and description that match the purpose or team of the GCP subscription/organization you want to monitor, for example, `dev-gcp-account`.
+6. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+7. Under **Deployment Options**, select **Agentless**.
+8. Next, you’ll need to authenticate to GCP. Expand the **Steps to Generate GCP Account Credentials** section, then follow the instructions that appear to automatically create the necessary credentials using Google Cloud Shell.
+9. Once you’ve provided the necessary credentials, click **Save and continue** to finish deployment. Your data should start to appear within a few minutes.
 
 ## Agent-based deployment [cspm-gcp-agent-based]
 
@@ -51,8 +56,14 @@ You can set up CSPM for GCP either by enrolling a single project, or by enrollin
 1. Find **Integrations** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 2. Search for `CSPM`, then click on the result.
 3. Click **Add Cloud Security Posture Management (CSPM)**.
-4. Under **Configure integration**, select **GCP**, then either **GCP Organization** (recommended) or **Single Project**.
-5. Give your integration a name that matches the purpose or team of the GCP account you want to monitor, for example, `dev-gcp-project`.
+4. Under **Configure integration**, select **GCP**, then either **GCP Organization** to onboard your whole organization, or **Single Project** to onboard an individual account.
+5. Give your integration a name and description that match the purpose or team of the GCP account you want to monitor, for example, `dev-gcp-project`.
+6. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+7. Under **Deployment options** select **Agent-based**.
 
 
 ### Set up cloud account access [cspm-set-up-cloud-access-section-gcp]

--- a/solutions/security/cloud/get-started-with-kspm.md
+++ b/solutions/security/cloud/get-started-with-kspm.md
@@ -50,12 +50,15 @@ The instructions differ depending on whether you’re installing on EKS or on un
 
 ### Name your integration and select a Kubernetes Deployment type [_name_your_integration_and_select_a_kubernetes_deployment_type]
 
-1. Find **Cloud Security Posture** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
-2. Click **Add a KSPM integration**.
-3. Read the integration’s description to understand how it works. Then, click [**Add Kubernetes Security Posture Management**](https://docs.elastic.co/en/integrations/cloud_security_posture).
-4. Name your integration. Use a name that matches the purpose or team of the cluster(s) you want to monitor, for example, `IT-dev-k8s-clusters`.
-5. Select **EKS** from the **Kubernetes Deployment** menu. A new section for AWS credentials will appear.
+1. Navigate to the **Integrations** page using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
+2. Search for `kspm`, and select the integration. Click **Add Kubernetes Security Posture Management (KSPM)**.
+3. Under **Configure integration**, select **EKS**. A new section called **Setup Access** appears.
+4. Name your integration and add a description. Use a name that matches the purpose or team of the cluster(s) you want to monitor, for example, `IT-dev-k8s-clusters`.
+5. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
 
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
 
 ### Authenticate to AWS [kspm-setup-eks-auth]
 
@@ -248,14 +251,19 @@ Follow these steps to deploy the KSPM integration to unmanaged clusters. Keep in
 
 To install the integration on unmanaged clusters:
 
-1. Find **Cloud Security Posture** in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
-2. Click **Add a KSPM integration**.
-3. Read the integration’s description to understand how it works. Then, click [**Add Kubernetes Security Posture Management**](https://docs.elastic.co/en/integrations/cloud_security_posture).
-4. Name your integration. Use a name that matches the purpose or team of the cluster(s) you want to monitor, for example, `IT-dev-k8s-clusters`.
-5. Select **Unmanaged Kubernetes** from the **Kubernetes Deployment** menu.
-6. If you want to monitor Kubernetes clusters that aren’t yet enrolled in {{fleet}}, select **New Hosts** when choosing the {{agent}} policy.
-7. Select the {{agent}} policy where you want to add the integration.
-8. Click **Save and continue**, then **Add agent to your hosts**. The **Add agent** wizard appears and provides a DaemonSet manifest `.yaml` file with pre-populated configuration information, such as the `Fleet ID` and `Fleet URL`.
+1. Navigate to the **Integrations** page using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
+2. Search for `kspm`, and select the integration. Click **Add Kubernetes Security Posture Management (KSPM)**.
+3. Under **Configure integration**, select **Self-Managed**.
+4. Name your integration and add a description. Use a name that matches the purpose or team of the cluster(s) you want to monitor, for example, `IT-dev-k8s-clusters`.
+5. (Optional) under **Advanced options**, you can add a `Namespace` to the integration's data stream.
+
+   ```{Namespaces}
+   Using a namespace can help you organize your data, for example you query data from a particular namespace, or filter the Cloud Security dashboard based on namespace. Do not try to use data stream namespaces to manage data access within your organization — this is ineffective because the default findings index includes data from all namespaces (`logs-findings*`). Use [document-level security](/reference/search-connectors/document-level-security.md) instead.
+   ```
+
+6. Select the {{agent}} policy where you want to add the integration.
+7. Click **Save and continue**, then **Add agent to your hosts**. The **Add agent** wizard appears and provides a DaemonSet manifest `.yaml` file with pre-populated configuration information, such as the `Fleet ID` and `Fleet URL`.
+
 
 :::{image} /solutions/images/security-kspm-add-agent-wizard.png
 :alt: The KSPM integration's Add agent wizard


### PR DESCRIPTION
Fixes #2207 by updating the CSPM and KSPM documentation to describe the new config setting which enables you to specify a data stream namespace where you want to save an individual integration's data. Also updates the Cloud Posture Dashboard page to reflect the new option to filter by namespace.

