### PR TITLE
Adds an xlink to the toc that points to reconciled page

### DIFF
--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -601,7 +601,8 @@ toc:
               - file: users-roles/cluster-or-deployment-auth/manage-authentication-for-multiple-clusters.md
           - file: users-roles/cluster-or-deployment-auth/user-roles.md
             children:
-              - file: users-roles/cluster-or-deployment-auth/built-in-roles.md
+              - title: "Roles"
+                crosslink: elasticsearch://reference/elasticsearch/roles.md
               - file: users-roles/cluster-or-deployment-auth/defining-roles.md
                 children:
                   - file: users-roles/cluster-or-deployment-auth/role-structure.md


### PR DESCRIPTION
As part of replacing the Elasticsearch [Built-in roles page in the Deploy and manage section](https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles) with its [counterpart in the Reference section](https://www.elastic.co/docs/reference/elasticsearch/roles) this PR will retire the existing page in the Deploy and manage section and instead link to the correct, deduplicated page in the 
Reference section
Relates #2218