### PR TITLE
Add redirects for deduplicated roles and privileges pages

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -356,3 +356,7 @@ redirects:
 
 # Related to https://github.com/elastic/docs-content/pull/2843
   'solutions/search/serverless-elasticsearch-get-started.md': 'solutions/search/get-started.md'
+
+# Remove duplicate reference content
+  'deploy-manage/users-roles/cluster-or-deployment-auth/built-in-roles.md': 'elasticsearch://reference/elasticsearch/roles.md'
+  'deploy-manage/users-roles/cluster-or-deployment-auth/elasticsearch-privileges.md': 'elasticsearch://reference/elasticsearch/security-privileges.md'


### PR DESCRIPTION
Followup to the following PRs:

https://github.com/elastic/docs-content/pull/2989
https://github.com/elastic/docs-content/pull/2811

We forgot a redirect and so now when someone looks for these pages in google they run into a sad 404