### PR TITLE
Update ingest-lag.md because of `event.put` to event.*P*ut

### DIFF
--- a/manage-data/ingest/transform-enrich/ingest-lag.md
+++ b/manage-data/ingest/transform-enrich/ingest-lag.md
@@ -89,7 +89,7 @@ As discussed above `@timestamp` is set to the timestamp from within the collecte
     lang: javascript
     source: >
       function process(event) {
-          event.put("event.created", Date.now());
+          event.Put("event.created", Date.now());
       }
 ```
 


### PR DESCRIPTION
This is a typo in the JavaScript, fixing it for better copy pasting. Thanks @morashwan for pointing it out