### PR TITLE
Fixes applies to labels for Cloud Asset Discovery integration

### DIFF
--- a/solutions/security/cloud/asset-disc-aws.md
+++ b/solutions/security/cloud/asset-disc-aws.md
@@ -1,6 +1,6 @@
 ---
 applies_to:
-  stack: preview
+  stack: preview 9.1
   serverless:
     security: preview
 ---

--- a/solutions/security/cloud/asset-disc-azure.md
+++ b/solutions/security/cloud/asset-disc-azure.md
@@ -1,8 +1,8 @@
 ---
 applies_to:
-  stack: all
+  stack: preview 9.1
   serverless:
-    security: all
+    security: preview
 ---
 
 # Set up Cloud Asset Discovery for Azure

--- a/solutions/security/cloud/asset-disc-gcp.md
+++ b/solutions/security/cloud/asset-disc-gcp.md
@@ -1,6 +1,6 @@
 ---
 applies_to:
-  stack: preview
+  stack: preview 9.1
   serverless:
     security: preview
 ---

--- a/solutions/security/cloud/asset-disc.md
+++ b/solutions/security/cloud/asset-disc.md
@@ -1,6 +1,6 @@
 ---
 applies_to:
-  stack: preview
+  stack: preview 91
   serverless:
     security: preview
 ---

--- a/solutions/security/cloud/asset-disc.md
+++ b/solutions/security/cloud/asset-disc.md
@@ -1,6 +1,6 @@
 ---
 applies_to:
-  stack: preview 91
+  stack: preview 9.1
   serverless:
     security: preview
 ---


### PR DESCRIPTION
Follow up PR to https://github.com/elastic/docs-content/pull/2381, fixes the applies to labels for the Cloud Asset Discovery integration docs. 

Thanks!