### PR TITLE
Remove Android from apm agents index

### DIFF
--- a/reference/apm-agents/index.md
+++ b/reference/apm-agents/index.md
@@ -4,7 +4,6 @@
 
 This section contains reference information for APM Agents features, including:
 
-* Android
 * .NET
 * Go
 * Java


### PR DESCRIPTION
I cannot see the android sub page.. I guess it was removed and replaced with https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/android