### PR TITLE
reword to clarify when people should consider index size

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md
+++ b/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings.md
@@ -160,7 +160,7 @@ To ensure optimal performance in Serverless Elasticsearch projects, follow these
 | **General search (non data-stream)** | 300GB | General purpose |
 | **Other uses (non data-stream)** | 600GB | General purpose |
 
-For large datasets that exceed the recommended maximum size, consider splitting your data across smaller indices and using an alias to search them collectively.
+If you expect that you will have large datasets that exceed the recommended maximum size, consider creating multiple smaller indices that you can query using an [alias](/manage-data/data-store/aliases.md), or configuring [data stream lifecycle](/manage-data/lifecycle/data-stream) to prevent data streams from growing larger than the maximum size.
 
 These recommendations do not apply to indices using better binary quantization (BBQ). Refer to [vector quantization](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization) for more information.
 


### PR DESCRIPTION
- fixes https://github.com/elastic/docs-content-internal/issues/32

clarify that people should consider index size / growth when they're designing their indices, not when they're about to reach their max size.