### PR TITLE
[Obs AI Assistant] Update Mistral ES|QL rating in the LLM performance matrix

### DIFF
--- a/solutions/observability/llm-performance-matrix.md
+++ b/solutions/observability/llm-performance-matrix.md
@@ -51,7 +51,7 @@ Models you can [deploy and manage yourself](/solutions/observability/connect-to-
 | Provider | Model | **Alert questions** | **APM questions** | **Contextual insights** | **Documentation retrieval** | **Elasticsearch operations** | **{{esql}} generation** | **Execute connector** | **Knowledge retrieval** |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | Meta | **Llama-3.3-70B-Instruct** | Excellent | Good | Great | Excellent | Excellent | Good | Good | Excellent |
-| Mistral | **Mistral-Small-3.2-24B-Instruct-2506** | Excellent | Poor | Great | Great | Excellent | Poor | Good | Excellent |
+| Mistral | **Mistral-Small-3.2-24B-Instruct-2506** | Excellent | Poor | Great | Great | Excellent | Good | Good | Excellent |
 | Alibaba Cloud | **Qwen2.5-72b-Instruct** | Excellent | Good | Great | Excellent | Excellent | Good | Good | Excellent |
 
 ::::{note}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/232547

There was an issue with Mistral Small 3.2 ES|QL generation. This has now been fixed when used with the latest LM studio version. This PR updates the ES|QL generation rating for Mistral Small 3.2 based on the evaluation results obtained after the fix.