### PR TITLE
Update agent builder programmatic access 

### DIFF
--- a/solutions/search/agent-builder/kibana-api.md
+++ b/solutions/search/agent-builder/kibana-api.md
@@ -7,8 +7,6 @@ applies_to:
 ---
 
 :::{warning}
-WIP
-
 These pages are hidden from the docs TOC and have `noindexed` meta headers.
 :::
 
@@ -18,7 +16,8 @@ These APIs allow you to programmatically work with the {{agent-builder}} abstrac
 
 ## API reference
 
-For the full API documentation, refer to the [Kibana API reference](https://www.elastic.co/docs/api/doc/kibana/).
+For the full API documentation, refer to the [Kibana serverless API reference](https://www.elastic.co/docs/api/doc/serverless/).
+% TODO: Update link once page is live
 
 ## Using the APIs
 

--- a/solutions/search/agent-builder/programmatic-access.md
+++ b/solutions/search/agent-builder/programmatic-access.md
@@ -7,18 +7,20 @@ applies_to:
 ---
 
 :::{warning}
-WIP
-
 These pages are hidden from the docs TOC and have `noindexed` meta headers.
 :::
 
 # Work programmatically with {{agent-builder}}
 
-{{agent-builder}} provides comprehensive APIs and additional integration options for programmatic access and automation.
+{{agent-builder}} provides comprehensive integration options for programmatic access and automation.
 
 These interfaces enable you to build integrations with other applications and extend Agent Builder's capabilities to fit your specific requirements.
 
-- **[Kibana API](kibana-api.md)**: RESTful APIs for working with {{agent-builder}} programmatically
+:::{tip}
+Most users will probably want to integrate with Agent Builder using MCP or A2A, but you can also work programmatically with tools, agents, and conversations using the Kibana APIs.
+:::
+
 - **[MCP server](mcp-server.md)**: A standardized interface that allows external MCP clients (such as Claude Desktop or Cursor) to access {{agent-builder}} tools
 - **[A2A server](a2a-server.md)**: Agent-to-agent communication endpoints that follow the A2A protocol specification, enabling external A2A clients to interact with {{agent-builder}} agents
+- **[Kibana API](kibana-api.md)**: RESTful APIs for working with {{agent-builder}} programmatically
 


### PR DESCRIPTION
Key changes:

- Removed "WIP" warning from kibana-api.md
- Updated API reference link from Kibana API to Kibana serverless API (with TODO for when page goes live)
  - Because live on serverless now and we will be publishing new Kib serverless pages ASAP
- Reordered programmatic-access.md content to prioritize MCP/A2A over Kibana APIs
- Added tip explaining most users prefer MCP/A2A integration
- Moved Kibana API to bottom of the list