### PR TITLE
Update data-tiers.md

### DIFF
--- a/manage-data/lifecycle/data-tiers.md
+++ b/manage-data/lifecycle/data-tiers.md
@@ -494,4 +494,33 @@ This setting will not unallocate a currently allocated shard, but might prevent 
 
 ### Automatic data tier migration [data-tier-migration]
 
-{{ilm-init}} automatically transitions managed indices through the available data tiers using the [migrate](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-migrate.md) action. By default, this action is automatically injected in every phase. You can explicitly specify the migrate action with `"enabled": false` to [disable automatic migration](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-migrate.md#ilm-disable-migrate-ex), for example, if you’re using the [allocate action](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-allocate.md) to manually specify allocation rules.
+{{ilm-init}} automatically transitions managed indices through the available data tiers using the [migrate](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-migrate.md) action. By default, this action is automatically injected in every phase. 
+
+### Disable data tier allocation [data-tier-allocation]
+You can explicitly disable data allocation for  data tier migration in an ILM policy with the following setting:
+```sh
+    "migrate": {
+            "enabled": false
+          }
+```
+
+For example:
+
+```sh
+ "cold": {
+        "min_age": "15m",
+        "actions": {
+          "set_priority": {
+            "priority": 0
+          },
+          "migrate": {
+            "enabled": false
+          }
+        }
+      },
+```
+
+By defining the `migrate` action with `"enabled": false` for a data tier, this will [disable automatic ILM shard migration](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-migrate.md#ilm-disable-migrate-ex), for example, if you’re using the [allocate action](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-allocate.md) to manually specify allocation rules.          
+
+#### Important Note: 
+Do not disable automatic ILM migration without manually defining ILM allocation rules. If data migration is disabled without allocation rules defined, this can prevent data from moving to the specified data tier, although the data has successfully moved through the ILM policy with a status of `complete`.


### PR DESCRIPTION
The existing description of "automatic data tier migration" did not explicitly call out the impact of setting "migrate": {
            "enabled": false
          } without specifying manual allocation rules. The setting alone can prevent data from moving to a data tier while "succeeding" through the ILM "complete" phase.

I am also including an image that may be a useful addition contextually:
<img width="1218" height="264" alt="data-allocation-migrate" src="https://github.com/user-attachments/assets/b7f8b071-ddc6-4913-b03c-54e90425a4ff" />
