### PR TITLE
Fix grammatical error in release notes introduction

### DIFF
--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -12,7 +12,7 @@ navigation_title: Release notes
 
 Stay up to date with the latest changes, fixes, known issues, and deprecations in Elastic products. 
 
-Release notes cover the all the latest Elastic product changes, including the following:
+Release notes cover all the latest Elastic product changes, including the following:
 * {{stack}} {{version.stack.base}} and later, including the most recent {{version.stack}} release
 * {{serverless-full}}, including updates to {{es}}, and {{observability}} and {{elastic-sec}} solutions
 


### PR DESCRIPTION
Hi, I found a grammatical error in the [release notes page](https://www.elastic.co/docs/release-notes) and fixed it.

**Before**
```text
Release notes cover the all the latest ...
```

**After**: I removed `the`
```text
Release notes cover all the latest ...
```
