### PR TITLE
[AutoOps] Update incoming HTTP port for OTLP

### DIFF
--- a/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md
+++ b/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md
@@ -102,4 +102,4 @@ $$$data-gathering$$$ **How does AutoOps gather data from my cluster and ensure i
     | Protocol | Data extracted | Port | Authentication method | 
     | --- | --- | --- | --- |
     | HTTP |  Basic cluster information from the `/` endpoint <br><br> License information from the `/_license` endpoint | **443**: standard HTTPS port | Uses an {{ecloud}} API key which is limited for use with Cloud Connect only. |
-    | OTLP over HTTP | Operational information | **434**: standard HTTPS port | Uses an AutoOps token which is functionally equivalent to an API key. |
+    | OTLP over HTTP | Operational information | **443**: standard HTTPS port | Uses an AutoOps token which is functionally equivalent to an API key. |

--- a/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md
+++ b/deploy-manage/monitor/autoops/cc-cloud-connect-autoops-faq.md
@@ -102,4 +102,4 @@ $$$data-gathering$$$ **How does AutoOps gather data from my cluster and ensure i
     | Protocol | Data extracted | Port | Authentication method | 
     | --- | --- | --- | --- |
     | HTTP |  Basic cluster information from the `/` endpoint <br><br> License information from the `/_license` endpoint | **443**: standard HTTPS port | Uses an {{ecloud}} API key which is limited for use with Cloud Connect only. |
-    | OTLP | Operational information | **4318**: standard OTLP HTTP port <br><br> This service will be exposed on port 443 in the future. | Uses an AutoOps token which is functionally equivalent to an API key. |
+    | OTLP over HTTP | Operational information | **434**: standard HTTPS port | Uses an AutoOps token which is functionally equivalent to an API key. |


### PR DESCRIPTION
This updates the OTLP port to indicate that it is now exclusively `443` instead of the standard `4318` (which causes issues for some users).