### PR TITLE
Add Details to JWT Authentication Document About JWKS Background Reloading

### DIFF
--- a/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/jwt.md
@@ -121,18 +121,18 @@ Client authentication is enabled by default for the JWT realms. Disabling client
   :   Indicates that {{es}} should use the `RS256` or `HS256` signature algorithms to verify the signature of the JWT from the JWT issuer.
 
   `pkc_jwkset_path`
-  :   The file name or URL to a JSON Web Key Set (JWKS) with the public key material that the JWT Realm uses for verifying token signatures. A value is considered a file name if it does not begin with `https`. The file name is resolved relative to the {{es}} configuration directory. If a URL is provided, then it must begin with `https://` (`http://` is not supported). {{es}} automatically caches the JWK set and will attempt to refresh the JWK set upon signature verification failure, as this might indicate that the JWT Provider has rotated the signing keys. Background JWKS reloading can also be configured with the setting `pkc_jwkset_reload.enabled`.
+  :   The file name or URL to a JSON Web Key Set (JWKS) with the public key material that the JWT Realm uses for verifying token signatures. A value is considered a file name if it does not begin with `https`. The file name is resolved relative to the {{es}} configuration directory. If a URL is provided, then it must begin with `https://` (`http://` is not supported). {{es}} automatically caches the JWK set and will attempt to refresh the JWK set upon signature verification failure, as this might indicate that the JWT Provider has rotated the signing keys. Background JWKS reloading can also be configured with the setting `pkc_jwkset_reload.enabled`. This ensures that rotated keys are automatically discovered and used to verify JWT signatures.
 
   `pkc_jwkset_reload.enabled` {applies_to}`stack: ga 9.3`
   :   Indicates whether JWKS background reloading is enabled. Defaults to `false`.
 
-  `pkc_jwkset_reload.file_interval`
+  `pkc_jwkset_reload.file_interval` {applies_to}`stack: ga 9.3`
   :   Specifies the reload interval for file-based JWKS. Defaults to `5m`.
 
-  `pkc_jwkset_reload.url_interval_min`
+  `pkc_jwkset_reload.url_interval_min` {applies_to}`stack: ga 9.3`
   :   Specifies the minimum reload interval for URL-based JWKS. The `Expires` and `Cache-Control` HTTP response headers inform the reload interval. This configuration setting is the lower bound of what is considered, and it is also the default interval in the absence of useful response headers. Defaults to `1h`.
 
-  `pkc_jwkset_reload.url_interval_max`
+  `pkc_jwkset_reload.url_interval_max` {applies_to}`stack: ga 9.3`
   :   Specifies the maximum reload interval for URL-based JWKS. This configuration setting is the upper bound of what is considered from header responses (`5d`).
 
   `claims.principal`


### PR DESCRIPTION
A new JSON Web Key Set (JWKS) background reloading feature is being added to the JWT Realm in Elasticsearch.

This documentation change briefly outlines the capability and the four new settings for configuring it.

* `pkc_jwkset_reload.enabled` - Enable/disable automatic reloading (default: false)
* `pkc_jwkset_reload.file_interval` - File check interval (default: 5 minutes)
* `pkc_jwkset_reload.url_interval_min` - Minimum URL reload interval (default: 60 minutes)
* `pkc_jwkset_reload.url_interval_max` - Maximum URL reload interval (default: 5 days)