### PR TITLE
Super small changes to apply/policy pages

### DIFF
--- a/manage-data/lifecycle/index-lifecycle-management/policy-apply.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-apply.md
@@ -8,20 +8,21 @@ products:
 
 # Manually apply a lifecycle policy to an index [apply-policy-manually]
 
-When you create a new {{es}} index, it automatically picks up settings, mappings, and aliases from any matching [index template](/manage-data/data-store/templates.md#index-templates) and its component templates. If the template specifies a lifecycle policy, that policy is applied to the new index as soon as it's created. This process is described in detail in [Configure a lifecycle policy](/manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md).
+When you create a new {{es}} index, it automatically picks up settings, mappings, and aliases from any matching [index template](/manage-data/data-store/templates.md#index-templates) and its component templates. If the template specifies a lifecycle policy, that policy is applied to the new index as soon as it's created so that the index will be managed by {{ilm-init}}. This process is described in detail in [Configure a lifecycle policy](/manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md).
 
-You can also apply a lifecycle policy manually to existing indices, as described on this page. This is useful if you want to:
+You can also apply a lifecycle policy manually to existing indices that are not yet managed, as described on this page. This is useful if you want to:
  * Configure the indices to move through different [data tiers](/manage-data/lifecycle/data-tiers.md) as they age.
  * Perform [lifecycle actions](elasticsearch://reference/elasticsearch/index-lifecycle-actions/index.md) such as downsampling or shrinking.
  * Delete the indices when they reach a certain age.
 
-If an index is currently managed by an ILM policy you must first remove that policy before applying a new one. Refer to [Switch to a different lifecycle policy](/manage-data/lifecycle/index-lifecycle-management/policy-updates.md#switch-lifecycle-policies) for details.
+:::{warning}
+Consider the following before manually applying a policy to an index:
+
+* If an index is currently managed by an ILM policy you must first remove that policy before applying a new one. To remove or make changes to an {{ilm-init}} policy currently applied to one or more indices, or to switch indices to use a different policy, refer to [Update or switch a lifecycle policy](/manage-data/lifecycle/index-lifecycle-management/policy-updates.md).
+* Do not manually apply a policy that uses the rollover action. Policies that use rollover must be applied by the [index template](/manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md#apply-policy-template). Otherwise, the policy is not carried forward when the rollover action creates a new index.
+:::
 
 You can do this procedure in {{kib}} or using the {{es}} API.
-
-::::{warning}
-Do not manually apply a policy that uses the rollover action. Policies that use rollover must be applied by the [index template](/manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md#apply-policy-template). Otherwise, the policy is not carried forward when the rollover action creates a new index.
-::::
 
 ::::{tab-set}
 :group: kibana-api

--- a/manage-data/lifecycle/index-lifecycle-management/policy-updates.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-updates.md
@@ -10,13 +10,13 @@ products:
 
 # Update or switch a lifecycle policy
 
-
 You can change how the lifecycle of an index or collection of rolling indices is managed by modifying the current policy or switching to a different policy.
 
 To ensure that policy updates don’t put an index into a state where it can’t exit the current phase, the phase definition is cached in the index metadata when it enters the phase. If changes can be safely applied, {{ilm-init}} updates the cached phase definition. If they cannot, phase execution continues using the cached definition.
 
 When the index advances to the next phase, it uses the phase definition from the updated policy.
 
+If you'd like to configure an index not currently managed by {{ilm-init}} to be governed by an lifecycle policy, refer to [Manually apply a policy to an index](/manage-data/lifecycle/index-lifecycle-management/policy-apply.md).
 
 ## How changes are applied [ilm-apply-changes]
 

--- a/manage-data/lifecycle/index-lifecycle-management/policy-updates.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-updates.md
@@ -1,5 +1,4 @@
 ---
-navigation_title: Update or switch a policy
 mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/update-lifecycle-policy.html
 applies_to:

--- a/manage-data/lifecycle/index-lifecycle-management/policy-updates.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-updates.md
@@ -15,7 +15,7 @@ To ensure that policy updates don’t put an index into a state where it can’t
 
 When the index advances to the next phase, it uses the phase definition from the updated policy.
 
-If you'd like to configure an index not currently managed by {{ilm-init}} to be governed by an lifecycle policy, refer to [Manually apply a policy to an index](/manage-data/lifecycle/index-lifecycle-management/policy-apply.md).
+To configure an index not currently managed by {{ilm-init}} to be governed by an lifecycle policy, refer to [Manually apply a policy to an index](/manage-data/lifecycle/index-lifecycle-management/policy-apply.md).
 
 ## How changes are applied [ilm-apply-changes]
 


### PR DESCRIPTION
Edu noted that these two pages seem a bit similar, so I'm adding a sentence or two to each to help clarify the scope. Also, the title change is just for better consistency in the navigation pane.

Preview:
 - [Manually apply a lifecycle policy to an index](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2923/manage-data/lifecycle/index-lifecycle-management/policy-apply)
 - [Update or switch a lifecycle policy](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/2923/manage-data/lifecycle/index-lifecycle-management/policy-updates)

Rel: https://github.com/elastic/docs-content-internal/issues/190

