### PR TITLE
Add ES reference to /solutions/search nav

### DIFF
--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -3,8 +3,6 @@ toc:
   - file: index.md
   - file: search.md
     children:
-      - title: "Reference docs"
-        crosslink: elasticsearch://reference/elasticsearch/index.md
       - file: search/get-started.md
         children:
           - file: search/search-connection-details.md
@@ -102,6 +100,8 @@ toc:
       - file: search/apis-and-tools.md
       - file: search/ai-assistant.md
       - file: search/query-rules-ui.md
+      - title: "Elasticsearch engine reference →"
+        crosslink: elasticsearch://reference/elasticsearch/index.md
   - file: observability.md
     children:
       - file: observability/get-started.md


### PR DESCRIPTION
@shainaraskas I opened this for discussion, to at least tackle one part of the discoverability/confusion problem between the two Elasticsearch "books"


### https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/3598/solutions/search

#### reciprocal PR in `elasticsearch`: https://github.com/elastic/elasticsearch/pull/136944