### PR TITLE
[E&A] Marks ELSER on EIS as GA

### DIFF
--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -7,7 +7,7 @@ applies_to:
 
 # Elastic {{infer-cap}} Service [elastic-inference-service-eis]
 
-The Elastic {{infer-cap}} Service (EIS) enables you to leverage AI-powered search as a service without deploying a model in your cluster.
+The Elastic {{infer-cap}} Service (EIS) enables you to leverage AI-powered search as a service without deploying a model in your environment.
 With EIS, you don't need to manage the infrastructure and resources required for {{ml}} {{infer}} by adding, configuring, and scaling {{ml}} nodes.
 Instead, you can use {{ml}} models for ingest, search, and chat independently of your {{es}} infrastructure.
 
@@ -15,7 +15,7 @@ Instead, you can use {{ml}} models for ingest, search, and chat independently of
 
 * Your Elastic deployment or project comes with a default [`Elastic Managed LLM` connector](https://www.elastic.co/docs/reference/kibana/connectors-kibana/elastic-managed-llm). This connector is used in the AI Assistant, Attack Discovery, Automatic Import and Search Playground.
 
-* You can use [ELSER](/explore-analyze/machine-learning/nlp/ml-nlp-elser.md) to perform semantic search as a service (ELSER on EIS). {applies_to}`stack: preview 9.1` {applies_to}`serverless: preview`
+* You can use [ELSER](/explore-analyze/machine-learning/nlp/ml-nlp-elser.md) to perform semantic search as a service (ELSER on EIS). {applies_to}`stack: preview 9.1, ga 9.2` {applies_to}`serverless: ga`
 
 ## Region and hosting [eis-regions]
 
@@ -27,25 +27,20 @@ ELSER requests are managed by Elastic's own EIS infrastructure.
 ## ELSER via Elastic {{infer-cap}} Service (ELSER on EIS) [elser-on-eis]
 
 ```{applies_to}
-stack: preview 9.1
-serverless: preview
+stack: preview 9.1, ga 9.2
+serverless: ga
 ```
 
-ELSER on EIS enables you to use the ELSER model on GPUs, without having to manage your own ML nodes. We expect better performance for throughput and latency than ML nodes, and will continue to benchmark, remove limitations and address concerns as we move towards General Availability.
+ELSER on EIS enables you to use the ELSER model on GPUs, without having to manage your own ML nodes. We expect better performance for throughput and latency than ML nodes, and will continue to benchmark, remove limitations and address concerns.
+
+### Pricing
+
+ELSER on EIS usage is billed separately from your other Elastic deployment resources.
+For details about request-based pricing and billing dimensions, refer to the [ELSER on GPU item on the pricing page](https://www.elastic.co/pricing/serverless-search).
 
 ### Limitations
 
-While we do encourage experimentation, we do not recommend implementing production use cases on top of this feature while it is in Technical Preview.
-
-#### Access
-
-This feature is being gradually rolled out to Serverless and Cloud Hosted customers.
-It may not be available to all users at launch.
-
-#### Uptime
-
-There are no uptime guarantees during the Technical Preview.
-While Elastic will address issues promptly, the feature may be unavailable for extended periods.
+Elastic is continuously working to remove these constraints and further improve performance and scalability.
 
 #### Throughput and latency
 
@@ -58,6 +53,6 @@ Performance may vary during the Technical Preview.
 Batches are limited to a maximum of 16 documents.
 This is particularly relevant when using the [_bulk API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-bulk) for data ingestion.
 
-#### Rate Limits 
+#### Rate Limits
 
 Rate limit for search and ingest is currently at 2000 requests per minute.


### PR DESCRIPTION
## Overview

This PR:
* amends the `applies_to` tags relevant to ELSER on EIS to mark the feature as GA
* adds a Pricing section that links to the pricing page
* removes limitations that are not relevant anymore

### Important note

**Serverless:**
After this PR is merged, the docs will state that ELSER on EIS is GA on Serverless. **Only merge once the feature is actually released as GA on Serverless.**

**Stack:**
If the PR is merged before the 9.2 release, the docs will show the GA status on the stack as Planned, without referencing a specific version. After the release, the badge will update dynamically to show the feature as GA in 9.2.