### PR TITLE
[Ingest] Update title for data ingestion documentation

### DIFF
--- a/manage-data/ingest.md
+++ b/manage-data/ingest.md
@@ -16,7 +16,7 @@ products:
   - id: elasticsearch
 ---
 
-# Bring your data to Elastic
+# Ingest: Bring your data to Elastic
 
 Whether you call it *adding*, *indexing*, or *ingesting* data, you have to get the data into {{es}} before you can search it, visualize it, and use it for insights.
 


### PR DESCRIPTION
Update title to enhance reader scanability and improve SEO.

### Scanability
Leadership recently said, "To truly keep a modern enterprise secure, you need to **_ingest_**, **_retain_** and **_analyze_** all data." [emphasis mine]. "Ingest" is a word that users are likely to scan the TOC for as part of a normal workflow, so let's make it easy for them to find. 

#### SEO rankings
Search terms in headings get higher relevance rankings. By removing "ingest" or "ingestion" from the heading, we're missing an opportunity for better rankings. 