### PR TITLE
Update ECK 3.2 upgrade documentation (#2361)

### DIFF
--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
@@ -100,9 +100,7 @@ This will update the ECK installation to the latest binary and update the CRDs a
 
 Upgrading the operator results in a one-time update to existing managed resources in the cluster. This potentially triggers a rolling restart of pods by Kubernetes to apply those changes. The following list contains the ECK operator versions that would cause a rolling restart after they have been installed.
 
-```
 1.6, 1.9, 2.0, 2.1, 2.2, 2.4, 2.5, 2.6, 2.7, 2.8, 2.14, 3.1^1^, 3.2^1^
-```
 
 ^1^ The restart when upgrading to version 3.1 and 3.2 happens only for applications using [stack monitoring](/deploy-manage/monitor/stack-monitoring/eck-stack-monitoring.md).
 


### PR DESCRIPTION
Update documentation to say upgrading to ECK 3.2 will cause restarts when stack monitoring is used (same as for ECK 3.1).