### PR TITLE
Add missing applies_to tag on the Observability Cloud page

### DIFF
--- a/solutions/observability/cloud.md
+++ b/solutions/observability/cloud.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/observability/current/cloud-monitoring.html
 applies_to:
   stack:
+  serverless:
 products:
   - id: observability
 ---


### PR DESCRIPTION
This PR adds the missing `serverless` tag to the https://www.elastic.co/docs/solutions/observability/cloud page.