### PR TITLE
Removes agentless integration deployment beta list

### DIFF
--- a/solutions/security/get-started/agentless-integrations.md
+++ b/solutions/security/get-started/agentless-integrations.md
@@ -31,26 +31,7 @@ To learn more about agentless CSPM deployments, refer to the getting started gui
 ## Beta agentless integrations
 
 ::::{warning}
-Agentless deployment for the following integrations is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+Agentless deployment for other following integrations is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
 ::::
 
-1. AbuseCH
-2. Cloud Asset Discovery
-3. CrowdStrike  
-4. Elastic Security
-5. Google SecOps 
-6. Google Security Command Center
-7. Google Workspace
-8. Microsoft 365 Defender
-9. Microsoft Defender for Endpoint
-10. Microsoft Sentinel
-11. Okta
-12. Qualys VMDR
-13. SentinelOne
-14. Splunk
-15. Tenable IO
-16. Wiz
-17. Zscaler ZIA
-
-
-To learn more about these integrations and find setup guides, refer to [Elastic integrations](https://docs.elastic.co/en/integrations/).
+For setup guides and to learn more about Elastic's integrations, including whether each one supports agentless deployment, refer to [Elastic integrations](https://docs.elastic.co/en/integrations/).


### PR DESCRIPTION
Fixes #2995 by removing the list of beta agentless integrations and making some related updates. This list had become outdated, and agentless deployment for integrations will be GA in 9.2 anyway. This page will be further updated when 9.2 is released, including highlighting the ability to filter for integrations that support agentless deployment, and clarifying that agentless deployment is GA.