### PR TITLE
Updates links on Fundamentals page 

### DIFF
--- a/get-started/index.md
+++ b/get-started/index.md
@@ -32,9 +32,9 @@ Elastic provides an open source search, analytics, and AI platform, and out-of-t
 
 Elastic offers the following solutions or types of projects:
 
-* [{{es}}](/solutions/search.md): Build powerful search and RAG applications using Elasticsearch's vector database, AI toolkit, and advanced retrieval capabilities.  
-* [Elastic {{observability}}](/solutions/observability.md): Gain comprehensive visibility into applications, infrastructure, and user experience through logs, metrics, traces, and other telemetry data, all in a single interface.
-* [{{elastic-sec}}](/solutions/security.md): Combine SIEM, endpoint security, and cloud security to provide comprehensive tools for threat detection and prevention, investigation, and response.
+* [**{{es}}**](/solutions/search/get-started.md): Build powerful search and RAG applications using {{es}}'s vector database, AI toolkit, and advanced retrieval capabilities.  
+* [**Elastic {{observability}}**](/solutions/observability/get-started.md): Gain comprehensive visibility into applications, infrastructure, and user experience through logs, metrics, traces, and other telemetry data, all in a single interface.
+* [**{{elastic-sec}}**](/solutions/security/get-started.md): Combine SIEM, endpoint security, and cloud security to provide comprehensive tools for threat detection and prevention, investigation, and response.
 
 ## Explore the fundamentals
 


### PR DESCRIPTION
An addendum to #2795. Updates the links to point to the Get Started landing pages instead of the solution landing pages. 