### PR TITLE
Remove general references to Elasticsearch Serverless profiles

### DIFF
--- a/solutions/search/get-started/keyword-search-python.md
+++ b/solutions/search/get-started/keyword-search-python.md
@@ -24,7 +24,7 @@ To follow the steps, you must have a recent version of a Python interpreter.
 
 ::::{step} Create a project
 
-Create an [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md) general purpose project.
+Create an [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md) project.
 To add the sample data, you must have a `developer` or `admin` predefined role or an equivalent custom role.
 To learn about role-based access control, go to [](/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md).
 

--- a/solutions/search/get-started/semantic-search.md
+++ b/solutions/search/get-started/semantic-search.md
@@ -22,7 +22,7 @@ By playing with a simple use case, you'll take the first steps toward understand
 
 ## Prerequisites
 
-- If you're using [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md), create a project with a general purpose configuration. To add the sample data, you must have a `developer` or `admin` predefined role or an equivalent custom role.
+- If you're using [{{es-serverless}}](/solutions/search/serverless-elasticsearch-get-started.md), you must have a `developer` or `admin` predefined role or an equivalent custom role to add the sample data.
 - If you're using [{{ech}}](/deploy-manage/deploy/elastic-cloud/cloud-hosted.md) or [running {{es}} locally](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md), start {{es}} and {{kib}}. To add the sample data, log in with a user that has the `superuser` built-in role.
   
 To learn about role-based access control, check out [](/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md).

--- a/solutions/search/serverless-elasticsearch-get-started.md
+++ b/solutions/search/serverless-elasticsearch-get-started.md
@@ -44,15 +44,10 @@ On this page, you will learn how to:
 Use your {{ecloud}} account to create a fully-managed {{es}} project:
 
 1. Navigate to [cloud.elastic.co](https://cloud.elastic.co?page=docs&placement=docs-body) and create a new account or log in to your existing account.
-2. Within **Serverless Projects**, choose **Create project**.
-3. Choose the {{es}} project type.
-4. Select a **configuration** for your project, based on your use case.
-
-    * **General purpose**: For general search use cases across various data types.
-    * **Optimized for Vectors**: For search use cases using vectors and near real-time retrieval.
-
-5. Provide a name for the project and optionally edit the project settings, such as the cloud platform [region](../../deploy-manage/deploy/elastic-cloud/regions.md). Select **Create project** to continue.
-6. Once the project is ready, select **Continue**.
+1. Within **Serverless Projects**, choose **Create project**.
+1. Choose the {{es}} project type.
+1. Provide a name for the project and optionally edit the project settings, such as the cloud platform [region](../../deploy-manage/deploy/elastic-cloud/regions.md). Select **Create project** to continue.
+1. Once the project is ready, select **Continue**.
 
 ::::{tip}
 Learn how billing works for your project in [Elasticsearch billing dimensions](../../deploy-manage/cloud-organization/billing/elasticsearch-billing-dimensions.md).

--- a/solutions/search/vector/bring-own-vectors.md
+++ b/solutions/search/vector/bring-own-vectors.md
@@ -18,7 +18,7 @@ In this introduction to [vector search](/solutions/search/vector.md), you’ll s
 
 ## Prerequisites for vector search
 
-- If you're using {{es-serverless}}, create a project with the general purpose configuration. To add the sample data, you must have a `developer` or `admin` predefined role or an equivalent custom role.
+- If you're using {{es-serverless}}, you must have a `developer` or `admin` predefined role or an equivalent custom role to add the sample data.
 - If you're using {{ech}} or a self-managed cluster, start {{es}} and {{kib}}. The simplest method to complete the steps in this guide is to log in with a user that has the `superuser` built-in role.
   
 To learn about role-based access control, check out [](/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md).


### PR DESCRIPTION
Relates to https://github.com/elastic/cloud/issues/146427

This PR removes mention of the Elasticsearch Serverless configuration profiles from the getting started content.