### PR TITLE
[Private preview] Add page about connecting localhost to AutoOps

### DIFF
--- a/deploy-manage/_snippets/autoops-cc-ech-faq.md
+++ b/deploy-manage/_snippets/autoops-cc-ech-faq.md
@@ -1,4 +1,6 @@
 :::{dropdown} Can I use Cloud Connect to connect my {{ech}} clusters to AutoOps?
 
 This path is not supported. Currently, we only support using Cloud Connect to connect ECE, ECK, and self-managed clusters to AutoOps.
+
+For {{ech}} clusters, AutoOps is set up and enabled automatically in all supported [regions](/deploy-manage/monitor/autoops/ec-autoops-regions.md), and can be [accessed](/deploy-manage/monitor/autoops/ec-autoops-how-to-access.md) from the deployment overview page. 
 :::

--- a/deploy-manage/monitor/autoops.md
+++ b/deploy-manage/monitor/autoops.md
@@ -12,8 +12,6 @@ products:
 
 AutoOps diagnoses issues in {{es}} by analyzing hundreds of metrics, providing root-cause analysis and accurate resolution paths. With AutoOps, customers can prevent and resolve issues, cut down administration time, and optimize resource utilization.
 
-AutoOps is currently only available for [{{ech}} deployments](/deploy-manage/deploy/elastic-cloud/cloud-hosted.md).
-
 :::{image} /deploy-manage/images/cloud-autoops-overview-page.png
 :alt: The Overview page
 :::

