### PR TITLE
Fix anchor link By shutting down the host

### DIFF
--- a/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
+++ b/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
@@ -23,7 +23,7 @@ You can perform these maintenance actions on the hosts in your ECE installation 
   * [For Docker-based installations: disable the Docker service](#ece-perform-host-maintenance-docker-disable)
   * [For Podman-based installations: disable the Podman-related services](#ece-perform-host-maintenance-podman-disable) 
 * [By deleting the host (destructive)](#ece-perform-host-maintenance-delete-runner)
-* [By shutting down the host (less destructive)](#ece-perform-host-maintenance-delete-runner)
+* [By shutting down the host (less destructive)](#ece-perform-host-maintenance-shutdown-host)
 
 Which method you choose depends on how invasive your host maintenance needs to be. If your host maintenance could affect ECE, use the destructive method that first deletes the host from your installation. These methods include a step that moves any hosted {{es}} clusters and {{kib}} instances off the affected hosts and are generally considered safe, provided that your ECE installation still has sufficient resources available to operate after the host has been removed.
 


### PR DESCRIPTION
Just fixing anchor currently [By shutting down the host (less destructive)](https://www.elastic.co/docs/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance#ece-perform-host-maintenance-delete-runner) to point to correct anchor that should be https://www.elastic.co/docs/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance#ece-perform-host-maintenance-shutdown-host