### PR TITLE
[Security][9.x & Serverless][Bug] Removes note about suppression and prebuilt rules that's no longer applicable

### DIFF
--- a/solutions/security/detect-and-alert/suppress-detection-alerts.md
+++ b/solutions/security/detect-and-alert/suppress-detection-alerts.md
@@ -35,10 +35,6 @@ Normally, when a rule meets its criteria repeatedly, it creates multiple alerts,
 
 The {{security-app}} displays several indicators in the Alerts table and the alert details flyout when a detection alert is created with alert suppression enabled. You can view the original events associated with suppressed alerts by investigating the alert in Timeline.
 
-::::{note}
-Alert suppression is not available for Elastic prebuilt rules. However, if you want to suppress alerts for a prebuilt rule, you can duplicate it, then configure alert suppression on the duplicated rule.
-::::
-
 
 ## Configure alert suppression [security-alert-suppression-configure-alert-suppression]
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/3290.

Removes note about suppression and prebuilt rules that's no longer applicable. Since 8.18, users can configure suppression on prebuilt rules if they edit them.

Corresponding 8.18 and 8.19 doc updates are at: https://github.com/elastic/security-docs/pull/7081

[Preview](https://github.com/elastic/docs-content/pull/3304#issuecomment-3363322685)