### PR TITLE
Fix 7.x info and nesting issues on snapshot repo topics

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
+++ b/deploy-manage/tools/snapshot-and-restore/ec-azure-snapshotting.md
@@ -19,26 +19,7 @@ Configure a custom snapshot repository using your Azure Blob storage account.
 Follow the Microsoft documentation to [set up an Azure storage account](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create) with an access key, and then [create a container](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
 
 
-## Enable the `repository-azure` plugin in {{stack}} 7.17 and earlier [ec-enable-azure-plugin]
-
-For deployments with **{{stack}} version 7.17 and earlier**, you’ll need to enable the `repository-azure` plugin to use the Azure repository type. On the Azure platform, the plugin is enabled by default. If your deployment is on AWS or GCP, follow these steps to enable the `repository-azure` plugin:
-
-1. Refer to [Azure Repository Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-azure.html) to download the version of the plugin that matches your {{stack}} version.
-2. Upload the plugin to your deployment:
-
-    1. Log in to the [{{ecloud}} Console](https://cloud.elastic.co?page=docs&placement=docs-body).
-    2. From your deployment, select **Manage**.
-    3. From the lower navigation menu, select **Extensions** and then select **Upload extension**.
-    4. Specify the plugin name (`repository-azure`) and version.
-    5. Select **An installable plugin (compiled, no source code)**.
-    6. Select **Create extension**.
-    7. Navigate back to the **Extensions** page.
-    8. Select the extension name.
-    9. Drag and drop to upload the `repository-azure` plugin zip file.
-
-
-
-### Configure the keystore [ec-configure-azure-keystore]
+## Configure the keystore [ec-configure-azure-keystore]
 
 Create an entry for the Azure client in the {{es}} keystore:
 
@@ -52,8 +33,7 @@ Create an entry for the Azure client in the {{es}} keystore:
 
 5. Select **Save**.
 
-
-### Create the repository [ec-create-azure-repository]
+## Create the repository [ec-create-azure-repository]
 
 1. Open {{kib}} and go to **Management** > **Snapshot and Restore**.
 2. On the **Repositories** tab, select **Register a repository**.

--- a/deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
+++ b/deploy-manage/tools/snapshot-and-restore/ec-gcs-snapshotting.md
@@ -32,26 +32,7 @@ For more detailed information on the JSON account service key, refer to [Using a
 Follow the Google Cloud Storage documentation to [create a GCS bucket](https://cloud.google.com/storage/docs/creating-buckets).
 
 
-## Enable the `repository-gcs` plugin in {{stack}} 7.17 and earlier [ec-enable-gcs-plugin]
-
-For deployments with **{{stack}} version 7.17 and earlier**, you’ll need to enable the `repository-gcs` plugin to use the Google Cloud Storage repository type. On Google Cloud Platform, the plugin is enabled by default. If your deployment is on AWS or Azure, follow these steps to enable the `repository-gcs` plugin:
-
-1. Refer to [Google Cloud Storage Repository Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-gcs.html) to download the version of the plugin that matches your {{stack}} version.
-2. Upload the plugin to your deployment:
-
-    1. Log in to the [{{ecloud}} Console](https://cloud.elastic.co?page=docs&placement=docs-body).
-    2. From your deployment, select **Manage**.
-    3. From the lower navigation menu, select **Extensions** and then select **Upload extension**.
-    4. Specify the plugin name (`repository-gcs`) and version.
-    5. Select **An installable plugin (compiled, no source code)**.
-    6. Select **Create extension**.
-    7. Navigate back to the **Extensions** page.
-    8. Select the extension name.
-    9. Drag and drop to upload the `repository-gcs` plugin zip file.
-
-
-
-### Configure the keystore [ec-configure-gcs-keystore]
+## Configure the keystore [ec-configure-gcs-keystore]
 
 Create an entry for the GCS client in the {{es}} keystore:
 
@@ -62,8 +43,7 @@ Create an entry for the GCS client in the {{es}} keystore:
 5. With **Type** set to **JSON block / file**, add your [GCS service account key JSON file](#ec-gcs-service-account-key).
 6. Select **Save**.
 
-
-### Create the repository [ec-create-gcs-repository]
+## Create the repository [ec-create-gcs-repository]
 
 1. Open {{kib}} and go to **Management** > **Snapshot and Restore**.
 2. On the **Repositories** tab, select **Register a repository**.


### PR DESCRIPTION
These pages had the following problems:
 
* they had a section specific to 7.x. These docs are for 9.x+ so there should be no 7.x content
* the core steps were nested under this 7.x section (this was an issue in the previous docs system too)

and I fixed that

fixes https://github.com/elastic/docs-content/issues/2436