### PR TITLE
Revise connection steps for self-managed clusters

### DIFF
--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -35,7 +35,7 @@ Ensure your system meets the following requirements before proceeding:
 :::
 :::
 
-The following steps describe how to connect your ECE, ECK, or self-managed cluster to AutoOps. 
+The following steps describe how to connect your ECE, ECK, or  cluster to AutoOps. 
 
 <!-- Private preview instructions:
 :::::{tab-set}
@@ -71,8 +71,8 @@ If you don’t have an existing {{ecloud}} account:
 
 If you already have an {{ecloud}} account:
 1. Log in to [{{ecloud}}](https://cloud.elastic.co?page=docs&placement=docs-body).
-2. On your home page, in the **Connected clusters** section, select **Connect self-managed cluster**. 
-3. On the **Connect your self-managed cluster** page, in the **AutoOps** section, select **Connect**.
+2. On your home page, in the **Connected clusters** section, select **Connect  cluster**. 
+3. On the **Connect your  cluster** page, in the **AutoOps** section, select **Connect**.
 4. Go through the installation wizard as detailed in the following sections.
 ::::
 
@@ -121,7 +121,7 @@ Depending on your selected installation method, you may have to provide the foll
 
 With this authentication method, you need to create an API key to grant access to your cluster. Complete the following steps:
 
-1. From your {{ecloud}} home page, select a deployment.
+1. Open your self-managed cluster's Kibana
 2. Go to the **API keys** management page in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 3.  Select **Create API key**.
 4. In the flyout, enter a name for your key and select **User API key**.
@@ -167,7 +167,7 @@ With this authentication method, you need to create an API key to grant access t
 
 With this authentication method, you need the username and password of a user with the necessary privileges to grant access to your cluster. There are two ways to set up a user with the these privileges:
 
-* (Recommended) From your {{ecloud}} home page, select a deployment and go to **Developer tools**. In **Console**, run the following command:
+* (Recommended) Open your self-managed cluster's Kibana and go to **Developer tools**. In **Console**, run the following command:
 ```js
 POST /_security/role/autoops
 {


### PR DESCRIPTION
Updated instructions for connecting self-managed clusters to AutoOps. We should create API Key or role in the self-managed cluster as a source, not Elastic Cloud deployment.