### PR TITLE
Fix ML function reference titles

### DIFF
--- a/reference/data-analysis/machine-learning/machine-learning-functions.md
+++ b/reference/data-analysis/machine-learning/machine-learning-functions.md
@@ -1,12 +1,12 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/machine-learning/current/ml-functions.html
-navigation_title: Function reference
+navigation_title: ML function reference
 products:
   - id: machine-learning
 ---
 
-# Function reference for Elastic {{ml} [ml-functions]
+# Function reference for Elastic {{ml}} [ml-functions]
 
 The {{ml-features}} include analysis functions that provide a wide variety of flexible ways to analyze data for anomalies.
 


### PR DESCRIPTION
The navigation title isn't clear that this is about ML, and the ML variable in the H1 title is missing a bracket