### PR TITLE
Updates to 'Migrate to ILM on self/ECK'

### DIFF
--- a/manage-data/lifecycle/index-lifecycle-management/manage-existing-indices.md
+++ b/manage-data/lifecycle/index-lifecycle-management/manage-existing-indices.md
@@ -12,22 +12,23 @@ products:
 
 # Migrate to {{ilm-init}} on self-managed and {{eck}} deployments [ilm-with-existing-indices]
 
-If you’ve been using Curator or some other mechanism to manage periodic indices, you have a couple of options when [migrating to {{ilm-init}}](./migrate-index-management.md):
+If you’ve been using [](/manage-data/lifecycle/curator.md) or some other mechanism to manage periodic indices, you have a couple of options when [migrating to {{ilm-init}}](./migrate-index-management.md):
 
 * Set up your index templates to use an {{ilm-init}} policy to manage your new indices. Once {{ilm-init}} is managing your current write index, you can apply an appropriate policy to your old indices.
 * Reindex into an {{ilm-init}}-managed index.
 
 ::::{note}
-Starting in Curator version 5.7, Curator ignores {{ilm-init}}-managed indices.
+* Starting in Curator version 5.7, Curator ignores {{ilm-init}}-managed indices.
+* This document is specifically about setting up {{ilm-init}} for managed indices. To manage the lifecycle of a [data stream](/manage-data/data-store/data-streams.md) you can opt to use either {{ilm-init}} or data stream lifecycle. Refer to [](/manage-data/lifecycle.md) for a comparison.
 ::::
 
 
 
 ## Apply policies to existing time series indices [ilm-existing-indices-apply]
 
-The simplest way to transition to managing your periodic indices with {{ilm-init}} is to [configure an index template](configure-lifecycle-policy.md#apply-policy-template) to apply a lifecycle policy to new indices. Once the index you are writing to is being managed by {{ilm-init}}, you can [manually apply a policy](/manage-data/lifecycle/index-lifecycle-management/policy-updates.md) to your older indices.
+The simplest way to transition to managing your periodic indices with {{ilm-init}} is to [configure an index template](configure-lifecycle-policy.md#apply-policy-template) to apply a lifecycle policy to new indices. You can check these [example {{ilm-init}} polices](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-rollover.md#ilm-rollover-ex) that initiate index rollover based on different criteria.
 
-Define a separate policy for your older indices that omits the rollover action. Rollover is used to manage where new data goes, so isn’t applicable.
+Once the index you are writing to is being managed by {{ilm-init}}, you can [manually apply a policy](/manage-data/lifecycle/index-lifecycle-management/policy-apply.md) to your older indices. Define a separate policy for your older indices that omits the rollover action. Rollover is used to manage where new data goes, so isn’t applicable.
 
 Keep in mind that policies applied to existing indices compare the `min_age` for each phase to the original creation date of the index, and might proceed through multiple phases immediately. If your policy performs resource-intensive operations like force merge, you don’t want to have a lot of indices performing those operations all at once when you switch over to {{ilm-init}}.
 

--- a/manage-data/lifecycle/index-lifecycle-management/policy-apply.md
+++ b/manage-data/lifecycle/index-lifecycle-management/policy-apply.md
@@ -19,7 +19,7 @@ You can also apply a lifecycle policy manually to existing indices that are not 
 Consider the following before manually applying a policy to an index:
 
 * If an index is currently managed by an ILM policy you must first remove that policy before applying a new one. To remove or make changes to an {{ilm-init}} policy currently applied to one or more indices, or to switch indices to use a different policy, refer to [Update or switch a lifecycle policy](/manage-data/lifecycle/index-lifecycle-management/policy-updates.md).
-* Do not manually apply a policy that uses the rollover action. Policies that use rollover must be applied by the [index template](/manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md#apply-policy-template). Otherwise, the policy is not carried forward when the rollover action creates a new index.
+* Do not manually apply a policy that uses the rollover action. Policies that use rollover must be applied by the [index template](/manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md#apply-policy-template). Otherwise, the policy is not carried forward when the rollover action creates a new index. For an approach to migrating existing indices that supports rollover, refer to [](/manage-data/lifecycle/index-lifecycle-management/migrate-ilm.md).
 :::
 
 You can do this procedure in {{kib}} or using the {{es}} API.


### PR DESCRIPTION
This updates the recently renamed "Migrate to ILM on self-managed and Elastic Cloud on Kubernetes deployments" page, to:
 - clarify that the scope doesn't include data streams
 - link to the helpful rollover examples