### PR TITLE
Fixes typo in JWT token doc

### DIFF
--- a/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
@@ -178,7 +178,7 @@ Client authentication is enabled by default for the JWT realms. Disabling client
 
    * The `shared_secret` value for `client_authentication.type`
 
-      (`xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret1`)
+      (`xpack.security.authc.realms.jwt.jwt1.client_authentication.shared_secret`)
    * The HMAC keys for `allowed_signature_algorithms`
 
       (`xpack.security.authc.realms.jwt.jwt1.hmac_jwkset`)


### PR DESCRIPTION
## Overview

This PR fixes a typo in the secret config by deleting an extra `1` at the end of the line. This was correct in the 8.x docs, for example: https://www.elastic.co/guide/en/elasticsearch/reference/8.19/jwt-auth-realm.html

[Slack thread](https://elastic.slack.com/archives/CJE3WCFEH/p1754539786659949)