### PR TITLE
Adding 3 new Serverless Azure regions

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/regions.md
+++ b/deploy-manage/deploy/elastic-cloud/regions.md
@@ -41,6 +41,9 @@ The following Azure regions are currently available:
 | Region | Name |
 | :--- | :--- |
 | eastus | East US |
+| northeurope | North Europe |
+| australiaeast | Australia East |
+| westus2 | West US 2 |
 
 ## Google Cloud Platform (GCP) regions [regions-gcp-regions]
 

--- a/release-notes/elastic-cloud-serverless/index.md
+++ b/release-notes/elastic-cloud-serverless/index.md
@@ -11,6 +11,15 @@ Review the changes, fixes, and more to {{serverless-full}}.
 
 
 
+## August 28, 2025 [serverless-changelog-08282025]
+
+### Features and enhancements [serverless-changelog-08282025-features-enhancements]
+
+* {{serverless-full}} is now available in three new Microsoft Azure [regions](/deploy-manage/deploy/elastic-cloud/regions.md): 
+    * `northeurope` (North Europe), located in Ireland 
+    * `australiaeast` (Australia East), located in Victoria, Australia
+    * ` westus2` (West US 2), located in Washington, United Stated
+
 ## August 18, 2025 [serverless-changelog-08182025]
 
 ### Features and enhancements [serverless-changelog-08182025-features-enhancements]


### PR DESCRIPTION
Updates the [Serverless changelog](https://www.elastic.co/docs/release-notes/cloud-serverless) and the Serverless [Regions](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/regions) page for the newly supported Azure regions.

The names of the regions are listed as they appear on the [Azure regions list](https://learn.microsoft.com/en-us/azure/reliability/regions-list) page.

Fixes [#688](https://github.com/elastic/platform-docs-team/issues/688)