### PR TITLE
EIS: remove limitations for GA

### DIFF
--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -43,30 +43,6 @@ You can now use `semantic_text` with the new ELSER endpoint on EIS. To learn how
 #### Get started with semantic search with ELSER on EIS
 [Semantic Search with `semantic_text`](/solutions/search/semantic-search/semantic-search-semantic-text.md) has a detailed tutorial on using the `semantic_text` field and using the ELSER endpoint on EIS instead of the default endpoint. This is a great way to get started and try the new endpoint.
 
-### Limitations
-
-While we do encourage experimentation, we do not recommend implementing production use cases on top of this feature while it is in Technical Preview.
-
-#### Uptime
-
-There are no uptime guarantees during the Technical Preview.
-While Elastic will address issues promptly, the feature may be unavailable for extended periods.
-
-#### Throughput and latency
-
-{{infer-cap}} throughput via this endpoint is expected to exceed that of {{infer}} operations on an ML node.
-However, throughput and latency are not guaranteed.
-Performance may vary during the Technical Preview.
-
-#### Batch size
-
-Batches are limited to a maximum of 16 documents.
-This is particularly relevant when using the [_bulk API](https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-bulk) for data ingestion.
-
-#### Rate limits 
-
-Rate limit for search and ingest is currently at 500 requests per minute. This allows you to ingest approximately 8000 documents per minute at 16 documents per request.
-
 ## Pricing 
 
 All models on EIS incur a charge per million tokens. The pricing details are at our [Pricing page](https://www.elastic.co/pricing/serverless-search) for the Elastic Managed LLM and ELSER. 


### PR DESCRIPTION
The Elastic Inference Service (EIS) is going GA in `9.2`. Hence we remove the limitations that apply to tech preview.

We leave in the batch size limitation as it currently still exists.
