### PR TITLE
Document SLO transform limitations related to misreported state and P…

### DIFF
--- a/explore-analyze/transforms/transform-limitations.md
+++ b/explore-analyze/transforms/transform-limitations.md
@@ -153,7 +153,7 @@ If you encounter this error, do not delete the {{transform}}. If a {{transform}}
 
 #### Large numbers of {{transform}} can cause PIT overloads [transforms-pit-overloads]
 
-{{transforms-cap}} relies on point-in-time (PIT) searches to ensure that queries remain consistent during data changes. Each {{transform}} can open and close multiple PITs during its lifetime. 
+{{transforms-cap}} rely on point-in-time (PIT) searches to ensure that queries remain consistent during data changes. Each {{transform}} can open and close multiple PITs during its lifetime. 
 
 When many {{transforms}} run concurrently, especially in environments with large numbers of SLOs (hundreds to more than a thousand transforms), PITs can be opened and closed in quick succession. Because PITs are closed asynchronously, the close operation does not wait for the previous request to complete. This can create a backlog of PIT close requests, known as a PIT overload.
 


### PR DESCRIPTION
This PR adds a new limitation to the [Transforms limitation](https://www.elastic.co/docs/explore-analyze/transforms/transform-limitations) page about the behavior of SLO transforms at scale. When many SLO transforms run concurrently, two issues can occur:

- Transforms may misreport their state and suggest deletion, even though they remain valid.
- PIT requests may accumulate and create excess activity on the cluster, leading to degraded performance.

The new section explains these limitations.