### PR TITLE
Observability 9.0.6 release notes

### DIFF
--- a/release-notes/elastic-observability/index.md
+++ b/release-notes/elastic-observability/index.md
@@ -185,6 +185,11 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Improves finding functions in Universal Profiling [#210437]({{kib-pull}}210437).
 * Adds logical `AND` to monitor tags and locations filter [#217985]({{kib-pull}}217985).
 
+## 9.0.6 [elastic-observability-9.0.6-release-notes]
+
+### Fixes [elastic-observability-9.0.6-fixes]
+* Fixes AI Assistant for Observability settings to only show for Enterprise users [#231989]({{kib-pull}}231989).
+
 ## 9.0.5 [elastic-observability-9.0.5-release-notes]
 
 ### Features and enhancements[elastic-observability-9.0.5-features]


### PR DESCRIPTION
This PR closes https://github.com/elastic/docs-content/issues/2678 and adds the 9.0.6 release notes for Observability.