### PR TITLE
Updating the info around the Kibana Docker image

### DIFF
--- a/deploy-manage/deploy/self-managed/install-kibana-with-docker.md
+++ b/deploy-manage/deploy/self-managed/install-kibana-with-docker.md
@@ -11,7 +11,7 @@ products:
 # Install {{kib}} with Docker [docker]
 
 
-Docker [images for {{kib}}](https://hub.docker.com/_/kibana) are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi.
+Docker [images for {{kib}}](https://hub.docker.com/_/kibana) are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi if you use [hardened Docker images](/deploy-manage/deploy/self-managed/install-kibana-with-docker.md#_hardened_docker_images).
 
 A list of all published Docker images and tags is available at [www.docker.elastic.co](https://www.docker.elastic.co). The source code is in [GitHub](https://github.com/elastic/dockerfiles/tree/master/kibana).
 

--- a/deploy-manage/deploy/self-managed/install-kibana-with-docker.md
+++ b/deploy-manage/deploy/self-managed/install-kibana-with-docker.md
@@ -11,7 +11,7 @@ products:
 # Install {{kib}} with Docker [docker]
 
 
-Docker [images for {{kib}}](https://hub.docker.com/_/kibana) are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi if you use [hardened Docker images](/deploy-manage/deploy/self-managed/install-kibana-with-docker.md#_hardened_docker_images).
+Docker [images for {{kib}}](https://hub.docker.com/_/kibana) are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi if you use [hardened Docker images](install-kibana-with-docker.md#_hardened_docker_images).
 
 A list of all published Docker images and tags is available at [www.docker.elastic.co](https://www.docker.elastic.co). The source code is in [GitHub](https://github.com/elastic/dockerfiles/tree/master/kibana).
 

--- a/deploy-manage/deploy/self-managed/install-kibana-with-docker.md
+++ b/deploy-manage/deploy/self-managed/install-kibana-with-docker.md
@@ -11,7 +11,7 @@ products:
 # Install {{kib}} with Docker [docker]
 
 
-Docker images for {{kib}} are available from the Elastic Docker registry. The base image is [ubuntu:20.04](https://hub.docker.com/_/ubuntu).
+Docker [images for {{kib}}](https://hub.docker.com/_/kibana) are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi.
 
 A list of all published Docker images and tags is available at [www.docker.elastic.co](https://www.docker.elastic.co). The source code is in [GitHub](https://github.com/elastic/dockerfiles/tree/master/kibana).
 

--- a/solutions/observability/apm/apm-server-binary.md
+++ b/solutions/observability/apm/apm-server-binary.md
@@ -844,7 +844,7 @@ To add the apm-server repository for YUM:
 
 ## Run APM Server on Docker [apm-running-on-docker]
 
-Docker images for APM Server are available from the Elastic Docker registry. The base image is [ubuntu:22.04](https://hub.docker.com/_/ubuntu).
+Docker images for APM Server are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi.
 
 A list of all published Docker images and tags is available at [www.docker.elastic.co](https://www.docker.elastic.co).
 

--- a/solutions/observability/apm/apm-server-binary.md
+++ b/solutions/observability/apm/apm-server-binary.md
@@ -844,7 +844,7 @@ To add the apm-server repository for YUM:
 
 ## Run APM Server on Docker [apm-running-on-docker]
 
-Docker images for APM Server are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or Wolfi.
+Docker images for APM Server are available from the Elastic Docker registry. The base image is Red Hat Universal Base Images (UBI) or [Wolfi](https://github.com/wolfi-dev/) if you use hardened Docker images.
 
 A list of all published Docker images and tags is available at [www.docker.elastic.co](https://www.docker.elastic.co).
 


### PR DESCRIPTION
The base image is Red Hat Universal Base Images (UBI) or Wolfi.

Fixes #1575 