### PR TITLE
Document unsupported third-party collectors for ECS

### DIFF
--- a/solutions/security/get-started/elastic-security-requirements.md
+++ b/solutions/security/get-started/elastic-security-requirements.md
@@ -80,7 +80,7 @@ The [Elastic Common Schema (ECS)](ecs://reference/index.md) defines a common set
 
 ## Third-party collectors NOT mapped to ECS [security-requirements-overview-third-party-collectors-not-mapped-to-ecs]
 
-The use of third-party connectors that do not map data to ECS, including third-party and open source OTel collectors, is not supported by {{elastic-sec}}.
+{{elastic-sec}} does not support the use of third-party connectors that do not map data to ECS, including third-party and open source OTel collectors.
 
 ## Cross-cluster searches [security-cross-cluster-searches]
 


### PR DESCRIPTION
Added a section on unsupported third-party collectors not mapped to ECS.

Closes: https://github.com/elastic/docs-content/issues/2934