### PR TITLE
Fix link to the conceptual page about rollover

### DIFF
--- a/troubleshoot/elasticsearch/index-lifecycle-management-errors.md
+++ b/troubleshoot/elasticsearch/index-lifecycle-management-errors.md
@@ -151,7 +151,7 @@ POST /my-index-000001/_ilm/retry
 
 ### How `min_age` is calculated [min-age-calculation]
 
-When setting up an [{{ilm-init}} policy](../../manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md) or [automating rollover with {{ilm-init}}](../../manage-data/lifecycle/index-lifecycle-management.md), be aware that `min_age` can be relative to either the rollover time or the index creation time.
+When setting up an [{{ilm-init}} policy](../../manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md) or [automating rollover with {{ilm-init}}](../../manage-data/lifecycle/index-lifecycle-management/rollover.md), be aware that `min_age` can be relative to either the rollover time or the index creation time.
 
 If you use [{{ilm-init}} rollover](elasticsearch://reference/elasticsearch/index-lifecycle-actions/ilm-rollover.md), `min_age` is calculated relative to the time the index was rolled over. This is because the [rollover API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-rollover) generates a new index and updates the `age` of the previous index to reflect the rollover time. If the index hasn’t been rolled over, then the `age` is the same as the `creation_date` for the index.
 


### PR DESCRIPTION
When working on #1553, I've noticed that this troubleshooting section link was pointing to the wrong page. The [Rollover](https://www.elastic.co/docs/manage-data/lifecycle/index-lifecycle-management/rollover) page in the Manage data docs used to have a section about automating rollover with ILM, so I imagine this is trying to point to the info on that page.