### PR TITLE
Update CODEOWNERS for elastic-cloud-serverless

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@
 /release-notes/                             @elastic/docs
 
 /release-notes/apm-agents/                  @elastic/ingest-docs
-/release-notes/elastic-cloud-serverless/    @elastic/admin-docs
+/release-notes/elastic-cloud-serverless/    @elastic/docs
 /release-notes/elastic-observability/       @elastic/ski-docs
 /release-notes/elastic-security/            @elastic/ski-docs
 /release-notes/elasticsearch-clients/       @elastic/developer-docs


### PR DESCRIPTION
Since Admin Docs doesn't own the Serverless changelog, updates the codeowners to all of Docs.