### PR TITLE
Update SSL config settings for logstash output

### DIFF
--- a/reference/fleet/logstash-output.md
+++ b/reference/fleet/logstash-output.md
@@ -37,7 +37,7 @@ input {
   elastic_agent {
     port => 5044
     enrich => none <1>
-    ssl => true
+    ssl_enabled => true
     ssl_certificate_authorities => ["<ca_path>"]
     ssl_certificate => "<server_cert_path>"
     ssl_key => "<server_cert_key_in_pkcs8>"


### PR DESCRIPTION
Updates config example to use current SSL settings. 
Closes: #2682

[logstash-input-elastic_agent](https://www.elastic.co/docs/reference/logstash/plugins/plugins-inputs-elastic_agent): 
ssl_verify_mode replaced by [ssl_client_authentication](https://www.elastic.co/docs/reference/logstash/plugins/plugins-inputs-elastic_agent#plugins-inputs-elastic_agent-ssl_client_authentication)

[logstash-output-elasticsearch](https://www.elastic.co/docs/reference/logstash/plugins/plugins-outputs-elasticsearch):
cacert replaced by [ssl_certificate_authorities](https://www.elastic.co/docs/reference/logstash/plugins/plugins-outputs-elasticsearch#plugins-outputs-elasticsearch-ssl_certificate_authorities)

### To Do
- [ ] Complete updated settings with realistic values