### PR TITLE
[Obs AI Assistant] Add Qwen ratings to the LLM performance matrix

### DIFF
--- a/solutions/observability/llm-performance-matrix.md
+++ b/solutions/observability/llm-performance-matrix.md
@@ -51,6 +51,7 @@ Models you can [deploy and manage yourself](/solutions/observability/connect-to-
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Meta | **Llama-3.3-70B-Instruct** | Excellent | Good | Great | Excellent | Excellent | Good | Good | Excellent |
 | Mistral | **Mistral-Small-3.2-24B-Instruct-2506** | Excellent | Poor | Great | Great | Excellent | Poor | Good | Excellent |
+| Alibaba Cloud | **Qwen2.5-72b-instruct** | Excellent | Good | Great | Excellent | Excellent | Good | Good | Excellent |
 
 ::::{note}
 `Llama-3.3-70B-Instruct` is supported with simulated function calling.


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-assistant-team/issues/355

This PR adds the performance scores for Qwen 2.5 72B to the LLM performance matrix.