### PR TITLE
Docs Update 9.0.5

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images.md
@@ -72,6 +72,11 @@ Enterprise Search is not available in versions 9.0+.
 | docker.elastic.co/cloud-release/kibana-cloud:9.1.1 | ECE 4.0.0 |
 | docker.elastic.co/cloud-release/elastic-agent-cloud:9.1.1 | ECE 4.0.0 |
 |  |  |
+| [{{es}}, {{kib}}, APM, and Enterprise Search stack pack: 9.0.5](https://download.elastic.co/cloud-enterprise/versions/9.0.5.zip) | ECE 4.0.0 |
+| docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.0.5 | ECE 4.0.0 |
+| docker.elastic.co/cloud-release/kibana-cloud:9.0.5 | ECE 4.0.0 |
+| docker.elastic.co/cloud-release/elastic-agent-cloud:9.0.5 | ECE 4.0.0 |
+|  |  |
 | [{{es}}, {{kib}}, APM, and Enterprise Search stack pack: 9.0.4](https://download.elastic.co/cloud-enterprise/versions/9.0.4.zip) | ECE 4.0.0 |
 | docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.0.4 | ECE 4.0.0 |
 | docker.elastic.co/cloud-release/kibana-cloud:9.0.4 | ECE 4.0.0 |

--- a/deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions.md
+++ b/deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions.md
@@ -51,6 +51,7 @@ Following is the full list of available packs containing {{stack}} versions. Not
 | Stack pack download link | Minimum required ECE version |
 | --- | --- |
 | [{{es}}, {{kib}}, and APM stack pack: 9.1.1](https://download.elastic.co/cloud-enterprise/versions/9.1.1.zip) | ECE 4.0.0 |
+| [{{es}}, {{kib}}, and APM stack pack: 9.0.5](https://download.elastic.co/cloud-enterprise/versions/9.0.5.zip) | ECE 4.0.0 |
 | [{{es}}, {{kib}}, and APM stack pack: 9.0.4](https://download.elastic.co/cloud-enterprise/versions/9.0.4.zip) | ECE 4.0.0 |
 | [{{es}}, {{kib}}, and APM stack pack: 9.0.3](https://download.elastic.co/cloud-enterprise/versions/9.0.3.zip) | ECE 4.0.0 |
 | [{{es}}, {{kib}}, and APM stack pack: 9.0.2](https://download.elastic.co/cloud-enterprise/versions/9.0.2.zip) | ECE 4.0.0 |


### PR DESCRIPTION
Adds `9.0.5` to list of ECE stackpacks

Rel: https://github.com/elastic/cloud/issues/145185

