### PR TITLE
[Private preview] AutoOps for self-managed clusters: Hide K8s helm chart option

### DIFF
--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -212,7 +212,8 @@ The wizard will generate an installation command based on your configuration. De
 
 * Kubernetes
     * YAML
-    * Helm Chart
+    <!-- Not applicable for private preview 
+    * Helm Chart -->
 * Docker
     * Docker
     * Docker compose


### PR DESCRIPTION
Helm chart won't be available as a command format for now.

Rel: https://github.com/elastic/docs-content-internal/issues/169