--- a/deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected.md
+++ b/deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected.md
@@ -17,7 +17,8 @@ Cloud Connect enables users of ECE, ECK, and self-managed clusters to use {{eclo
 
 In this section, you'll find the following information:
 
-* How to [connect your cluster to AutoOps](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md)
+* How to [connect your self-managed cluster to AutoOps](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md)
+* How to [connect your local development cluster to AutoOps](/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md)
 * How to [manage users of your connected clusters](/deploy-manage/monitor/autoops/cc-manage-users.md)
 * [FAQs](/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md) about AutoOps for your clusters
 * A [troubleshooting guide](/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-troubleshooting.md) to help you with any issues you may encounter

--- a/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
@@ -49,7 +49,9 @@ Complete the following steps to connect your local development cluster to AutoOp
         ```sh
         docker run -d --network host \
         ```
-
+        
+        This replacement is also required if your cluster is running on macOS.
+      
 After completing all the steps, you can [Access AutoOps](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#access-autoops).
 
 

--- a/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
@@ -41,7 +41,7 @@ Complete the following steps to connect your local development cluster to AutoOp
     ```
 5. Follow the instructions to [Connect to AutoOps](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#connect-to-autoops) with the following differences:
     * In the [Select installation method](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#select-installation-method) step, select **Docker**.
-    * In the [Configure agent](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#configure-agent) step, when prompted to enter your **{{es}} endpoint URL**, enter the name of your local development cluster or enter the folllowing:
+    * In the [Configure agent](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#configure-agent) step, when prompted to enter your **{{es}} endpoint URL**, enter the name of your local development cluster or enter the following:
         ```sh
         http://localhost:9200
         ```

--- a/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md
@@ -1,0 +1,57 @@
+---
+applies_to:
+  deployment:
+    self:
+navigation_title: Connect your local development cluster
+---
+
+# Connect your local development cluster to AutoOps
+
+If you have an {{es}} cluster set up for local development or testing, you can connect it to AutoOps using Docker.
+
+## Prerequisites
+
+Ensure your system meets the following requirements before proceeding:
+
+* You have set up [{{es}} for local development](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md).
+* You have installed [Docker Desktop](https://www.docker.com/products/docker-desktop).
+* You have an {{ecloud}} account with the [Organization owner role](/deploy-manage/monitor/autoops/cc-manage-users.md#assign-roles).
+
+## Connect your local development cluster to AutoOps
+
+Complete the following steps to connect your local development cluster to AutoOps.
+
+1. Run the following command in your terminal to open the `/etc/hosts` file in a text editor with administrator privileges:
+
+  ```sh
+  vim /etc/hosts
+  ```
+2. On a new line in the `/etc/hosts` file, add an entry to map the {{es}} cluster URL to the IP address representing the local development cluster.
+
+    The entry should be formatted as `127.0.0.1 {{hostname}}`.
+3. Save the changes.
+4. In your terminal, run the following command to reload the hostname service:
+    * For Linux: 
+    ```sh
+    /bin/systemctl restart systemd-hostnamed
+    ```
+    * For macOS: 
+    ```sh
+    sudo dscacheutil -flushcache
+    ```
+5. Follow the instructions to [Connect to AutoOps](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#connect-to-autoops) with the following differences:
+    * In the [Select installation method](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#select-installation-method) step, select **Docker**.
+    * In the [Configure agent](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#configure-agent) step, when prompted to enter your **{{es}} endpoint URL**, enter the name of your local development cluster or enter the folllowing:
+        ```sh
+        http://localhost:9200
+        ```
+    * In the [Install agent](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#install-agent) step, paste the command into the text editor and replace `docker run -d \` with:
+        ```sh
+        docker run -d --network host \
+        ```
+
+After completing all the steps, you can [Access AutoOps](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#access-autoops).
+
+
+
+

--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -25,7 +25,7 @@ Ensure your system meets the following requirements before proceeding:
 * Your cluster is on an [Enterprise self-managed license](https://www.elastic.co/subscriptions) or an active self-managed [trial](https://cloud.elastic.co/registration).
 * The agent you install for the connection is allowed to send metrics to {{ecloud}}.
 
-## Connect to AutoOps
+## Connect to AutoOps (private preview)
 
 :::{note}
 :::{include} /deploy-manage/monitor/_snippets/single-cloud-org.md

--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -4,14 +4,18 @@ applies_to:
     self:
     ece:
     eck:
-navigation_title: Connect your cluster
+navigation_title: Connect your self-managed cluster
 ---
 
-# Connect your cluster to AutoOps
+# Connect your self-managed cluster to AutoOps
 
 To use AutoOps with your ECE, ECK, or self-managed cluster, you first need to create an {{ecloud}} account or log in to your existing account. An installation wizard will then guide you through the steps of installing {{agent}} to send metrics from your cluster to AutoOps in {{ecloud}}.  
 
 Complete the steps in the following subsections to connect your cluster to AutoOps. The connection process takes about 10 minutes.
+
+:::{note}
+If you have an {{es}} cluster set up for local development or testing, you can connect it to AutoOps using Docker. Refer to [](/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md).
+:::
 
 ## Prerequisites
 
@@ -86,8 +90,8 @@ This is the first step of the installation wizard. Your cluster ships metrics to
 
 Select one of the following methods to install {{agent}}:
 
-* Kubernetes
-* Docker
+* **Kubernetes**
+* **Docker**
 <!-- Not applicable for private preview
 * Linux
 * Windows
@@ -226,18 +230,18 @@ Complete the following steps to run the command:
 1. Copy the command. 
 2. Paste it into a text editor and update the placeholder values in the following environment variables:
 
-| Environment variable | Description |
-| --- | --- |
-| `AUTOOPS_OTEL_URL` | The {{ecloud}} URL to which {{agent}} ships data. The URL is generated based on the CSP and region you pick. <br> This URL shouldn't be edited. |
-| `AUTOOPS_ES_URL` | The URL {{agent}} uses to communicate with {{es}}. |
-| `ELASTICSEARCH_READ_API_KEY` | The API key for API key authentication to access the cluster. It combines the `${id}:${api_key}` values. <br> This variable shouldn't be used with `ELASTICSEARCH_READ_USERNAME` and `ELASTICSEARCH_READ_PASSWORD`. |
-| `ELASTICSEARCH_READ_USERNAME` | The username for basic authentication to access the cluster. <br> This variable should be used with `ELASTICSEARCH_READ_PASSWORD`. |
-| `ELASTICSEARCH_READ_PASSWORD` | The password for basic authentication to access the cluster. <br> This variable should be used with `ELASTICSEARCH_READ_USERNAME`. |
-| `ELASTIC_CLOUD_CONNECTED_MODE_API_KEY` | The {{ecloud}} API Key used to register the cluster. <br> This key shouldn't be edited. |
-| `AUTOOPS_TEMP_RESOURCE_ID` | The temporary ID for the current installation wizard. |
+    | Environment variable | Description |
+    | --- | --- |
+    | `AUTOOPS_OTEL_URL` | The {{ecloud}} URL to which {{agent}} ships data. The URL is generated based on the CSP and region you pick. <br> This URL shouldn't be edited. |
+    | `AUTOOPS_ES_URL` | The URL {{agent}} uses to communicate with {{es}}. |
+    | `ELASTICSEARCH_READ_API_KEY` | The API key for API key authentication to access the cluster. It combines the `${id}:${api_key}` values. <br> This variable shouldn't be used with `ELASTICSEARCH_READ_USERNAME` and `ELASTICSEARCH_READ_PASSWORD`. |
+    | `ELASTICSEARCH_READ_USERNAME` | The username for basic authentication to access the cluster. <br> This variable should be used with `ELASTICSEARCH_READ_PASSWORD`. |
+    | `ELASTICSEARCH_READ_PASSWORD` | The password for basic authentication to access the cluster. <br> This variable should be used with `ELASTICSEARCH_READ_USERNAME`. |
+    | `ELASTIC_CLOUD_CONNECTED_MODE_API_KEY` | The {{ecloud}} API Key used to register the cluster. <br> This key shouldn't be edited. |
+    | `AUTOOPS_TEMP_RESOURCE_ID` | The temporary ID for the current installation wizard. |
 
-4. Run the command from the machine where you want to install the agent. 
-5. Return to the wizard and select **I have run the command**.
+3. Run the command from the machine where you want to install the agent. 
+4. Return to the wizard and select **I have run the command**.
 
 It might take a few minutes for your cluster details to be validated and the first metrics to be shipped to AutoOps.
 

--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -25,7 +25,7 @@ Ensure your system meets the following requirements before proceeding:
 * Your cluster is on an [Enterprise self-managed license](https://www.elastic.co/subscriptions) or an active self-managed [trial](https://cloud.elastic.co/registration).
 * The agent you install for the connection is allowed to send metrics to {{ecloud}}.
 
-## Connect to AutoOps (private preview)
+## Connect to AutoOps (private preview) [connect-to-autoops]
 
 :::{note}
 :::{include} /deploy-manage/monitor/_snippets/single-cloud-org.md

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -676,6 +676,7 @@ toc:
           - file: monitor/autoops/ec-autoops-faq.md
           - hidden: monitor/autoops/cc-autoops-as-cloud-connected.md
           - hidden: monitor/autoops/cc-connect-self-managed-to-autoops.md
+          - hidden: monitor/autoops/cc-connect-local-dev-to-autoops.md
           - hidden: monitor/autoops/cc-manage-users.md
           - hidden: monitor/autoops/cc-cloud-connect-autoops-faq.md
           - hidden: monitor/autoops/cc-cloud-connect-autoops-troubleshooting.md


### PR DESCRIPTION
This PR adds a page explaining [how to connect a local development cluster to AutoOps](https://docs.google.com/document/d/1bhi-ChuqS1lnTkC9fmseXIPC3Y04k1tC8q8g7UE5hpY/edit?tab=t.u0r4otlndm4k#heading=h.wolypdlz1nl2) through Cloud Connect + some small clarifications.

### Note to reviewers:
- @arnonst will check for accuracy of the workflow and the code snippets.
- Users of this new **Connect your local development cluster to AutoOps** page will follow almost the same steps as the ones in [Connect your self-managed cluster to AutoOps](https://www.elastic.co/docs/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops), so I opted to send them to that page and pointed out the differences in their workflow. Alternatively, we could duplicate all the instructions (in snippets) and edit for the differences, but I'm hesitant about this approach because a) the page will be much longer and b) the differences might not stand out. Let me know what you think. 
- I didn't add the `applies_to ECE` or `ECK` tags to the **Connect your local development cluster to AutoOps** page because this is for [local dev install](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/local-development-installation-quickstart) only, but I'm not sure about this. Please correct me if I'm wrong.

Closes: https://github.com/elastic/docs-content/issues/2483