### PR TITLE
WIP refactor reference landing page

### DIFF
--- a/reference/index.md
+++ b/reference/index.md
@@ -20,83 +20,106 @@ Explore the reference documentation for [Elastic APIs]({{apis}}).
 | APM | • [APM Server](/solutions/observability/apm/apm-server/api.md)<br>• [Observability intake Serverless]({{intake-apis}})<br> |
 | {{ecloud}} | • [{{ech}}]({{cloud-apis}})<br>• [{{ecloud}} Serverless]({{cloud-serverless-apis}})<br>• [{{ece}}]({{ece-apis}})<br>• [{{eck}}](cloud-on-k8s://reference/api-docs.md)<br>• [{{ecloud}} billing]({{cloud-billing-apis}})<br> |
 
-## Security
+## Solutions, Platform, Deploy
 
-Access detailed reference documentation on field and object schemas as well as the different commands used to manage and troubleshoot Elastic Endpoint.
+Find the relevant documentation for Elastic solutions, platform components, and deployment options.
 
-**Learn more in [Security](security/index.md)**
 
-## Observability
+::::{tab-set}
 
-Access detailed reference documentation on field and object schemas as well as the Elastic Entity Model.
+:::{tab-item} Solutions
 
-**Learn more in [Observability](observability/index.md)**
+|     |     |
+| --- | --- |
+| [**Get started with {{es}}**](/solutions/search/get-started.md) | [Reference docs](elasticsearch://reference/elasticsearch/index.md) |
+| [**Get started with Observability**](/solutions/observability/get-started.md) | [Reference docs](observability/index.md) |
+| [**Get started with Security**](/solutions/security/get-started.md) | [Reference docs](security/index.md) |
 
-## Elasticsearch and index management
+:::
 
-Customize your Elastic Stack setup with our configuration reference guides. Explore JVM settings, client documentation, Elasticsearch privileges, and index lifecycle actions to find the detailed information you need to configure your environment to your specific needs.
+:::{tab-item} Platform
 
-**Learn more in [Elasticsearch and index management](elasticsearch://reference/elasticsearch/index.md)**
+|     |     |
+| --- | --- |
+| [{{es}}](elasticsearch://reference/elasticsearch/index.md) | The core distributed search and analytics engine at the heart of the Elastic platform. |
+| [{{ls}}](logstash://reference/index.md) | A data collection engine with real-time pipelining capabilities. |
+| [{{kib}}](kibana://reference/index.md) | Visualize and analyze your data with Kibana, the extensible user interface of the Elastic platform. |
+| [Fleet and Elastic Agent](/reference/fleet/index.md) | A unified method to collect logs, metrics, and security data. |
+| [Beats](beats://reference/index.md) | Lightweight data shippers that send data to your cluster. |
 
-## Elastic Distributions of OpenTelemetry (EDOT)
+:::
 
-Elastic Distributions of OpenTelemetry (EDOT) is an open-source ecosystem of OpenTelemetry distributions tailored to Elastic. They include a customized OpenTelemetry Collector and several OpenTelemetry Language SDKs.
+:::{tab-item} Deploy
 
-**Learn more in [Elastic Distributions of OpenTelemetry](opentelemetry://reference/index.md)**
+|     |     |
+| --- | --- |
+| [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md) | {{serverless-full}} is a fully managed solution that allows you to deploy and use Elastic for your use cases without managing the underlying infrastructure. |
+| [{{ech}}](/deploy-manage/deploy/elastic-cloud/cloud-hosted.md) | {{ech}} is the Elastic Stack, managed through Elastic Cloud deployments. |
+| [{{ece}}](/deploy-manage/deploy/cloud-enterprise.md) | Deploy Elastic Cloud on public or private clouds, virtual machines, or your own premises. |
+| [{{eck}}](/deploy-manage/deploy/cloud-on-k8s.md) | Deploy Elastic Cloud on Kubernetes. |
+| [Self-managed](/deploy-manage/deploy/self-managed.md) | Install, configure, and run Elastic products on your own premises. |
 
-## Ingestion tools
+:::
 
-Streamline data ingestion with tools like Fleet and Elastic Agent, APM, and Beats. Explore processor references and Logstash plugins to efficiently manage your data flow.
+::::
+
+:::{tip}
+To learn about RESTful APIs, third-party dependencies, supported regions, and more for ECH, ECE, ECK, and ECCTL deployments, refer to the [Cloud reference documentation](cloud://reference/index.md).
+:::
+
+## Browse reference docs
+
+### Ingestion tools
+
+Find the reference docs for various Elastic ingestion tools including:
+
+* [Logstash](logstash://reference/index.md)
+* [Beats](beats://reference/index.md)
+* [Elastic Distributions of OpenTelemetry](opentelemetry://reference/index.md)
+* [Fleet and Elastic Agent](/reference/fleet/index.md)
+* [APM](/reference/apm/observability/apm.md)
+* [Elastic Serverless Forwarder for AWS](elastic-serverless-forwarder://reference/index.md)
+* [Content connectors](elasticsearch://reference/search-connectors/index.md)
+* [Elastic integrations](integration-docs://reference/index.md)
 
 **Learn more in [Ingestion tools](ingestion-tools/index.md)**
 
-## Kibana
+### Query languages
 
-Visualize and analyze your data with Kibana. Configure advanced settings, explore plugins, and utilize command line tools to enhance your data insights.
+Find detailed reference documentation for:
 
-**Learn more in [Kibana](kibana://reference/index.md)**
+* [Query DSL](elasticsearch://reference/query-languages/querydsl.md)
+* [{{esql}}](elasticsearch://reference/query-languages/esql.md)
+* [SQL](elasticsearch://reference/query-languages/sql.md)
+* [EQL](elasticsearch://reference/query-languages/eql.md)
+* [Kibana Query Language](elasticsearch://reference/query-languages/kql.md)
 
-## Elasticsearch plugins
-
-Extend the functionality of your Elastic Stack with a variety of plugins. From analysis and discovery to snapshot/restore and store plugins, customize your setup to fit your requirements.
-
-**Learn more in [Plugins](elasticsearch://reference/elasticsearch-plugins/index.md)**
-
-## Query languages
-
-Master data querying with our comprehensive guides on QueryDSL, ES|QL, SQL, EQL, and Kibana Query Language.
-
-**Learn more in [Query languages](elasticsearch://reference/query-languages/index.md)**
-
-## Scripting languages
+### Painless scripting language
 
 Access syntax references, function libraries, and best practices for Painless scripting.
 
 **Learn more in [Painless scripting](elasticsearch://reference/scripting-languages/painless/painless.md)**
 
-## ECS (Elastic Common Schema) reference
+### Elastic Common Schema (ECS) reference
 
 Standardize your data with ECS. Access logging libraries, field references, and categorization fields to ensure consistency and compatibility across your data sources.
 
 **Learn more in [ECS](ecs://reference/index.md)**
 
-## Data analysis
+### Search UI library
 
-Unlock insights with powerful data analysis tools. Utilize text analysis components, aggregations, and function references to derive meaningful conclusions from your data.
-
-**Learn more in [Data analysis](data-analysis/index.md)**
-
-## Search UI library
-
-Explore reference content on the Search UI library and how you can develop fast, modern, and engaging search experiences.
+Explore reference content on the Search UI library and how you can develop fast, modern, and engaging search experiences on top of {{es}}.
 
 **Learn more in [Search UI](search-ui://reference/index.md)**
 
-## Cloud
+### Elastic Distributions of OpenTelemetry (EDOT)
 
-Leverage the power of the cloud with Elastic Cloud solutions. Explore Elastic Cloud on Kubernetes, Elastic Cloud Enterprise, and Elastic Cloud Hosted to scale your operations.
+Elastic Distributions of OpenTelemetry (EDOT) is an open-source ecosystem of OpenTelemetry distributions tailored to Elastic. They include a customized OpenTelemetry Collector and several OpenTelemetry Language SDKs.
 
-**Learn more in [Cloud](cloud://reference/index.md)**
+**Learn more in [Elastic Distributions of OpenTelemetry](opentelemetry://reference/index.md)**
 
+### Elasticsearch plugins
 
+Extend the functionality of your Elastic Stack with a variety of plugins. From analysis and discovery to snapshot/restore and store plugins, customize your setup to fit your requirements.
 
+**Learn more in [Plugins](elasticsearch://reference/elasticsearch-plugins/index.md)**


### PR DESCRIPTION
> [!NOTE]  
> Just a testeroo, check out an **Appendix: Alternative** for another idea

Tries to restore some of the navigation on https://www.elastic.co/guide/index.html, using tabs and tables instead of custom CSS


🔍 [Preview link](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/3147/reference)

Screenshot

<img width="2894" height="7702" alt="Screenshot 2025-09-24 at 14-35-01 Reference Elastic Docs" src="https://github.com/user-attachments/assets/22e064f7-f74d-4e0e-a34a-b886fdaa70ab" />


## Appendix: Alternative 🤔 

An alternative would be use more tabs
<img width="2894" height="7154" alt="Screenshot 2025-09-24 at 13-42-27 Reference Elastic Docs" src="https://github.com/user-attachments/assets/2bf0dcb0-c129-4978-8e5f-f747701469cd" />



