### PR TITLE
[Internal][Observability][UX Management][9.1 & Serverless]: Document related alerts, related dashboards, and investigation guides

### DIFF
--- a/solutions/observability/incident-management/create-manage-rules.md
+++ b/solutions/observability/incident-management/create-manage-rules.md
@@ -68,7 +68,7 @@ From the action menu you can also:
 Incident management resources can help you respond to alerts more efficiently and consistently. You can add these resources to a rule that you are creating or managing. When an alert is generated from that rule, the resources that you added can be accessed from the [alert's details page](/solutions/observability/incident-management/view-alerts.md#observability-view-alerts-view-alert-details). Here are some resources you can add to a rule: 
 
 * **Investigation guide**: An investigation guide provides step-by-step instructions and links to external resources for investigating and responding to alerts. On the alert's details page, you can access the guide from the **Investigation guide** tab.
-* **Related and suggested dashboards**: (Only available for custom threshold rules) Dashboards can provide additional context and information about the alert. You can access them from the **Dashboards** tab on the alert's details page. Related dashboards are linked to the rule that generated the alert. Suggested dashboards are comprised of other dashboards that use lens visualizations that:
+* **Related and suggested dashboards**: (Only available for custom threshold rules) Dashboards can provide additional context and information about the alert. You can access them from the **Related dashboards** tab on the alert's details page. Related dashboards are linked to the rule that generated the alert. Suggested dashboards are comprised of other dashboards that use lens visualizations that:
 
    * Query the same data view
    * Use some of the same fields that are specified in the rule's configuration or are present in alert's genereated by the rule. 

--- a/solutions/observability/incident-management/create-manage-rules.md
+++ b/solutions/observability/incident-management/create-manage-rules.md
@@ -67,8 +67,8 @@ From the action menu you can also:
 
 Incident management resources can help you respond to alerts more efficiently and consistently. You can add these resources to a rule that you are creating or managing. When an alert is generated from that rule, the resources that you added can be accessed from the [alert's details page](/solutions/observability/incident-management/view-alerts.md#observability-view-alerts-view-alert-details). Here are some resources you can add to a rule: 
 
-* **Investigation guide**: An investigation guide provides step-by-step instructions and links to external resources for investigating and responding to alerts. On the alert's details page, you can access the guide from the **Investigation guide** tab.
-* **Related and suggested dashboards**: (Only available for custom threshold rules) Dashboards can provide additional context and information about the alert. You can access them from the **Related dashboards** tab on the alert's details page. Related dashboards are linked to the rule that generated the alert. Suggested dashboards are comprised of other dashboards that use lens visualizations that:
+* {applies_to}`stack: ga 9.1` **Investigation guide**: An investigation guide provides step-by-step instructions and links to external resources for investigating and responding to alerts. On the alert's details page, you can access the guide from the **Investigation guide** tab.
+*  {applies_to}`stack: ga 9.1` **Related and suggested dashboards**: (Only available for custom threshold rules) Dashboards can provide additional context and information about the alert. You can access them from the **Related dashboards** tab on the alert's details page. Related dashboards are linked to the rule that generated the alert. Suggested dashboards are comprised of other dashboards that use lens visualizations that:
 
    * Query the same data view
    * Use some of the same fields that are specified in the rule's configuration or are present in alert's genereated by the rule. 

--- a/solutions/observability/incident-management/create-manage-rules.md
+++ b/solutions/observability/incident-management/create-manage-rules.md
@@ -63,6 +63,16 @@ From the action menu you can also:
 * Run rule (without waiting for next scheduled check)
 * Update API keys
 
+## Add incident management and response resources to rules [observability-create-manage-rules-incident-management]
+
+Incident management resources can help you respond to alerts more efficiently and consistently. You can add these resources to a rule that you are creating or managing. When an alert is generated from that rule, the resources that you added can be accessed from the [alert's details page](/solutions/observability/incident-management/view-alerts.md#observability-view-alerts-view-alert-details). Here are some resources you can add to a rule: 
+
+* **Investigation guide**: An investigation guide provides step-by-step instructions and links to external resources for investigating and responding to alerts. On the alert's details page, you can access the guide from the **Investigation guide** tab.
+* **Related and suggested dashboards**: (Only available for custom threshold rules) Dashboards can provide additional context and information about the alert. You can access them from the **Dashboards** tab on the alert's details page. Related dashboards are linked to the rule that generated the alert. Suggested dashboards are comprised of other dashboards that use lens visualizations that:
+
+   * Query the same data view
+   * Use some of the same fields that are specified in the rule's configuration or are present in alert's genereated by the rule. 
+
 
 ## View rule details [observability-create-manage-rules-view-rule-details]
 

--- a/solutions/observability/incident-management/view-alerts.md
+++ b/solutions/observability/incident-management/view-alerts.md
@@ -64,6 +64,12 @@ To view the alert in the app that triggered it:
 * From the alert detail flyout, click **View in app**.
 * From the **Alerts** table, click the {icon}`eye` icon.
 
+## Find related alerts [observability-view-alerts-find-related-alerts]
+
+Related alerts can help you to identify patterns and recurring events that might warrant investigation. When examining an alert's details, you can find related alerts by selecting the **Related alerts** tab. 
+
+Relevance to the current alert is based on how closely other alerts match it. Certain attributes are evaluated for matching, such as groups, tags, associated rules, and the time of which an alert was created. Alerts with more matching attributes are determined as more relevant and placed higher on the list of related alerts. To find related alerts that were created around the same time, apply the **Triggered around the same time** filter.
+
 ## Understand alert statuses [observability-view-alerts-understand-statuses]
 
 There are four common alert statuses:

--- a/solutions/observability/incident-management/view-alerts.md
+++ b/solutions/observability/incident-management/view-alerts.md
@@ -66,6 +66,10 @@ To view the alert in the app that triggered it:
 
 ## Find related alerts [observability-view-alerts-find-related-alerts]
 
+```{applies_to}
+stack: ga 9.1 
+```
+
 Related alerts can help you to identify patterns and recurring events that might warrant investigation. When examining an alert's details, you can find related alerts by selecting the **Related alerts** tab. 
 
 Relevance to the current alert is based on how closely other alerts match it. Certain attributes are evaluated for matching, such as groups, tags, associated rules, and the time of which an alert was created. Alerts with more matching attributes are determined as more relevant and placed higher on the list of related alerts. To find related alerts that were created around the same time, apply the **Triggered around the same time** filter.


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/2721 by adding docs for the new **Related alerts** tab, **Investigation guides** tab, and **Related dashboards** tab. 

Corresponding 8.19 PR: https://github.com/elastic/observability-docs/pull/4955

Preview: 