### PR TITLE
Update release notes landing page to use version variables

### DIFF
--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -4,7 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elastic-stack/current/elastic-stack-breaking-changes.html
 products:
   - id: elastic-stack
-description: Explore the new features, enhancements, fixes, and deprecations for Elastic Stack 9.0+ (latest 9.1.0), Elastic Cloud Serverless, and...
+description: Explore the new features, enhancements, fixes, and deprecations for Elastic Stack 9.0+ (latest {{version.stack}}), Elastic Cloud Serverless, and...
 ---
 
 # Elastic release notes [elastic-release-notes]
@@ -12,12 +12,12 @@ description: Explore the new features, enhancements, fixes, and deprecations for
 Stay up to date with the latest changes, fixes, known issues, and deprecations in Elastic products. 
 
 Release notes cover the all the latest Elastic product changes, including the following:
-* {{stack}} 9.0.0 and later, including the most recent 9.1.0 release
+* {{stack}} 9.0.0 and later, including the most recent {{version.stack}} release
 * {{serverless-full}}, including updates to {{es}}, and {{observability}} and {{elastic-sec}} solutions
 
 ## What's new in the latest Elastic release?
 
-Elastic Stack 9.1.0 includes new features, enhancements, and critical fixes across {{es}}, {{observability}}, {{elastic-sec}}, {{kib}}, and more. To view detailed release notes, select a product.
+Elastic Stack {{version.stack}} includes new features, enhancements, and critical fixes across {{es}}, {{observability}}, {{elastic-sec}}, {{kib}}, and more. To view detailed release notes, select a product.
 
 :::{tip}
 Looking for earlier versions? Go to [Release docs](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/8.19/new.html).

--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -4,7 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elastic-stack/current/elastic-stack-breaking-changes.html
 products:
   - id: elastic-stack
-description: Explore the new features, enhancements, fixes, and deprecations for Elastic Stack 9.0+ (latest {{version.stack}}), Elastic Cloud Serverless, and...
+description: Explore the new features, enhancements, fixes, and deprecations for Elastic Stack 9.0+ (latest 9.1.1), Elastic Cloud Serverless, and...
 ---
 
 # Elastic release notes [elastic-release-notes]

--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -12,7 +12,7 @@ description: Explore the new features, enhancements, fixes, and deprecations for
 Stay up to date with the latest changes, fixes, known issues, and deprecations in Elastic products. 
 
 Release notes cover the all the latest Elastic product changes, including the following:
-* {{stack}} 9.0.0 and later, including the most recent {{version.stack}} release
+* {{stack}} {{version.stack.base}} and later, including the most recent {{version.stack}} release
 * {{serverless-full}}, including updates to {{es}}, and {{observability}} and {{elastic-sec}} solutions
 
 ## What's new in the latest Elastic release?


### PR DESCRIPTION
This page wasn't using version variables.
Pending to determine if the frontmatter allow the version variable, otherwise we should remove it.