### PR TITLE
[Do not merge] Updates AutoOps retention period

### DIFF
--- a/deploy-manage/monitor/autoops-vs-stack-monitoring.md
+++ b/deploy-manage/monitor/autoops-vs-stack-monitoring.md
@@ -18,7 +18,7 @@ Review how these tools differ in their provisioning, set up procedure, method of
 ### Resource provisioning and billing
 
 #### AutoOps [ao-resource]
-AutoOps stores and backs up your monitoring data internally on {{ecloud}} infrastructure so you don’t need to think about provisioning, sizing, and availability. The data is retained for four days by default. Using AutoOps is free for {{ecloud}} customers and is offered to [all subscription tiers](https://www.elastic.co/subscriptions/cloud).
+AutoOps stores and backs up your monitoring data internally on {{ecloud}} infrastructure so you don’t need to think about provisioning, sizing, and availability. The data is retained for 10 days by default. Using AutoOps is free for {{ecloud}} customers and is offered to [all subscription tiers](https://www.elastic.co/subscriptions/cloud).
 
 #### Stack Monitoring [sm-resource]
 With Stack Monitoring, you are responsible for storing your monitoring data. This requires provisioning the necessary resources based on your performance and retention needs as well as paying for the allocated resources. The default retention period is six days.

--- a/deploy-manage/monitor/autoops.md
+++ b/deploy-manage/monitor/autoops.md
@@ -43,7 +43,7 @@ AutoOps diagnoses issues in {{es}} by analyzing hundreds of metrics, providing r
 
 ## AutoOps retention period [ec_autoops_retention_period]
 
-AutoOps currently has a four-day retention period for all {{ech}} customers.
+AutoOps currently has a 10 day retention period for all {{ech}} customers.
 
 
 ## AutoOps scope [ec_autoops_scope]

--- a/deploy-manage/monitor/autoops.md
+++ b/deploy-manage/monitor/autoops.md
@@ -10,27 +10,25 @@ products:
 
 # AutoOps [ec-autoops]
 
-AutoOps diagnoses issues in {{es}} by analyzing hundreds of metrics, providing root-cause analysis and accurate resolution paths. With AutoOps, customers can prevent and resolve issues, cut down administration time, and optimize resource utilization.
+AutoOps analyzes a comprehensive set of metrics to diagnose issues in {{es}} and provide you with root-cause analyses and accurate resolution paths. With AutoOps, you can prevent and resolve issues, cut down administration time, and optimize resource utilization.
 
 :::{image} /deploy-manage/images/cloud-autoops-overview-page.png
 :alt: The Overview page
 :::
 
-
 ## AutoOps key features [ec_autoops_key_features]
 
-* Real-time root-cause analysis for hundreds of issues.
-* Accurate resolution paths and customized recommendations.
-* Insight into what occurred and detailed views into nodes, index, shards, and templates.
+* Real-time root-cause analysis for hundreds of issues
+* Accurate resolution paths and customized recommendations
+* Insight into what occurred and detailed views into nodes, indices, shards, and templates
 * Wide range of insights, including:
-
-    * Cluster status, node failures, and shard sizes.
-    * High CPU, memory, disk usage, and other resource-related metrics.
-    * Misconfigurations and possible optimizations.
-    * Insights on data structure, shards, templates, and mapping optimizations.
-    * Unbalanced loads between nodes.
-    * Indexing latency, rejections, search latency, high index/search queues, and slow queries.
-    * Resource utilization.
+    * Cluster status, node failures, and shard sizes
+    * High CPU, memory, disk usage, and other resource-related metrics
+    * Misconfigurations and possible optimizations
+    * Data structure, templates, and mapping optimizations
+    * Unbalanced loads between nodes
+    * Indexing latency, rejections, search latency, high index/search queues, and slow queries
+    * Resource utilization
 
 
 

--- a/deploy-manage/monitor/autoops.md
+++ b/deploy-manage/monitor/autoops.md
@@ -10,25 +10,27 @@ products:
 
 # AutoOps [ec-autoops]
 
-AutoOps analyzes a comprehensive set of metrics to diagnose issues in {{es}} and provide you with root-cause analyses and accurate resolution paths. With AutoOps, you can prevent and resolve issues, cut down administration time, and optimize resource utilization.
+AutoOps diagnoses issues in {{es}} by analyzing hundreds of metrics, providing root-cause analysis and accurate resolution paths. With AutoOps, customers can prevent and resolve issues, cut down administration time, and optimize resource utilization.
 
 :::{image} /deploy-manage/images/cloud-autoops-overview-page.png
 :alt: The Overview page
 :::
 
+
 ## AutoOps key features [ec_autoops_key_features]
 
-* Real-time root-cause analysis for hundreds of issues
-* Accurate resolution paths and customized recommendations
-* Insight into what occurred and detailed views into nodes, indices, shards, and templates
+* Real-time root-cause analysis for hundreds of issues.
+* Accurate resolution paths and customized recommendations.
+* Insight into what occurred and detailed views into nodes, index, shards, and templates.
 * Wide range of insights, including:
-    * Cluster status, node failures, and shard sizes
-    * High CPU, memory, disk usage, and other resource-related metrics
-    * Misconfigurations and possible optimizations
-    * Data structure, templates, and mapping optimizations
-    * Unbalanced loads between nodes
-    * Indexing latency, rejections, search latency, high index/search queues, and slow queries
-    * Resource utilization
+
+    * Cluster status, node failures, and shard sizes.
+    * High CPU, memory, disk usage, and other resource-related metrics.
+    * Misconfigurations and possible optimizations.
+    * Insights on data structure, shards, templates, and mapping optimizations.
+    * Unbalanced loads between nodes.
+    * Indexing latency, rejections, search latency, high index/search queues, and slow queries.
+    * Resource utilization.
 
 
 

--- a/deploy-manage/monitor/autoops/ec-autoops-faq.md
+++ b/deploy-manage/monitor/autoops/ec-autoops-faq.md
@@ -34,7 +34,7 @@ $$$faq-autoops-issue-resolution$$$Can AutoOps currently automatically resolve is
 :   AutoOps only analyzes metrics, and is a read-only solution.
 
 $$$faq-autoops-data-retention$$$How long does Elastic retain AutoOps data?
-:   Currently, AutoOps has a four-day retention period for all {{ech}} customers.
+:   Currently, AutoOps has a 10 day retention period for all {{ech}} customers.
 
 $$$faq-autoops-metrics-storage$$$Where are AutoOps metrics stored, and does AutoOps affect customer ECU usage?
 :   AutoOps metrics are stored internally within the Elastic infrastructure, not on customer deployments. So using AutoOps does not consume customer ECU.


### PR DESCRIPTION
This PR updates all mentions of the AutoOps data retention period to 10 days. Will merge this when I get the go-ahead from product.

Closes https://github.com/elastic/opex-product/issues/599