### PR TITLE
[Security] Adds link to support matrix from Defend requirements page

### DIFF
--- a/solutions/security/configure-elastic-defend/elastic-defend-requirements.md
+++ b/solutions/security/configure-elastic-defend/elastic-defend-requirements.md
@@ -15,6 +15,8 @@ products:
 
 To properly deploy {{elastic-defend}} without a Mobile Device Management (MDM) profile, you must manually enable additional permissions on the host before {{elastic-endpoint}}—the installed component that performs {{elastic-defend}}'s threat monitoring and prevention—is fully functional. For more information, refer to [](enable-access-for-macos.md).
 
+For information about supported operating systems, refer to the [Elastic Support Matrix](https://www.elastic.co/support/matrix#elastic-defend).
+
 
 ## Minimum system requirements [_minimum_system_requirements]
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1618. 

Preview: [Elastic Defend requirements](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2895/solutions/security/configure-elastic-defend/elastic-defend-requirements)

8.x PR: https://github.com/elastic/security-docs/pull/7060