### PR TITLE
Update cases page; Watcher unavailable on Serverless

### DIFF
--- a/explore-analyze/alerts-cases.md
+++ b/explore-analyze/alerts-cases.md
@@ -36,5 +36,8 @@ If you have a planned outage, maintenance windows prevent rules from generating 
 By combining these tools, Elasticsearch and Kibana enable incident response workflows, helping teams to detect, investigate, and resolve issues efficiently.
 
 ## Watcher
+```{applies_to}
+serverless: unavailable
+```
 
 You can use Watcher for alerting and monitoring specific conditions in your data. It enables you to define rules and take automated actions when certain criteria are met. Watcher is a powerful alerting tool for custom use cases and more complex alerting logic. It allows advanced scripting using Painless to define complex conditions and transformations.


### PR DESCRIPTION
This updates the Watcher section of the [Alerts and cases](https://www.elastic.co/docs/explore-analyze/alerts-cases#watcher) page. 

@mattc58, I didn't add a sentence since we have section-level `applies_to` tagging that will serve our purpose:

<img width="714" height="216" alt="watcher" src="https://github.com/user-attachments/assets/8573aded-c043-4bee-acbb-adf3cc70ce67" />
