### PR TITLE
Updates Automatic Import log sample information

### DIFF
--- a/solutions/security/get-started/automatic-import.md
+++ b/solutions/security/get-started/automatic-import.md
@@ -32,7 +32,7 @@ Click [here](https://elastic.navattic.com/automatic-import) to access an interac
 ::::
 
 ::::{admonition} Notes on sample data
-To use Automatic Import, you must provide a sample of the data you wish to import. An LLM will process that sample and automatically create an integration suitable for processing the data represented by the sample. **Any structured or unstructured format is acceptable, including but not limited to JSON, NDJSON, CSV, Syslog.**
+To use Automatic Import, you must provide a sample of the data you wish to import. An LLM will process that sample and automatically create an integration suitable for processing the data represented by the sample. **Automatic Import supports the following sample formats: JSON, NDJSON, CSV, and syslog (structured and unstructured).**
 
 * You can upload a sample of arbitrary size. The LLM will detect its format and select up to 100 documents for detailed analysis.
 * The more variety in your sample, the more accurate the pipeline will be. For best results, include a wide range of unique log entries in your sample instead of repeating similar logs.


### PR DESCRIPTION
Fixes #2979 by updating how we talk about the log sample formats supported by Automatic Import. [This thread](https://elastic.slack.com/archives/C075CE8JBDF/p1757948931535359) details how the current language is unclear, and has resulted in an SDH because a customer tried to use an unsupported format. 

This update uses the specific, updated language approved by the product team.