### PR TITLE
Updating Cloud Connected AWS region names

### DIFF
--- a/deploy-manage/monitor/autoops/ec-autoops-regions.md
+++ b/deploy-manage/monitor/autoops/ec-autoops-regions.md
@@ -29,27 +29,27 @@ AutoOps for {{ECH}} is currently available in the following regions for AWS:
 
 | Region | Name |
 | --- | --- | --- | --- |
-| us-east-1 | N. Virginia |
-| us-east-2 | Ohio |
-| us-west-1 | N. California |
-| us-west-2 | Oregon |
-| ca-central-1 | Canada |
-| eu-west-1 | Ireland |
-| eu-west-2 | London |
-| eu-west-3 | Paris |
-| eu-north-1 | Stockholm |
-| eu-central-1 | Frankfurt |
-| eu-central-2 | Zurich |
-| eu-south-1 | Milan |
-| me-south-1 | Bahrain |
-| ap-east-1 | Hong Kong |
-| ap-northeast-1 | Tokyo |
-| ap-northeast-2 | Seoul |
-| ap-southeast-1 | Singapore |
-| ap-southeast-2 | Sydney |
-| ap-south-1 | Mumbai |
-| sa-east-1 | Sao Paulo |
-| af-south-1 | Cape Town |
+| us-east-1 | US East (N. Virginia) |
+| us-east-2 | US East (Ohio) |
+| us-west-1 | US West (N. California) |
+| us-west-2 | US West (Oregon) |
+| ca-central-1 | Canada (Central) |
+| eu-west-1 | Europe (Ireland) |
+| eu-west-2 | Europe (London) |
+| eu-west-3 | Europe (Paris) |
+| eu-north-1 | Europe (Stockholm) |
+| eu-central-1 | Europe (Frankfurt) |
+| eu-central-2 | Europe (Zurich) |
+| eu-south-1 | Europe (Milan) |
+| me-south-1 | Middle East (Bahrain) |
+| ap-east-1 | Asia Pacific (Hong Kong) |
+| ap-northeast-1 | Asia Pacific (Tokyo) |
+| ap-northeast-2 | Asia Pacific (Seoul) |
+| ap-southeast-1 | Asia Pacific (Singapore) |
+| ap-southeast-2 | Asia Pacific (Sydney) |
+| ap-south-1 | Asia Pacific (Mumbai) |
+| sa-east-1 | South America (Sao Paulo) |
+| af-south-1 | Africa (Cape Town) |
 
 Regions for Azure and GCP are coming soon.
 
@@ -68,9 +68,9 @@ AutoOps for serverless projects is currently available in the following regions 
 
 | Region | Name |
 | --- | --- | --- | --- |
-| us-east-1 | N. Virginia |
-| eu-west-1 | Ireland |
-| ap-southeast-1 | Singapore |
-| us-west-2 | Oregon |
+| us-east-1 | US East (N. Virginia) |
+| eu-west-1 | Europe (Ireland) |
+| ap-southeast-1 | Asia Pacific (Singapore) |
+| us-west-2 | US West (Oregon) |
 
 The only exception is the **Search AI Lake** view, which is available in all CSP regions across AWS, Azure and GCP.


### PR DESCRIPTION
This is linked to #3588 and updates the names of the AWS regions to correspond to the full region names as listed [here](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html).