### PR TITLE
Add project creation to Elasticsearch Getting Started

### DIFF
--- a/deploy-manage/deploy/_snippets/create-serverless-project-intro.md
+++ b/deploy-manage/deploy/_snippets/create-serverless-project-intro.md
@@ -1,4 +1,4 @@
 There are two options to create serverless projects:
 
 * If you are a new user, [sign up for a free 14-day trial](https://cloud.elastic.co/serverless-registration) to create a serverless project. For more information about the {{ecloud}} trials, check [Trial features](/deploy-manage/deploy/elastic-cloud/create-an-organization.md#general-sign-up-trial-what-is-included-in-my-trial).
-* If you are an existing customer, [log in to {{ecloud}}](https://cloud.elastic.co/login). On the home page, you will see a new option to create serverless projects.
+* If you are an existing customer, [log in to {{ecloud}}](https://cloud.elastic.co/login). On the home page, you will see a new option to create serverless projects. The **Admin** role or an equivalent custom role is required to create projects. Refer to [](/deploy-manage/users-roles/cloud-organization/user-roles.md).

--- a/deploy-manage/deploy/_snippets/create-serverless-project-intro.md
+++ b/deploy-manage/deploy/_snippets/create-serverless-project-intro.md
@@ -1,4 +1,4 @@
 There are two options to create serverless projects:
 
 * If you are a new user, [sign up for a free 14-day trial](https://cloud.elastic.co/serverless-registration) to create a serverless project. For more information about the {{ecloud}} trials, check [Trial features](/deploy-manage/deploy/elastic-cloud/create-an-organization.md#general-sign-up-trial-what-is-included-in-my-trial).
-* If you are an existing customer, [log in to {{ecloud}}](https://cloud.elastic.co/login). On the home page, you will see a new option to create serverless projects. The **Admin** role or an equivalent custom role is required to create projects. Refer to [](/deploy-manage/users-roles/cloud-organization/user-roles.md).
+* If you are an existing customer, [log in to {{ecloud}}](https://cloud.elastic.co/login). On the home page, you will see a new option to create serverless projects. The `admin` predefined role or an equivalent custom role is required to create projects. Refer to [](/deploy-manage/users-roles/cloud-organization/user-roles.md).

--- a/deploy-manage/deploy/_snippets/create-serverless-project-intro.md
+++ b/deploy-manage/deploy/_snippets/create-serverless-project-intro.md
@@ -1,0 +1,4 @@
+There are two options to create serverless projects:
+
+* If you are a new user, [sign up for a free 14-day trial](https://cloud.elastic.co/serverless-registration) to create a serverless project. For more information about the {{ecloud}} trials, check [Trial features](/deploy-manage/deploy/elastic-cloud/create-an-organization.md#general-sign-up-trial-what-is-included-in-my-trial).
+* If you are an existing customer, [log in to {{ecloud}}](https://cloud.elastic.co/login). On the home page, you will see a new option to create serverless projects.

--- a/deploy-manage/deploy/elastic-cloud/create-serverless-project.md
+++ b/deploy-manage/deploy/elastic-cloud/create-serverless-project.md
@@ -9,10 +9,8 @@ products:
 
 # Create a serverless project [serverless-get-started]
 
-There are two options to create serverless projects:
-
-* If you are a new user, [sign up for a free 14-day trial](https://cloud.elastic.co/serverless-registration) to create a serverless project. For more information about the {{ecloud}} trials, check [Trial features](create-an-organization.md#general-sign-up-trial-what-is-included-in-my-trial).
-* If you are an existing customer, [log in to {{ecloud}}](https://cloud.elastic.co/login). On the home page, you will see a new option to create serverless projects.
+:::{include} /deploy-manage/deploy/_snippets/create-serverless-project-intro.md
+:::
 
 Choose the type of project that matches your needs and we’ll help you get started with our solution guides.
 

--- a/deploy-manage/deploy/elastic-cloud/create-serverless-project.md
+++ b/deploy-manage/deploy/elastic-cloud/create-serverless-project.md
@@ -17,7 +17,7 @@ Choose the type of project that matches your needs and we’ll help you get star
 |     |     |
 | --- | --- |
 |  |  |
-| ![elasticsearch](../../images/64x64_Color_elasticsearch-logo-color-64px.png "elasticsearch =50%") | **Elasticsearch**<br> Build custom search applications with {{es}}.<br><br>[**View guide →**](/solutions/search/serverless-elasticsearch-get-started.md)<br> |
+| ![elasticsearch](../../images/64x64_Color_elasticsearch-logo-color-64px.png "elasticsearch =50%") | **Elasticsearch**<br> Build custom search applications with {{es}}.<br><br>[**View guide →**](/solutions/search/get-started.md)<br> |
 | ![observability](../../images/64x64_Color_observability-logo-color-64px.png "observability =50%") | **Observability**<br> Monitor applications and systems with Elastic Observability.<br><br>[**View guide →**](/solutions/observability/get-started.md)<br> |
 | ![security](../../images/64x64_Color_security-logo-color-64px.png "security =50%") | **Security**<br> Detect, investigate, and respond to threats with Elastic Security.<br><br>[**View guide →**](/solutions/security/get-started/create-security-project.md)<br> |
 |  |  |

--- a/deploy-manage/deploy/elastic-cloud/serverless.md
+++ b/deploy-manage/deploy/elastic-cloud/serverless.md
@@ -27,7 +27,7 @@ There are differences between {{es-serverless}} and {{ech}}, for a list of diffe
 
 Elastic provides three serverless solutions available on {{ecloud}}. Follow these guides to get started with your serverless project:
 
-* **[{{es-serverless}}](../../../solutions/search/serverless-elasticsearch-get-started.md)**: Build powerful applications and search experiences using a rich ecosystem of vector search capabilities, APIs, and libraries.
+* **[{{es-serverless}}](/solutions/search/get-started.md)**: Build powerful applications and search experiences using a rich ecosystem of vector search capabilities, APIs, and libraries.
 * **[{{obs-serverless}}](../../../solutions/observability/get-started.md)**: Monitor your own platforms and services using powerful machine learning and analytics tools with your logs, metrics, traces, and APM data.
 * **[{{sec-serverless}}](../../../solutions/security/get-started/create-security-project.md)**: Detect, investigate, and respond to threats with SIEM, endpoint protection, and AI-powered analytics capabilities.
 

--- a/solutions/search/get-started.md
+++ b/solutions/search/get-started.md
@@ -21,11 +21,16 @@ New to {{es}}? Start building a search experience by setting up your first deplo
 If you're looking for an introduction to the {{stack}} or the {{es}} product, go to [](/get-started/index.md) or [](/manage-data/data-store.md).
 :::
 
-:::::{stepper}
-::::{step} Choose your deployment type
+::::::{stepper}
+:::::{step} Choose your deployment type
 
 Elastic provides several self-managed and Elastic-managed options.
-For simplicity and speed, try out [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md).
+For simplicity and speed, try out [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md):
+
+::::{dropdown} Create an {{es-serverless}} project
+:::{include} /deploy-manage/deploy/_snippets/create-serverless-project-intro.md
+:::
+::::
 
 Alternatively, create a [local development installation](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md) in Docker:
 
@@ -34,17 +39,17 @@ curl -fsSL https://elastic.co/start-local | sh
 ```
 
 Check out the full list of [deployment types](/deploy-manage/deploy.md#choosing-your-deployment-type) to learn more.
-::::
+:::::
 
-::::{step} Identify your search goals
+:::::{step} Identify your search goals
 Depending on your use case, you can choose multiple [search approaches](search-approaches.md), for example full-text and semantic search.
 Each approach affects your options for storing and querying your data.
 
 If you're unsure which approaches match your goals, you can try them out with sample data. For example, [](/solutions/search/get-started/semantic-search.md).
 
 If you prefer to ingest your data first and transform or reindex it as needed later, skip to the next step.
-::::
-::::{{step}} Ingest your data
+:::::
+:::::{{step}} Ingest your data
 
 If your goals include vector or semantic AI-powered search, create vectorized data with built-in and third-party natural language processing (NLP) models and store it in an {{es}} vector database.
 The approach that requires the least configuration involves adding `semantic_text` fields when ingesting your data.
@@ -54,9 +59,9 @@ To learn about adding data for other search goals, go to [](/solutions/search/in
 For a broader overview of ingestion options, go to [](/manage-data/ingest.md).
 
 If you're not ready to add your own data, you can use [sample data](/manage-data/ingest/sample-data.md) or create small data sets when you follow the instructions in the [quickstarts](/solutions/search/get-started/quickstarts.md).
-::::
+:::::
 
-::::{{step}} Build your search queries
+:::::{{step}} Build your search queries
 
 Your next steps will be to choose a method to write queries and interact with {{es}}.
 You can pick a programming language [client](/reference/elasticsearch-clients/index.md) that matches your application and choose which [query languages](/solutions/search/querying-for-search.md) you will use to express your search logic.
@@ -64,8 +69,8 @@ Each decision builds on the previous ones, offering flexibility to mix and match
 
 Not sure where to start exploring?
 Get an introduction to [index and search basics](/solutions/search/get-started/index-basics.md) or [build your first search query with Python](/solutions/search/get-started/keyword-search-python.md).
-::::
 :::::
+::::::
 
 ## Related resources
 

--- a/solutions/search/get-started.md
+++ b/solutions/search/get-started.md
@@ -30,6 +30,11 @@ For simplicity and speed, try out [{{es-serverless}}](/solutions/search/serverle
 ::::{dropdown} Create an {{es-serverless}} project
 :::{include} /deploy-manage/deploy/_snippets/create-serverless-project-intro.md
 :::
+
+Choose the {{es}} project type and provide a name.
+You can optionally edit the project settings, such as the [region](/deploy-manage/deploy/elastic-cloud/regions.md).
+
+When your project is created, you're ready to start creating indices, adding data, and performing searches.
 ::::
 
 Alternatively, create a [local development installation](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md) in Docker:

--- a/solutions/search/get-started.md
+++ b/solutions/search/get-started.md
@@ -34,7 +34,7 @@ For simplicity and speed, try out [{{es-serverless}}](/solutions/search/serverle
 Choose the {{es}} project type and provide a name.
 You can optionally edit the project settings, such as the [region](/deploy-manage/deploy/elastic-cloud/regions.md).
 
-When your project is created, you're ready to start creating indices, adding data, and performing searches.
+When your project is created, you're ready to move on to the next step and to start creating indices, adding data, and performing searches.
 ::::
 
 Alternatively, create a [local development installation](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md) in Docker:

--- a/solutions/search/get-started/keyword-search-python.md
+++ b/solutions/search/get-started/keyword-search-python.md
@@ -24,10 +24,11 @@ To follow the steps, you must have a recent version of a Python interpreter.
 
 ::::{step} Create a project
 
-Create an [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md) general purpose project.
-To add the sample data, you must have a `developer` or `admin` predefined role or an equivalent custom role.
-To learn about role-based access control, go to [](/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md).
+:::{include} /deploy-manage/deploy/_snippets/create-serverless-project-intro.md
+:::
 
+Choose the {{es}} project type and provide a name.
+You can optionally edit the project settings, such as the [region](/deploy-manage/deploy/elastic-cloud/regions.md).
 ::::
 ::::{step} Create an index
 

--- a/solutions/search/ingest-for-search.md
+++ b/solutions/search/ingest-for-search.md
@@ -14,7 +14,6 @@ products:
 
 # Ingest for search use cases
 
-
 $$$elasticsearch-ingest-time-series-data$$$
 ::::{note}
 This page covers ingest methods specifically for search use cases. If you're working with a different use case, refer to the [ingestion overview](/manage-data/ingest.md) for more options.
@@ -32,7 +31,11 @@ If you just want to do a quick test, you can load [sample data](/manage-data/ing
 
 ## Use APIs [es-ingestion-overview-apis]
 
-You can use the [`_bulk` API](https://www.elastic.co/docs/api/doc/elasticsearch/v8/group/endpoint-document) to add data to your {{es}} indices, using any HTTP client, including the [{{es}} client libraries](/solutions/search/site-or-app/clients.md).
+You can use the [`_bulk` API]({{es-apis}}group/endpoint-document) to add data to your {{es}} indices, using any HTTP client, including the [{{es}} client libraries](/solutions/search/site-or-app/clients.md).
+
+::::{tip}
+To connect to an {{es-serverless}} project, you must [find the connection details](/solutions/search/search-connection-details.md).
+::::
 
 While the {{es}} APIs can be used for any data type, Elastic provides specialized tools that optimize ingestion for specific use cases.
 


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-content/issues/1480

This PR:

- creates a drop-down in https://www.elastic.co/docs/solutions/search/get-started to contain project creation tips, similar to https://www.elastic.co/docs/solutions/observability/get-started. To avoid getting out of sync with https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/create-serverless-project, the shared content is moved to a snippet.
- adds Information about the authority required to create projects (derived from  https://www.elastic.co/docs/solutions/observability/get-started) to the snippet
- re-uses the same snippet in the "create a project" step in one of the quickstarts
- adds a link from the search ingestion page to the "find your connection details" page
- updates links from the serverless deployment pages to target https://www.elastic.co/docs/solutions/search/get-started