### PR TITLE
Update alerts/cases: Watcher is unavailable on Serverless

### DIFF
--- a/explore-analyze/alerts-cases.md
+++ b/explore-analyze/alerts-cases.md
@@ -35,6 +35,8 @@ If you have a planned outage, maintenance windows prevent rules from generating 
 
 By combining these tools, Elasticsearch and Kibana enable incident response workflows, helping teams to detect, investigate, and resolve issues efficiently.
 
-## Watcher {applies_to}`serverless: unavailable`
+## Watcher
+```{applies_to}
+serverless: unavailable
 
 You can use Watcher for alerting and monitoring specific conditions in your data. It enables you to define rules and take automated actions when certain criteria are met. Watcher is a powerful alerting tool for custom use cases and more complex alerting logic. It allows advanced scripting using Painless to define complex conditions and transformations.


### PR DESCRIPTION
This adds a "Serverless: unavailable" tag right over [here](https://www.elastic.co/docs/explore-analyze/alerts-cases#watcher).

This was discussed and confirmed over a Slack chat with Maggie Ghamry and Matt Culbreth.