### PR TITLE
Link from file-realm to file-based roles doc

### DIFF
--- a/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
@@ -201,7 +201,7 @@ eck: all
 ```
 You can also add file-based authentication users using [Kubernetes basic authentication secrets](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret).
 
-A basic authentication secret can optionally contain a [`roles`](#users_roles) entry. It must contain a comma separated list of roles to be associated with the user. The following example illustrates this combination:
+A basic authentication secret can optionally contain a [`roles`](#users_roles) entry. It must contain a comma separated list of roles to be associated with the user. To create custom roles that can be referenced in this list refer to [](/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file). The following example illustrates this combination:
 
 ```yaml
 apiVersion: v1

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
@@ -201,7 +201,7 @@ eck: all
 ```
 You can also add file-based authentication users using [Kubernetes basic authentication secrets](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret).
 
-A basic authentication secret can optionally contain a [`roles`](#users_roles) entry. It must contain a comma separated list of roles to be associated with the user. To create custom roles that can be referenced in this list refer to [](/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles#roles-management-file). The following example illustrates this combination:
+A basic authentication secret can optionally contain a [`roles`](#users_roles) entry. It must contain a comma separated list of roles to be associated with the user. To create custom roles that can be referenced in this list refer to [](/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md#roles-management-file). The following example illustrates this combination:
 
 ```yaml
 apiVersion: v1

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/file-based.md
@@ -201,7 +201,7 @@ eck: all
 ```
 You can also add file-based authentication users using [Kubernetes basic authentication secrets](https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret).
 
-A basic authentication secret can optionally contain a [`roles`](#users_roles) entry. It must contain a comma separated list of roles to be associated with the user. To create custom roles that can be referenced in this list refer to [](/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md#roles-management-file). The following example illustrates this combination:
+A basic authentication secret can optionally contain a [`roles`](#users_roles) entry. It must contain a comma separated list of roles to be associated with the user. The following example illustrates this combination:
 
 ```yaml
 apiVersion: v1
@@ -214,6 +214,10 @@ stringData:
   password: mypassword # required field for kubernetes.io/basic-auth
   roles: kibana_admin,ingest_admin  # optional, not part of kubernetes.io/basic-auth
 ```
+
+::::{tip}
+To create custom roles that can be referenced in this list refer to [](/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles.md#roles-management-file).
+::::
 
 You can make this file available to {{eck}} by adding it as a file realm secret:
 


### PR DESCRIPTION
This lead to confusion with a user recently as it was not clear how to create the roles referenced in the basic-auth secret. 

~LMK if you prefer this to be one of the tip boxes.~ Actually changed my mind and the tip box seems to make more sense here.

<img width="878" height="593" alt="Screenshot 2025-08-11 at 12 09 34" src="https://github.com/user-attachments/assets/913ca561-d5c3-4152-9e2b-62434681f21f" />
