### PR TITLE
add regions shortlist for cloud connected autoops

### DIFF
--- a/deploy-manage/monitor/_snippets/autoops-cc-regions.md
+++ b/deploy-manage/monitor/_snippets/autoops-cc-regions.md
@@ -1,0 +1,7 @@
+Choose from the following AWS regions:
+
+| Region | Name |
+| --- | --- | 
+| us-east-2 | Ohio |
+| eu-west-1 | Ireland |
+| ap-northeast-1 | Tokyo |

--- a/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md
+++ b/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md
@@ -61,7 +61,10 @@ $$$elastic-ip-address$$$ **Do I have to define an Elastic IP address to enable t
 
 ## Questions about collected metrics
 $$$autoops-metrics$$$ **Where are AutoOps metrics stored, and does it cost extra to ship metrics data to {{ecloud}}?**
-:   You can choose the CSP and region in which your cluster metrics will be stored from a list of [available regions](/deploy-manage/monitor/autoops/ec-autoops-regions.md). 
+:   You can choose the CSP and region in which your cluster metrics will be stored.
+
+    :::{include} _snippets/autoops-cc-regions.md
+    :::
 
     Shipping metrics to {{ecloud}} may come at an additional cost. For example, when sending metrics data from your cluster in a CSP region to {{ecloud}}, shipping costs will be determined by your agreement with that CSP.
 

--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -205,6 +205,9 @@ If you manually assign privileges, you won't be able to allow {{agent}} to acces
 :::::
 * **System architecture**: Select the system architecture of the machine running the agent.
 * **Metrics storage location**: Select where to store your metrics data from the list of available cloud service providers and regions.
+  
+  :::{include} _snippets/autoops-cc-regions.md
+  :::
 
 ### Install agent
 


### PR DESCRIPTION
Added shortlist for regions that can be used by cloud connected autoops

later, we can incorporate/merge this list into the [main autoops regions list](https://www.elastic.co/docs/deploy-manage/monitor/autoops/ec-autoops-regions)

<img width="689" height="354" alt="image" src="https://github.com/user-attachments/assets/b6803bd7-4688-47b6-be33-9777225ddf02" />

<img width="685" height="251" alt="image" src="https://github.com/user-attachments/assets/5459c5db-a223-47b8-8c10-c7424e891458" />
