### PR TITLE
Add code callout, referring to steps

### DIFF
--- a/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md
+++ b/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md
@@ -105,8 +105,8 @@ exporters:
       Authorization: ApiKey <your-api-key> <2>
 ```
 
-1. See [Step 2](#locate-your-motlp)
-2. See [Step 3](#create-an-api-key)
+1. The endpoint retrieved at [step 2](#locate-your-motlp)
+2. The API key created at [step 3](#create-an-api-key)
 
 Set the API key as an environment variable or directly in the configuration as shown in the example.
 :::
@@ -119,8 +119,8 @@ export OTEL_EXPORTER_OTLP_ENDPOINT="https://<motlp-endpoint>" <1>
 export OTEL_EXPORTER_OTLP_HEADERS="Authorization=ApiKey <your-api-key>" <2>
 ```
 
-1. See [Step 2](#locate-your-motlp)
-2. See [Step 3](#create-an-api-key)
+1. The endpoint retrieved at [step 2](#locate-your-motlp)
+2. The API key created at [step 3](#create-an-api-key)
 
 Avoid extra spaces in the header. For Python SDKs replace any spaces with `%20`. For example:
 
@@ -152,8 +152,8 @@ exporters:
       Authorization: ${API_KEY} <2>
 ```
 
-1. See [Step 2](#locate-your-motlp)
-2. See [Step 3](#create-an-api-key)
+1. The endpoint retrieved at [step 2](#locate-your-motlp)
+2. The API key created at [step 3](#create-an-api-key)
 
 And in your deployment spec:
 


### PR DESCRIPTION
This makes it easier to find how the endpoint is located or the API key is created when the user quickly scans the page and only looks at the code snippets.