### PR TITLE
[CCM] Swap `ELASTICSEARCH_READ_*` for `AUTOOPS_ES_*` keys

### DIFF
--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -238,9 +238,9 @@ Complete the following steps to run the command:
     | --- | --- |
     | `AUTOOPS_OTEL_URL` | The {{ecloud}} URL to which {{agent}} ships data. The URL is generated based on the CSP and region you pick. <br> This URL shouldn't be edited. |
     | `AUTOOPS_ES_URL` | The URL {{agent}} uses to communicate with {{es}}. |
-    | `ELASTICSEARCH_READ_API_KEY` | The API key for API key authentication to access the cluster. It combines the `${id}:${api_key}` values. <br> This variable shouldn't be used with `ELASTICSEARCH_READ_USERNAME` and `ELASTICSEARCH_READ_PASSWORD`. |
-    | `ELASTICSEARCH_READ_USERNAME` | The username for basic authentication to access the cluster. <br> This variable should be used with `ELASTICSEARCH_READ_PASSWORD`. |
-    | `ELASTICSEARCH_READ_PASSWORD` | The password for basic authentication to access the cluster. <br> This variable should be used with `ELASTICSEARCH_READ_USERNAME`. |
+    | `AUTOOPS_ES_API_KEY` | The API key for API key authentication to access the cluster. It combines the `${id}:${api_key}` values. <br> This variable shouldn't be used with `AUTOOPS_ES_USERNAME` and `AUTOOPS_ES_PASSWORD`. |
+    | `AUTOOPS_ES_USERNAME` | The username for basic authentication to access the cluster. <br> This variable should be used with `AUTOOPS_ES_PASSWORD`. |
+    | `AUTOOPS_ES_PASSWORD` | The password for basic authentication to access the cluster. <br> This variable should be used with `AUTOOPS_ES_USERNAME`. |
     | `ELASTIC_CLOUD_CONNECTED_MODE_API_KEY` | The {{ecloud}} API Key used to register the cluster. <br> This key shouldn't be edited. |
     | `AUTOOPS_TEMP_RESOURCE_ID` | The temporary ID for the current installation wizard. |
 


### PR DESCRIPTION
The `ELASTICSEARCH_READ_*` keys continue to work, but it was decided to add more explicit AutoOps-related key names and they are now being used by the wizard.

Relates to https://github.com/elastic/beats/pull/46358