### PR TITLE
Delete MCP server API and A2A task examples

### DIFF
--- a/solutions/search/agent-builder/kibana-api.md
+++ b/solutions/search/agent-builder/kibana-api.md
@@ -679,7 +679,7 @@ curl -X DELETE "https://${KIBANA_URL}/api/agent_builder/conversations/{conversat
 
 ### Get A2A agent card configuration
 
-:::{note}
+:::{important}
 You shouldn't use the REST APIs to interact with the A2A endpoint, apart from getting the A2A agent card configuration.
 Refer to [](a2a-server.md) for more information about using the A2A protocol. 
 :::
@@ -707,9 +707,6 @@ curl -X GET "https://${KIBANA_URL}/api/agent_builder/a2a/{agentId}.json" \
 :::
 
 ::::
-
-
-
 
 
 ## API reference


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content-internal/issues/446

GET agent card is the only relevant endpoint that you should be using the REST API to hit for MCP and A2A. 



This was confusing users.


related PR in Kibana for the generated API ref: https://github.com/elastic/kibana/pull/241856/