### PR TITLE
Update obs-serverless-project.md

### DIFF
--- a/solutions/_snippets/obs-serverless-project.md
+++ b/solutions/_snippets/obs-serverless-project.md
@@ -8,11 +8,11 @@ The **Admin** role or higher is required to create projects. Refer to [Assign us
 1. Navigate to [cloud.elastic.co](https://cloud.elastic.co/) and log in to your account, or create one.
 2. Select **Create serverless project**.
 3. Under **Elastic for Observability**, select **Next**.
-4. Enter a name for your project.
-5. (Optional) Select **Edit settings** to change your project settings:
+4. Enter a name for your project and select **Observability Complete**. 
+6. (Optional) Select **Edit settings** to change your project settings:
 
     * **Cloud provider**: The cloud platform where you’ll deploy your project. We currently support Amazon Web Services (AWS).
     * **Region**: The [region](/deploy-manage/deploy/elastic-cloud/regions.md) where your project will live.
 
-6. Select **Create project**. It takes a few minutes to create your project.
-7. When the project is ready, click **Continue**.
+7. Select **Create project**. It takes a few minutes to create your project.
+8. When the project is ready, click **Continue**.


### PR DESCRIPTION
Following https://github.com/elastic/docs-content/pull/3174#issuecomment-3335496214, this adds the Obs project type selection step to the reusable snippet for creating Obs Serverless projects.

+CC @mdbirnstiehl