### PR TITLE
Update rate limit description in eis.md

### DIFF
--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -66,7 +66,7 @@ This is particularly relevant when using the [_bulk API](https://www.elastic.co/
 
 #### Rate limits 
 
-Rate limit for search and ingest is currently at 500 requests per minute. This limits ingest to approximately 8,000 documents per minute.
+Rate limit for search and ingest is currently at 500 requests per minute. This permits ingest to approximately 8,000 documents per minute when ingesting 16 documents per request.
 
 ## Pricing 
 

--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -66,7 +66,7 @@ This is particularly relevant when using the [_bulk API](https://www.elastic.co/
 
 #### Rate limits 
 
-Rate limit for search and ingest is currently at 500 requests per minute. This permits ingest to approximately 8,000 documents per minute when ingesting 16 documents per request.
+Rate limit for search and ingest is currently at 500 requests per minute. This allows you to ingest approximately 8000 documents per minute at 16 documents per request.
 
 ## Pricing 
 

--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -66,7 +66,7 @@ This is particularly relevant when using the [_bulk API](https://www.elastic.co/
 
 #### Rate Limits 
 
-Rate limit for search and ingest is currently at 500 requests per minute (this is ~8000 documents per minute for ingest).
+Rate limit for search and ingest is currently at 500 requests per minute. This limits ingest to approximately 8,000 documents per minute.
 
 ## Pricing 
 

--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -64,7 +64,7 @@ Performance may vary during the Technical Preview.
 Batches are limited to a maximum of 16 documents.
 This is particularly relevant when using the [_bulk API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-bulk) for data ingestion.
 
-#### Rate Limits 
+#### Rate limits 
 
 Rate limit for search and ingest is currently at 500 requests per minute. This limits ingest to approximately 8,000 documents per minute.
 

--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -66,7 +66,7 @@ This is particularly relevant when using the [_bulk API](https://www.elastic.co/
 
 #### Rate Limits 
 
-Rate limit for search and ingest is currently at 500 requests per minute.
+Rate limit for search and ingest is currently at 500 requests per minute (this is ~8000 documents per minute for ingest).
 
 ## Pricing 
 


### PR DESCRIPTION
Clarified rate limit for search and ingest operations.

8000 docs/minute is worth being clear about