### PR TITLE
Revert "[agent builder] hotfix update enablement info and models page"

### DIFF
--- a/solutions/search/agent-builder/get-started.md
+++ b/solutions/search/agent-builder/get-started.md
@@ -26,24 +26,19 @@ You can set up a new [space](/deploy-manage/manage-spaces.md) to use the solutio
 
 :::::{step} Enable {{agent-builder}}
 
-
-<!-- 
-
-TODO: uncomment once default enabled is live on serverless
-
 ::::{applies-switch}
 
 :::{applies-item} { "serverless": "preview", "elasticsearch" }
 
 {{agent-builder}} is enabled by default in serverless {{es}} projects.
 
-Find **Agents** in the navigation menu to begin using the feature, or search for **Agents** in the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md). 
+Find **Agents** in the navigation menu to begin using the feature, or search for **Agents** in the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 
 :::
 
 :::{applies-item} stack: preview 9.2
--->
-You have to enable {{agent-builder}} to get started.
+
+You have to enable {{agent-builder}} to get started on non-serverless deployments.
 
 You can enable the features using the UI:
 

--- a/solutions/search/agent-builder/models.md
+++ b/solutions/search/agent-builder/models.md
@@ -10,10 +10,6 @@ applies_to:
 
 # Using different models in {{agent-builder}}
 
-:::{important}
-Due to phased rollout, the ability to use different models may not be immediately available in your project.
-:::
-
 {{agent-builder}} uses large language models (LLMs) to power agent reasoning and decision-making. By default, agents use the Elastic Managed LLM, but you can configure other models through Kibana connectors.
 
 ## Default model configuration


### PR DESCRIPTION
Reverts elastic/docs-content#3569 because the latest serverless update has happened