### PR TITLE
Remove model access instructions from documentation

### DIFF
--- a/solutions/security/ai/connect-to-amazon-bedrock.md
+++ b/solutions/security/ai/connect-to-amazon-bedrock.md
@@ -93,20 +93,6 @@ The following video demonstrates these steps (click to watch).
 [![bedrock-accesskey-video](https://play.vidyard.com/8oXgP1fbaQCqjWUgncF9at.jpg)](https://videos.elastic.co/watch/8oXgP1fbaQCqjWUgncF9at?)
 
 
-### Enable model access [_enable_model_access]
-
-Make sure the supported Amazon Bedrock LLMs are enabled:
-
-1. Search the AWS console for Amazon Bedrock.
-2. From the Amazon Bedrock page, click **Get started**.
-3. Select **Model access** from the left navigation menu, then click **Manage model access**.
-4. Check the box for the model or models you plan to use.
-5. Click **Save changes**.
-
-The following video demonstrates these steps (click to watch).
-
-[![bedrock-model-video](https://play.vidyard.com/Z7zpHq4N9uvUxegBUMbXDj.jpg)](https://videos.elastic.co/watch/Z7zpHq4N9uvUxegBUMbXDj?)
-
 
 ## Configure the Amazon Bedrock connector [_configure_the_amazon_bedrock_connector]
 


### PR DESCRIPTION
- Removed instructions for enabling model access in Amazon Bedrock.

If you go to [model access page](https://us-east-2.console.aws.amazon.com/bedrock/home?region=us-east-2#/modelaccess) today, you get the following message: 

<img width="1558" height="1158" alt="ElasticSupport 2025-11-02 at 15 53 03" src="https://github.com/user-attachments/assets/76d3e98c-050c-4335-81ce-1d0df64a9905" />

I don't think it's required anymore and therefore am proposing removing the step to keep instructions updated.