### PR TITLE
Adds a new section about BBQ to the 'Dense vector' page

### DIFF
--- a/solutions/search/vector/dense-vector.md
+++ b/solutions/search/vector/dense-vector.md
@@ -26,3 +26,161 @@ Dense vector search requires both index configuration and a strategy for generat
   - You can also [bring your own embeddings](bring-own-vectors.md)
     - Use the `dense_vector` field type
 2. Query the index using the [`knn` search](knn.md)
+
+## Better Binary Quantization (BBQ) [bbq]
+
+Better Binary Quantization (BBQ) is an advanced vector quantization method, designed for large-scale similarity search. BBQ is a form of lossy compression for [`dense_vector` fields](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/dense-vector) that enables efficient storage and retrieval of large numbers of vectors, while keeping results close to those from the original uncompressed vectors.
+
+BBQ offers significant improvements over scalar quantization by using more sophisticated algorithms to reduce memory usage and computational costs while maintaining high search relevance. BBQ is designed to work in combination with [oversampling](#bbq-oversampling) and reranking, and is compatible with various [vector search algorithms](#bbq-vector-search-algorithms), such as [HNSW](#bbq-hnsw) and [brute force (flat)](#bbq-flat).
+
+### How BBQ works [bbq-how-it-works]
+
+BBQ retains the original vector’s dimensionality but transforms the datatype of the dimensions from the original `float32` to `bit`. BBQ also keeps some additional information for each vector that improves the ability to predict the vector similarity of the original vector using the quantized vector. 
+
+Measuring vector similarity with BBQ vectors requires much less computing effort, allowing more candidates to be considered when using the HNSW algorithm. This often results in better ranking quality and improved relevance compared to the original `float32` vectors.
+
+### Vector search algorithms for BBQ [bbq-vector-search-algorithms]
+
+BBQ currently supports two vector search algorithms, each suited to different scenarios. You can can configure them by setting the dense vector field’s `index_type`.
+
+#### `bbq_hnsw` [bbq-hnsw]
+
+When you set a dense vector field’s `index_type` to `bbq_hnsw`, Elasticsearch uses the HNSW algorithm for fast [kNN search](/solutions/search/vector/knn) on compressed vectors. With the default [oversampling](#bbq-oversampling) applied, it delivers better cost efficiency, lower latency, and improved relevance ranking, making it the best choice for large-scale similarity search.
+
+:::{note}
+Starting in version 9.1, `bbq_hnsw` is the default indexing method for new `dense_vector` fields, so you don’t need to specify it explicitly when creating an index. 
+:::
+
+The following example creates an index with a `dense_vector` field configured to use the `bbq_hnsw` index type.
+
+```console
+PUT bbq_hnsw-index
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "dense_vector",
+        "dims": 64,
+        "index": true,
+        "index_options": {
+          "type": "bbq_hnsw"
+        }
+      }
+    }
+  }
+}
+```
+
+To change an existing index to use `bbq_hnsw`, update the field mapping:
+
+```console
+PUT bbq_hnsw-index/_mapping
+{
+  "properties": {
+    "my_vector": {
+      "type": "dense_vector",
+      "dims": 64,
+      "index": true,
+      "index_options": {
+        "type": "bbq_hnsw"
+      }
+    }
+  }
+}
+```
+
+After this change, all newly created segments will use the `bbq_hnsw` index type. As you add or update documents, the index will gradually convert to `bbq_hnsw`. 
+
+To apply `bbq_hnsw` to all vectors at once, reindex them into a new index where the index type is set to `bbq_hnsw`:
+
+:::::{stepper}
+::::{step} Create a destination index
+```console
+PUT my-index-bbq
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "dense_vector",
+        "dims": 64,
+        "index": true,
+        "index_options": {
+          "type": "bbq_hnsw"
+        }
+      }
+    }
+  }
+}
+```
+::::
+
+::::{step} Reindex the data
+```console
+POST _reindex
+{
+  "source": { "index": "my-index" }, <1>
+  "dest":   { "index": "my-index-bbq" }
+}
+```
+1. The existing index that you want to reindex into the newly created index with the `bbq_hnsw` `index_type`.
+::::
+
+:::::
+
+#### `bbq_flat` [bbq-flat]
+
+When you set a dense vector field’s `index_type` to `bbq_flat`, Elasticsearch uses the BBQ algorithm without HNSW. This option generally requires fewer computing resources and works best when the number of vectors being searched is relatively low.
+
+The following example creates an index with a `dense_vector` field configured to use the `bbq_flat` index type.
+
+```console
+PUT bbq_flat-index
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "dense_vector",
+        "dims": 64,
+        "index": true,
+        "index_options": {
+          "type": "bbq_flat"
+        }
+      }
+    }
+  }
+}
+```
+
+### Oversampling [bbq-oversampling]
+
+Oversampling is a technique used with BBQ searches to reduce the accuracy loss from compression. Compression lowers the memory footprint by over 95% and improves query latency, but this comes at the cost of some result accuracy. The accuracy loss can be mitigated by oversampling during query time and reranking the top results using the full vector. 
+
+When you run a kNN search on a BBQ-indexed field, Elasticsearch automatically retrieves more candidate vectors than the number of results you request. This oversampling improves accuracy by giving the system more vectors to re-rank using their full-precision values before returning the top results.
+
+```console
+GET bbq-index/_search
+{
+  "knn": {
+    "field": "my_vector",
+    "query_vector": [0.12, -0.45, ...],
+    "k": 10,
+    "num_candidates": 100
+  }
+}
+```
+
+By default, oversampling is set to 3×, meaning if you request k:10, Elasticsearch retrieves 30 candidates for re-ranking. You don’t need to configure this behavior; it’s applied automatically for BBQ searches.
+
+:::{note}
+You can change oversampling from the default 3× to another value. Refer to [Oversampling and rescoring for quantized vectors](/solutions/search/vector/knn#dense-vector-knn-search-rescoring) for details.
+:::
+
+### Learn more [bbq-learn-more]
+
+- [Better Binary Quantization (BBQ) in Lucene and Elasticsearch](https://www.elastic.co/search-labs/blog/better-binary-quantization-lucene-elasticsearch) - Learn how BBQ works, its benefits, and how it reduces memory usage while preserving search accuracy.
+- [Dense vector field type](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/dense-vector) - Find code examples for using `bbq_hnsw` `index_type`.
+- [kNN search](/solutions/search/vector/knn) - Learn about the search algorithm that BBQ works with.
+
+
+
+


### PR DESCRIPTION
This PR introduces a new section on Better Binary Quantization (BBQ) in the "Dense vector" documentation.

The new section explains what BBQ is, outlines its benefits, and describes how it works with different vector search algorithms (bbq_hnsw and bbq_flat). 

Related issue: https://github.com/elastic/developer-docs-team/issues/333

