### PR TITLE
Update ece-restore-snapshots-into-new-deployment.md

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
+++ b/deploy-manage/tools/snapshot-and-restore/ece-restore-snapshots-into-new-deployment.md
@@ -15,8 +15,9 @@ products:
 
 1. First, [create a new deployment](../../deploy/cloud-enterprise/create-deployment.md) and select **Restore snapshot data**. Select the deployment that you want to restore a snapshot *from*. If you don’t know the exact name, you can enter a few characters and then select from the list of matching deployments.
 2. Select the snapshot that you want to restore from. If none is chosen, the latest successful snapshot from the cluster you selected is restored on the new cluster when you create it.
+   **Please note that this only supports snapshots created in the `found-snpashots` repository**.
 
     ![Restoring from a snapshot](/deploy-manage/images/cloud-enterprise-restore-from-snapshot.png "")
 
-3. Manually recreate users using the X-Pack security features or using Shield on the new cluster. User information is not included when you restore across clusters.
+4. Manually recreate users using the X-Pack security features or using Shield on the new cluster. User information is not included when you restore across clusters.
 


### PR DESCRIPTION
Documenting that using snapshot to create a deployment on Elastic Cloud hosted is only supported for snapshots from the default `found-snapshots` repository