### PR TITLE
Add AI/LLM files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 # docs-builder default output
 .artifacts
 .DS_store
+
+# Add LLM/AI related files
+AGENTS.md
+.github/copilot-instructions.md
+.github/instructions/**.instructions.md
+CLAUDE.md
+GEMINI.md
+.cursor


### PR DESCRIPTION
This adds common AI agent context / instructions files to .gitignore, so they can be used in AI-powered tools / IDEs.