### PR TITLE
Fleet Server / Elastic Agent 9.1.2 release notes

### DIFF
--- a/release-notes/fleet-elastic-agent/index.md
+++ b/release-notes/fleet-elastic-agent/index.md
@@ -28,13 +28,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 ## 9.1.2 [fleet-elastic-agent-9.1.2-release-notes]
 
-### Features and enhancements [fleet-elastic-agent-9.1.2-features-enhancements]
-
-There are no new features or enhancements in this release.
-
-### Fixes [fleet-elastic-agent-9.1.2-fixes]
-
-There are no fixes in this release.
+There are no new features, enhancements, or fixes in this release.
 
 ## 9.1.1 [fleet-elastic-agent-9.1.1-release-notes]
 

--- a/release-notes/fleet-elastic-agent/index.md
+++ b/release-notes/fleet-elastic-agent/index.md
@@ -26,6 +26,16 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [fleet-elastic-agent-next-fixes]
 % *
 
+## 9.1.2 [fleet-elastic-agent-9.1.2-release-notes]
+
+### Features and enhancements [fleet-elastic-agent-9.1.2-features-enhancements]
+
+There are no new features or enhancements in this release.
+
+### Fixes [fleet-elastic-agent-9.1.2-fixes]
+
+There are no fixes in this release.
+
 ## 9.1.1 [fleet-elastic-agent-9.1.1-release-notes]
 
 ### Features and enhancements [fleet-elastic-agent-9.1.1-features-enhancements]


### PR DESCRIPTION
Adds a release notes entry for release 9.1.2. Although no changes were made in Fleet and Elastic Agent between 9.1.1 and 9.1.2, we still need to add an entry specifying this as customers can upgrade to this version.

cc @ebeahan @pierrehilbert