### PR TITLE
[SEARCH] Adds EIS scenario to semantic search tutorial

### DIFF
--- a/solutions/search/semantic-search/semantic-search-semantic-text.md
+++ b/solutions/search/semantic-search/semantic-search-semantic-text.md
@@ -27,7 +27,14 @@ This tutorial uses the `elasticsearch` service for demonstration, which is creat
 
 The mapping of the destination index - the index that contains the embeddings that the inference endpoint will generate based on your input text - must be created. The destination index must have a field with the [`semantic_text`](elasticsearch://reference/elasticsearch/mapping-reference/semantic-text.md) field type to index the output of the used inference endpoint.
 
-```console
+::::{tab-set}
+
+:::{tab-item} Using EIS on Serverless
+
+```{applies_to}
+serverless: ga
+```
+
 PUT semantic-embeddings
 {
   "mappings": {
@@ -38,17 +45,64 @@ PUT semantic-embeddings
     }
   }
 }
+:::
+
+1. The name of the field to contain the generated embeddings.
+2. The field to contain the embeddings is a `semantic_text` field. Since no `inference_id` is provided, the default endpoint `.elser-2-elastic` for the `elasticsearch` service is used. This {{infer}} endpoint uses the [Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md).
+
+:::{tab-item} Using EIS in Cloud
+
+```{applies_to}
+stack: ga
+deployment:
+  self: unavailable
+```
+
+PUT semantic-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content": { <1>
+        "type": "semantic_text", <2>
+        "inference_id": ".elser-2-elastic" <3>
+      }
+    }
+  }
+}
+:::
+
+1. The name of the field to contain the generated embeddings.
+2. The field to contain the embeddings is a `semantic_text` field.
+3. The `.elser-2-elastic` preconfigured {{infer}} endpoint for the `elasticsearch` service is used. This {{infer}} endpoint uses the [Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md).
+
+:::{tab-item} Using ML-nodes
+
+```console
+PUT semantic-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content": { <1>
+        "type": "semantic_text", <2>
+        "inference_id": ".elser-2-elasticsearch" <3>
+      }
+    }
+  }
+}
 ```
 
 1. The name of the field to contain the generated embeddings.
-2. The field to contain the embeddings is a `semantic_text` field. Since no `inference_id` is provided, the default endpoint `.elser-2-elasticsearch` for the `elasticsearch` service is used. To use a different {{infer}} service, you must create an {{infer}} endpoint first using the [Create {{infer}} API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) and then specify it in the `semantic_text` field mapping using the `inference_id` parameter.
+2. The field to contain the embeddings is a `semantic_text` field.
+3. The `.elser-2-elasticsearch` preconfigured {{infer}} endpoint for the `elasticsearch` service is used. To use a different {{infer}} service, you must create an {{infer}} endpoint first using the [Create {{infer}} API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-put) and then specify it in the `semantic_text` field mapping using the `inference_id` parameter.
+
+:::
+
+::::
 
 ::::{note}
 If you’re using web crawlers or connectors to generate indices, you have to [update the index mappings](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-mapping) for these indices to include the `semantic_text` field. Once the mapping is updated, you’ll need to run a full web crawl or a full connector sync. This ensures that all existing documents are reprocessed and updated with the new semantic embeddings, enabling semantic search on the updated data.
 
 ::::
-
-
 
 ## Load data [semantic-text-load-data]
 
@@ -58,7 +112,6 @@ Use the `msmarco-passagetest2019-top1000` data set, which is a subset of the MS 
 
 Download the file and upload it to your cluster using the [Data Visualizer](../../../manage-data/ingest/upload-data-files.md) in the {{ml-app}} UI. After your data is analyzed, click **Override settings**. Under **Edit field names**, assign `id` to the first column and `content` to the second. Click **Apply**, then **Import**. Name the index `test-data`, and click **Import**. After the upload is complete, you will see an index named `test-data` with 182,469 documents.
 
-
 ## Reindex the data [semantic-text-reindex-data]
 
 Create the embeddings from the text by reindexing the data from the `test-data` index to the `semantic-embeddings` index. The data in the `content` field will be reindexed into the `content` semantic text field of the destination index. The reindexed data will be processed by the {{infer}} endpoint associated with the `content` semantic text field.
@@ -67,7 +120,6 @@ Create the embeddings from the text by reindexing the data from the `test-data` 
 This step uses the reindex API to simulate data ingestion. If you are working with data that has already been indexed, rather than using the test-data set, reindexing is required to ensure that the data is processed by the {{infer}} endpoint and the necessary embeddings are generated.
 
 ::::
-
 
 ```console
 POST _reindex?wait_for_completion=false
@@ -84,7 +136,6 @@ POST _reindex?wait_for_completion=false
 
 1. The default batch size for reindexing is 1000. Reducing size to a smaller number makes the update of the reindexing process quicker which enables you to follow the progress closely and detect errors early.
 
-
 The call returns a task ID to monitor the progress:
 
 ```console
@@ -96,7 +147,6 @@ Reindexing large datasets can take a long time. You can test this workflow using
 ```console
 POST _tasks/<task_id>/_cancel
 ```
-
 
 ## Semantic search [semantic-text-semantic-search]
 


### PR DESCRIPTION
## Overview

Related issue: https://github.com/elastic/search-team/issues/10758

This PR updates the `Semantic search with semantic_text` tutorial to show how to use inference endpoints on EIS. It separates the behavior for Serverless and Cloud. From mid-October, EIS will be the default for `semantic_text` on Serverless, but on Cloud, it won’t become the default until January. Until then, the two cases need to be documented separately.