### PR TITLE
[Private preview] Unhide Linux as an agent installation option

### DIFF
--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -92,9 +92,9 @@ Select one of the following methods to install {{agent}}:
 
 * **Kubernetes**
 * **Docker**
+* **Linux**
 <!-- Not applicable for private preview
-* Linux
-* Windows
+* **Windows**
 -->
 
 :::{important} 
@@ -220,8 +220,8 @@ The wizard will generate an installation command based on your configuration. De
 * Docker
     * Docker
     * Docker compose
-<!-- Not applicable for private preview
 * Linux
+<!-- Not applicable for private preview
 * Windows
 -->
 


### PR DESCRIPTION
Linux is now available as an installation option for Elastic agent in AutoOps for self-managed clusters. 

Closes https://github.com/elastic/docs-content/issues/3047