### PR TITLE
Corrects use of autorefresh option

### DIFF
--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
@@ -48,7 +48,7 @@ rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
 ## Step 2: Install {{es}}
 
-You have several options for installing the {{es}} RPM package:
+You have two options for installing the {{es}} RPM package:
 
 * [From the RPM repository](#rpm-repo)
 * [Manually](#install-rpm)
@@ -91,7 +91,7 @@ type=rpm-md
 :::
 :::: 
 
-1. Install {{es}} from the repository you defined earlier.
+2. Install {{es}} from the repository you defined earlier.
 
 ::::{tab-set}
 :group:linux-distros

--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
@@ -17,7 +17,7 @@ sub:
 
 # Install {{es}} with RPM [rpm]
 
-The RPM package for {{es}} can be [downloaded from our website](#install-rpm) or from our  [RPM repository](#rpm-repo). It can be used to install {{es}} on any RPM-based system such as OpenSuSE, SLES, Centos, Red Hat, and Oracle Enterprise.
+The RPM package for {{es}} can be [downloaded from our website](#install-rpm) or from our  [RPM repository](#rpm-repo). It can be used to install {{es}} on any RPM-based system such as openSUSE, SLES, CentOS, Red Hat Enterprise Linux, and Oracle Linux.
 
 ::::{note}
 RPM install is not supported on distributions with old versions of RPM, such as SLES 11 and CentOS 5. Refer to [Install {{es}} from archive on Linux or MacOS](install-elasticsearch-from-archive-on-linux-macos.md) instead.
@@ -74,9 +74,9 @@ type=rpm-md
 ```
 ::: 
 
-:::{tab-item} OpenSuSE distributions
+:::{tab-item} openSUSE distributions
 :sync: suse
-For OpenSuSE based distributions, create a file called `elasticsearch.repo` in the `/etc/zypp/repos.d/` directory and include the following configuration:
+For openSUSE based distributions, create a file called `elasticsearch.repo` in the `/etc/zypp/repos.d/` directory and include the following configuration:
 
 ```ini subs=true
 [elasticsearch]
@@ -108,7 +108,7 @@ If you use CentOS, or Red Hat Enterprise Linux 7 and earlier, enter the followin
 sudo yum install --enablerepo=elasticsearch elasticsearch
 ```
 :::
-:::{tab-item} OpenSuSE distributions
+:::{tab-item} openSUSE distributions
 :sync: suse
 Enter the following command:
 

--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
@@ -17,7 +17,7 @@ sub:
 
 # Install {{es}} with RPM [rpm]
 
-The RPM package for {{es}} can be [downloaded from our website](#install-rpm) or from our  [RPM repository](#rpm-repo). It can be used to install {{es}} on any RPM-based system such as openSUSE, SLES, CentOS, Red Hat Enterprise Linux, and Oracle Linux.
+The RPM package for {{es}} can be [downloaded from our website](#install-rpm) or from our  [RPM repository](#rpm-repo). It can be used to install {{es}} on any RPM-based system such as openSUSE, SUSE Linux Enterprise Server (SLES), CentOS, Red Hat Enterprise Linux (RHEL), and Oracle Linux.
 
 ::::{note}
 RPM install is not supported on distributions with old versions of RPM, such as SLES 11 and CentOS 5. Refer to [Install {{es}} from archive on Linux or MacOS](install-elasticsearch-from-archive-on-linux-macos.md) instead.

--- a/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
+++ b/deploy-manage/deploy/self-managed/install-elasticsearch-with-rpm.md
@@ -55,7 +55,28 @@ You have several options for installing the {{es}} RPM package:
 
 ### Install from the RPM repository [rpm-repo]
 
-Create a file called `elasticsearch.repo` in the `/etc/yum.repos.d/` directory for RedHat based distributions, or in the `/etc/zypp/repos.d/` directory for OpenSuSE based distributions, containing:
+1. Define a repository for {{es}}.
+
+::::{tab-set}
+:group:linux-distros
+:::{tab-item} RedHat distributions
+:sync: rhel
+For RedHat based distributions, create a file called `elasticsearch.repo` in the `/etc/yum.repos.d/` directory and include the following configuration: 
+
+```ini subs=true
+[elasticsearch]
+name={{es}} repository for 9.x packages
+baseurl=https://artifacts.elastic.co/packages/9.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=0
+type=rpm-md
+```
+::: 
+
+:::{tab-item} OpenSuSE distributions
+:sync: suse
+For OpenSuSE based distributions, create a file called `elasticsearch.repo` in the `/etc/zypp/repos.d/` directory and include the following configuration:
 
 ```ini subs=true
 [elasticsearch]
@@ -67,19 +88,38 @@ enabled=0
 autorefresh=1
 type=rpm-md
 ```
-And your repository is ready for use. You can now install {{es}} with one of the following commands:
+:::
+:::: 
+
+1. Install {{es}} from the repository you defined earlier.
+
+::::{tab-set}
+:group:linux-distros
+:::{tab-item} RedHat distributions
+:sync: rhel
+If you use Fedora, or Red Hat Enterprise Linux 8 and later, enter the following command:
 
 ```sh
-sudo yum install --enablerepo=elasticsearch elasticsearch <1>
-sudo dnf install --enablerepo=elasticsearch elasticsearch <2>
-sudo zypper modifyrepo --enable elasticsearch && \
-  sudo zypper install elasticsearch; \
-  sudo zypper modifyrepo --disable elasticsearch <3>
+sudo dnf install --enablerepo=elasticsearch elasticsearch
 ```
 
-1. Use `yum` on CentOS and older Red Hat based distributions.
-2. Use `dnf` on Fedora and other newer Red Hat distributions.
-3. Use `zypper` on OpenSUSE based distributions.
+If you use CentOS, or Red Hat Enterprise Linux 7 and earlier, enter the following command:
+```sh
+sudo yum install --enablerepo=elasticsearch elasticsearch
+```
+:::
+:::{tab-item} OpenSuSE distributions
+:sync: suse
+Enter the following command:
+
+```sh
+sudo zypper modifyrepo --enable elasticsearch && \
+  sudo zypper install elasticsearch; \
+  sudo zypper modifyrepo --disable elasticsearch
+```
+::: 
+:::: 
+
 
 ### Download and install the RPM manually [install-rpm]
 


### PR DESCRIPTION
The author of #1745 is correct, `autorefresh = 1` is not a config option that's available in dnf or yum. However, it is a valid and often used option in [zypper](https://doc.opensuse.org/documentation/tumbleweed/zypper/) (openSUSE distros).

I've added tabs to account for this discrepancy (when creating the repo definition) and using tabs actually fixes the next step as well, which is trying to account for multiple Linux distros commands to install Elasticsearch from an RPM repo.
The RHEL-based commands for installing will also differ based on the version or RHEL you're using, so that tab accounts for RHEL 8 + (when dnf was introduced) and RHEL 7 & earlier for yum.

I've also updated the names of the distros for accuracy:
* Red Hat Enterprise Linux (RHEL)
* openSUSE
* SUSE Linux Enterprise Server (SLES)
* Oracle Linux (was renamed from Oracle Enterprise)
* CentOS

Fixes #1745