### PR TITLE
Syslog RFC typo

### DIFF
--- a/reference/fleet/syslog-processor.md
+++ b/reference/fleet/syslog-processor.md
@@ -10,7 +10,7 @@ products:
 # Syslog [syslog-processor]
 
 
-The syslog processor parses RFC 3146 and/or RFC 5424 formatted syslog messages that are stored in a field. The processor itself does not handle receiving syslog messages from external sources. This is done through an input, such as the TCP input. Certain integrations, when enabled through configuration, will embed the syslog processor to process syslog messages, such as Custom TCP Logs and Custom UDP Logs.
+The syslog processor parses RFC 3164 and/or RFC 5424 formatted syslog messages that are stored in a field. The processor itself does not handle receiving syslog messages from external sources. This is done through an input, such as the TCP input. Certain integrations, when enabled through configuration, will embed the syslog processor to process syslog messages, such as Custom TCP Logs and Custom UDP Logs.
 
 
 ## Example [_example_33]


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2509 by changing `RFC 3146` to `RFC 3164` on the https://www.elastic.co/docs/reference/fleet/syslog-processor page.