### PR TITLE
Cross-link troubleshooting: diagnose shards to allocation explain

### DIFF
--- a/troubleshoot/elasticsearch/diagnose-unassigned-shards.md
+++ b/troubleshoot/elasticsearch/diagnose-unassigned-shards.md
@@ -136,7 +136,7 @@ In order to diagnose the unassigned shards, follow the next steps:
 
 7. Change the settings using the [update index settings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-settings) and [cluster update settings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-put-settings) APIs to the correct values in order to allow the index to be allocated.
 
-For more guidance on fixing the most common causes for unassinged shards follow [this guide](red-yellow-cluster-status.md#fix-red-yellow-cluster-status), see [these examples](https://www.elastic.co/docs/troubleshoot/elasticsearch/cluster-allocation-api-examples) or contact [Elastic Support](https://support.elastic.co).
+For more guidance on fixing the most common causes for unassinged shards follow [this guide](red-yellow-cluster-status.md#fix-red-yellow-cluster-status), see [these examples](https://www.elastic.co/docs/troubleshoot/elasticsearch/cluster-allocation-api-examples), or contact [Elastic Support](https://support.elastic.co).
 ::::::
 
 ::::::{tab-item} Self-managed


### PR DESCRIPTION
👋 howdy, team! Just cross-links [Diagnose unassigned shards](https://www.elastic.co/docs/troubleshoot/elasticsearch/diagnose-unassigned-shards) to [Using the cluster allocation API for troubleshooting](https://www.elastic.co/docs/troubleshoot/elasticsearch/cluster-allocation-api-examples) right after Allocation Explain API noted. Also evens out the Cloud-vs-onPrem sentence parallels.