### PR TITLE
ECE version 3.8.3 and 4.0.3 docs-content updates

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/default-system-deployment-versions.md
+++ b/deploy-manage/deploy/cloud-enterprise/default-system-deployment-versions.md
@@ -16,9 +16,11 @@ Note that since version 2.7.0, system deployments are automatically upgraded whe
 
 | {{ece}} version | Admin cluster | Logging & Metrics cluster | Security cluster |
 | --- | --- | --- | --- |
+| 4.0.3 | 8.18.8 | 8.18.8 | 8.18.8 |
 | 4.0.2 | 8.18.8 | 8.18.8 | 8.18.8 |
 | 4.0.1 | 8.18.2 | 8.18.2 | 8.18.2 |
 | 4.0.0 | 8.18.0 | 8.18.0 | 8.18.0 |
+| 3.8.3 | 8.17.10 | 8.17.10 | 8.17.10 |
 | 3.8.2 | 8.17.10 | 8.17.10 | 8.17.10 |
 | 3.8.1 | 8.17.4 | 8.17.4 | 8.17.4 |
 | 3.8.0 | 8.17.4 | 8.17.4 | 8.17.4 |

--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-no-registry.md
@@ -36,13 +36,13 @@ To perform an offline installation without a private Docker registry, you have t
 
     ```sh subs=true
     docker save -o ece.{{version.ece}}.tar docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{version.ece}}
-    docker save -o es.8.18.2.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-8}}
-    docker save -o kibana.8.18.2.tar docker.elastic.co/cloud-release/kibana-cloud:{{ece-docker-images-8}}
-    docker save -o apm.8.18.2.tar docker.elastic.co/cloud-release/elastic-agent-cloud:{{ece-docker-images-8}}
-    docker save -o enterprise-search.8.18.2.tar docker.elastic.co/cloud-release/enterprise-search-cloud:{{ece-docker-images-8}}
-    docker save -o es.9.0.1.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-9}}
-    docker save -o kibana.9.0.1.tar docker.elastic.co/cloud-release/kibana-cloud:{{ece-docker-images-9}}
-    docker save -o apm.9.0.1.tar docker.elastic.co/cloud-release/elastic-agent-cloud:{{ece-docker-images-9}}
+    docker save -o es.{{ece-docker-images-8}}.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-8}}
+    docker save -o kibana.{{ece-docker-images-8}}.tar docker.elastic.co/cloud-release/kibana-cloud:{{ece-docker-images-8}}
+    docker save -o apm.{{ece-docker-images-8}}.tar docker.elastic.co/cloud-release/elastic-agent-cloud:{{ece-docker-images-8}}
+    docker save -o enterprise-search.{{ece-docker-images-8}}.tar docker.elastic.co/cloud-release/enterprise-search-cloud:{{ece-docker-images-8}}
+    docker save -o es.{{ece-docker-images-9}}.tar docker.elastic.co/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-9}}
+    docker save -o kibana.{{ece-docker-images-9}}.tar docker.elastic.co/cloud-release/kibana-cloud:{{ece-docker-images-9}}
+    docker save -o apm.{{ece-docker-images-9}}.tar docker.elastic.co/cloud-release/elastic-agent-cloud:{{ece-docker-images-9}}
     ```
 
 3. Copy the .tar files to a location on your network where they are available to each host where you plan to install {{ece}}. Alternatively, you can copy the .tar files to each host directly.

--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-with-registry.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-with-registry.md
@@ -42,13 +42,13 @@ Installing ECE on multiple hosts with your own registry server is simpler, becau
 
     ```sh subs=true
     docker tag docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:{{version.ece}} REGISTRY/cloud-enterprise/elastic-cloud-enterprise:{{version.ece}}
-    docker tag docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.18.2 REGISTRY/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-8}}
-    docker tag docker.elastic.co/cloud-release/kibana-cloud:8.18.2 REGISTRY/cloud-release/kibana-cloud:{{ece-docker-images-8}}
-    docker tag docker.elastic.co/cloud-release/elastic-agent-cloud:8.18.2 REGISTRY/cloud-release/elastic-agent-cloud:{{ece-docker-images-8}}
-    docker tag docker.elastic.co/cloud-release/enterprise-search-cloud:8.18.2 REGISTRY/cloud-release/enterprise-search-cloud:{{ece-docker-images-8}}
-    docker tag docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.0.1 REGISTRY/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-9}}
-    docker tag docker.elastic.co/cloud-release/kibana-cloud:9.0.1 REGISTRY/cloud-release/kibana-cloud:{{ece-docker-images-9}}
-    docker tag docker.elastic.co/cloud-release/elastic-agent-cloud:9.0.1 REGISTRY/cloud-release/elastic-agent-cloud:{{ece-docker-images-9}}
+    docker tag docker.elastic.co/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-8}} REGISTRY/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-8}}
+    docker tag docker.elastic.co/cloud-release/kibana-cloud:{{ece-docker-images-8}} REGISTRY/cloud-release/kibana-cloud:{{ece-docker-images-8}}
+    docker tag docker.elastic.co/cloud-release/elastic-agent-cloud:{{ece-docker-images-8}} REGISTRY/cloud-release/elastic-agent-cloud:{{ece-docker-images-8}}
+    docker tag docker.elastic.co/cloud-release/enterprise-search-cloud:{{ece-docker-images-8}} REGISTRY/cloud-release/enterprise-search-cloud:{{ece-docker-images-8}}
+    docker tag docker.elastic.co/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-9}} REGISTRY/cloud-release/elasticsearch-cloud-ess:{{ece-docker-images-9}}
+    docker tag docker.elastic.co/cloud-release/kibana-cloud:{{ece-docker-images-9}} REGISTRY/cloud-release/kibana-cloud:{{ece-docker-images-9}}
+    docker tag docker.elastic.co/cloud-release/elastic-agent-cloud:{{ece-docker-images-9}} REGISTRY/cloud-release/elastic-agent-cloud:{{ece-docker-images-9}}
     ```
 
 4. Push the Docker images to your private Docker registry, using the same tags from the previous step. Replace `REGISTRY` with your actual registry URL, for example `my.private.repo:5000`:


### PR DESCRIPTION
This PR includes the info about system deployments on ECE 4.0.3 and 3.8.3.

It also adds some missing substitutions.

There's no change in the main substitutions as they remain the same:

```
  ece-docker-images-8: 8.18.8
  ece-docker-images-9: 9.0.8
```

version.ece bump to 4.0.3 is NOT related with this PR, that's changed in the main bump ECE PR on docs-builder repo.

cc: @claudia-correia / @elastic/admin-docs 