### PR TITLE
Remove outdated hardcoded version from frontmatter

### DIFF
--- a/release-notes/intro/index.md
+++ b/release-notes/intro/index.md
@@ -4,7 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elastic-stack/current/elastic-stack-breaking-changes.html
 products:
   - id: elastic-stack
-description: Explore the new features, enhancements, fixes, and deprecations for Elastic Stack 9.0+ (latest 9.1.1), Elastic Cloud Serverless, and...
+description: Explore new features, enhancements, fixes, and deprecations for Elastic Stack 9.0+, Elastic Cloud Serverless, and all other Elastic products
 navigation_title: Release notes
 ---
 


### PR DESCRIPTION
There is an outdated version hardcoded in one of our docs files. This PR removes it until support is added for variables in frontmatters

rel: https://github.com/elastic/docs-builder/issues/2079