### PR TITLE
Fix installation link targets

### DIFF
--- a/solutions/observability/apm/apm-server/binary.md
+++ b/solutions/observability/apm/apm-server/binary.md
@@ -21,7 +21,8 @@ You’ll need:
 * **{{es}}** for storing and indexing data.
 * **{{kib}}** for visualizing with the Applications UI.
 
-We recommend you use the same version of {{es}}, {{kib}}, and APM Server. See [Installing the {{stack}}](/get-started/the-stack.md) for more information about installing these products.
+We recommend you use the same version of {{es}}, {{kib}}, and APM Server.
+For more information about installing these products, refer to [](/deploy-manage/deploy.md).
 
 :::{image} /solutions/images/observability-apm-architecture-diy.png
 :alt: Install Elastic APM yourself
@@ -30,7 +31,8 @@ We recommend you use the same version of {{es}}, {{kib}}, and APM Server. See [I
 ## Step 1: Install [apm-installing]
 
 ::::{note}
-**Before you begin**: If you haven’t installed the {{stack}}, do that now. See [Learn how to install the {{stack}} on your own hardware](/get-started/the-stack.md).
+**Before you begin**: If you haven’t installed the {{stack}}, do that now.
+Refer to [](/deploy-manage/deploy.md).
 ::::
 
 To download and install APM Server, use the commands below that work with your system. If you use `apt` or `yum`, you can [install APM Server from our repositories](#apm-setup-repositories) to update to the newest version more easily.

--- a/solutions/observability/apm/apm-server/fleet-managed.md
+++ b/solutions/observability/apm/apm-server/fleet-managed.md
@@ -22,7 +22,7 @@ This guide will explain how to set up and configure a Fleet-managed APM Server.
 
 You need {{es}} for storing and searching your data, and {{kib}} for visualizing and managing it. When setting these components up, you need:
 
-* {{es}} cluster and {{kib}} (version 9.0) with a basic license or higher. [Learn how to install the {{stack}} on your own hardware](/get-started/the-stack.md).
+* {{es}} cluster and {{kib}} (version 9.0) with a basic license or higher. Refer to [](/deploy-manage/deploy.md).
 * Secure, encrypted connection between {{kib}} and {{es}}. For more information, refer to [](/deploy-manage/security/self-setup.md).
 * Internet connection for {{kib}} to download integration packages from the {{package-registry}}. Make sure the {{kib}} server can connect to `https://epr.elastic.co` on port `443`. If your environment has network traffic restrictions, there are ways to work around this requirement. See [Air-gapped environments](/reference/fleet/air-gapped.md) for more information.
 * {{kib}} user with `All` privileges on {{fleet}} and {{integrations}}. Since many Integrations assets are shared across spaces, users need the {{kib}} privileges in all spaces.

--- a/solutions/security/get-started/elastic-security-requirements.md
+++ b/solutions/security/get-started/elastic-security-requirements.md
@@ -25,7 +25,7 @@ stack:
 
 {{ecloud}} offers all of the features of {{es}}, {{kib}}, and {{elastic-sec}} as a hosted service available on AWS, GCP, and Azure. To get started, sign up for a [free {{ecloud}} trial](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 
-For information about installing and managing the {{stack}} yourself, see [Installing the {{stack}}](/get-started/the-stack.md).
+For information about installing and managing the {{stack}} yourself, refer to [](/deploy-manage/deploy/self-managed.md).
 
 ### Node role requirements [node-role-requirements]
 


### PR DESCRIPTION
This PR updates links that were targeting https://www.elastic.co/docs/get-started/the-stack for installation details. There are better targets within https://www.elastic.co/docs/deploy-manage