### PR TITLE
Add 9.2 to the list of target stack versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/b-internal-request.yaml
+++ b/.github/ISSUE_TEMPLATE/b-internal-request.yaml
@@ -65,6 +65,7 @@ body:
         - '8.19'
         - '9.0'
         - '9.1'
+        - '9.2'
       default: 0
     validations:
       required: true


### PR DESCRIPTION
Adds `9.2` to the list of target stack versions in the GitHub issue template