### PR TITLE
example youtube of updating data stream number_of_shards

### DIFF
--- a/manage-data/data-store/data-streams/modify-data-stream.md
+++ b/manage-data/data-store/data-streams/modify-data-stream.md
@@ -251,6 +251,7 @@ If wanted, you can [roll over the data stream](../data-streams/use-data-stream.m
 
 To apply static setting changes to existing backing indices, you must create a new data stream and reindex your data into it. See [Use reindex to change mappings or settings](../data-streams/modify-data-stream.md#data-streams-use-reindex-to-change-mappings-settings).
 
+See [this video](https://www.youtube.com/watch?v=fHL7SkQr7Wc) for a walkthrough of updating [`number_of_shards`](https://www.elastic.co/docs/reference/elasticsearch/index-settings/index-modules#_static_index_settings).
 
 ### Use reindex to change mappings or settings [data-streams-use-reindex-to-change-mappings-settings]
 


### PR DESCRIPTION
👋 howdy, team! This adds @anniegale9538's [video](https://www.youtube.com/watch?v=fHL7SkQr7Wc&list=PL_mJOmq4zsHbQlfEMEh_30_LuV_hZp-3d&index=1) to [modify static data stream](https://www.elastic.co/docs/manage-data/data-store/data-streams/modify-data-stream#change-static-index-setting-for-a-data-stream) for updating `number_of_shards` which is a common support volume related to [hotspotting](https://www.elastic.co/guide/en/elasticsearch/reference/current/hotspotting.html).