### PR TITLE
Expand Elasticsearch Search timeout

### DIFF
--- a/solutions/search/the-search-api.md
+++ b/solutions/search/the-search-api.md
@@ -195,7 +195,7 @@ PUT /_cluster/settings
 The `search.default_search_timeout` setting's resolution sensitivity is based from expert setting `thread_pool.estimated_time_interval` which defaults to `200ms`. This means the minimum meaningful impact threshold for `search.default_search_timeout` would also be `200ms`. Elastic recommends against overriding this expert setting as it has far reaching impact.
 :::
 
-The `search.default_search_timeout` cluster setting only applies to the current cluster and does not cascade during [Cross Cluster Search (CSS)](/solutions/search/cross-cluster-search). Remote clusters should be individually configured as makes sense for your use case.
+The `search.default_search_timeout` cluster setting only applies to the current cluster and does not cascade during [Cross Cluster Search (CSS)](/solutions/search/cross-cluster-search.md). Remote clusters should be individually configured as makes sense for your use case.
 
 ### Example [search-timeout-example]
 


### PR DESCRIPTION
👋🏽 howdy, team!

This updates the [The `_search` API > Search Timeout](https://www.elastic.co/docs/solutions/search/the-search-api#search-timeout) documentation section which causes user confusion and induces Support volume. TLDR it looks like we had aspirations to clarify this recently in https://github.com/elastic/elasticsearch/issues/47716 but need to go a bit farther. 

Statements pulled from
- [v5 docs](https://www.elastic.co/guide/en/elasticsearch/reference/5.2/search.html#global-search-cancellation)
 - [internal](https://github.com/elastic/sdh-elasticsearch/issues/1911) 
- https://support.elastic.co/knowledge/6ea7fdbb
- https://github.com/elastic/elasticsearch/issues/47716
- https://github.com/elastic/elasticsearch/pull/71713
- https://github.com/elastic/elasticsearch/issues/31263
- https://github.com/elastic/elasticsearch/issues/56258
- https://github.com/elastic/elasticsearch/issues/30897 

This does not include @\javanna's excellent callout [here](https://github.com/elastic/elasticsearch/issues/30897#issuecomment-1426478639) that some searches also cancel on connection closed. 

🙋‍♀️ This PR should be confirmed by a Dev before merging. 

TIA! Stef 