### PR TITLE
Update instructions for setting retention policies for ECE 3.8+ logging and metrics

### DIFF
--- a/deploy-manage/monitor/orchestrators/ece-monitoring-ece-set-retention.md
+++ b/deploy-manage/monitor/orchestrators/ece-monitoring-ece-set-retention.md
@@ -20,7 +20,7 @@ You might need to adjust the retention period for one of the following reasons:
 To customize the retention period, set up a custom lifecycle policy for logs and metrics indices:
 
 1. [Create a new index lifecycle management (ILM) policy](../../../manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md) in the logging and metrics cluster.
-2. Create a new composable index template that matches the data view (formerly *index pattern*) for the datastream you want to customize the lifecycle for.
+2. Create a new composable index template that matches the data view (formerly *index pattern*) for the data stream you want to customize the lifecycle for.
 3. Specify a custom lifecycle policy in the index template settings.
 4. Choose a higher `priority` for the template so the specified lifecycle policy will be used instead of the default.
 


### PR DESCRIPTION
Replaced outdated/legacy references since system logging and metrics start using datastreams in 3.8.
I can submit a 3.8 asciidoc equivalent.

There is room for improvement but kept it very simple for now.