### PR TITLE
Separate the curl outputs from the commands

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/generate-roles-tokens.md
+++ b/deploy-manage/deploy/cloud-enterprise/generate-roles-tokens.md
@@ -52,6 +52,8 @@ To generate an ephemeral token for additional allocators:
 
 ```sh
 curl -H 'Content-Type: application/json' -u USER:PASSWORD https://$COORDINATOR_HOST:12443/api/v1/platform/configuration/security/enrollment-tokens -d '{ "persistent": false, "roles": [ "allocator"] }'
+```
+```sh
 {
   "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0Njk3N2I3ZC1hM2U2LTQ2MDUtYjcwZC0xNzIzMTI5YWY4ZTQiLCJyb2xlcyI6WyJwcm94eSIsImFsbG9jYXRvciJdLCJpc3MiOiJib290c3RyYXAtaW5pdGlhbCIsImV4cCI6MTQ5MzY0NjIxM30.xsaRb72CsNMuXKy6Y-PJgqLc0qmjCljlB4Smcx_MRxg"
 }
@@ -61,6 +63,8 @@ To generate a persistent token for additional allocators:
 
 ```sh
 curl -H 'Content-Type: application/json' -u USER:PASSWORD https://$COORDINATOR_HOST:12443/api/v1/platform/configuration/security/enrollment-tokens -d '{ "persistent": true, "roles": [ "allocator"] }'
+```
+```sh
 {
   "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0Yzg5OTBkZi0xZmI3LTQ4MjAtYjg2OC02YmM5ZTg4NjA4MTQiLCJyb2xlcyI6WyJwcm94eSIsImFsbG9jYXRvciJdLCJpc3MiOiJib290c3RyYXAtaW5pdGlhbCJ9.mfTkO4j8uZJ-qwB2jmBuMScyYfLmcJpvKgSTLx2WV24",
   "token_id": "4c8990df-1fb7-4820-b868-6bc9e8860814"
@@ -83,6 +87,8 @@ To delete a token:
 
     ```sh
     curl -u USER:PASSWORD https://localhost:12443/api/v1/platform/configuration/security/enrollment-tokens
+    ```
+    ```sh
     {
       "tokens": [{
         "token_id": "5f9cad2f-c6e7-4ee2-8f6e-53225df45be5",
@@ -98,6 +104,8 @@ To delete a token:
 
     ```sh
     curl -XDELETE -u USER:PASSWORD  'https://localhost:12443/api/v1/platform/configuration/security/enrollment-tokens/4c8990df-1fb7-4820-b868-6bc9e8860814'
+    ```
+    ```sh
     {
     }
     ```


### PR DESCRIPTION
Currently, both the `curl` command and example output appear in the same `sh` block that may confuse users while copying and running the commands.

With this commit, the example outputs are separated from the `curl` commands similar to the command and output shown in https://www.elastic.co/docs/reference/cloud/cloud-enterprise/ece-restful-api-examples-get-deployments.