### PR TITLE
Clarify Elastic Agent upgrade rollouts

### DIFF
--- a/reference/fleet/upgrade-elastic-agent.md
+++ b/reference/fleet/upgrade-elastic-agent.md
@@ -101,6 +101,7 @@ You can do rolling upgrades to avoid exhausting network resources when updating 
 
 5. Upgrade the agents.
 
+Note that agents in a rollout period have the status `Updating` until the upgrade is complete, even if the upgrade has not started yet.
 
 ## Schedule an upgrade [schedule-agent-upgrade]
 
@@ -245,7 +246,9 @@ To configure an automatic rollout of a new minor or patch version to a percentag
 7. You can then add a different target version, and specify the percentage of agents you want to be upgraded to that version. The total percentage of agents to be upgraded cannot exceed 100%.
 8. Click **Save**.
 
-Once the configuration is saved, an asynchronous task runs every 30 minutes, gradually upgrading the agents in the policy to the specified target version.
+Once the configuration is saved, an asynchronous task runs every 30 minutes, upgrading the agents in the policy to the specified target version.
+
+If the number of agents to be upgraded is greater or equal to 10, a rollout period based on this number is automatically applied.
 
 In case of any failed upgrades, the upgrades are retried with exponential backoff mechanism until the upgrade is successful, or the maximum number of retries is reached. Note that the maximum number of retries is the number of [configured retry delays](#auto-upgrade-settings).
 


### PR DESCRIPTION
Adding a couple of clarifications regarding upgrading Elastic Agents with a rollout period:
1. Agents in the rollout but not actually upgrading yet have status `Updating` in Fleet.
2. For auto-upgrades, the rollout period is automatically calculated based on the number of agents (less than 10 agents: no rollout; more than 10 agents: rollout duration of 10 min or nAgents * 0.03 seconds, whichever is higher).