### PR TITLE
Add initial docs for `bfloat16` and `on_disk_rescore`  for dense vectors

### DIFF
--- a/deploy-manage/production-guidance/optimize-performance/approximate-knn-search.md
+++ b/deploy-manage/production-guidance/optimize-performance/approximate-knn-search.md
@@ -71,10 +71,19 @@ Here are estimates for different element types and quantization levels:
 
 If you're using HNSW, the graph must also be in memory. To estimate the required bytes, use the following formula below. The default value for the HNSW `m` parameter is `16`.
 
+For `element_type: float`:
 ```{math}
 \begin{align*}
 estimated\ bytes &= num\_vectors \times 4 \times m \\
 &= num\_vectors \times 4 \times 16
+\end{align*}
+```
+
+For `element_type: bfloat16`:
+```{math}
+\begin{align*}
+estimated\ bytes &= num\_vectors \times 2 \times m \\
+&= num\_vectors \times 2 \times 16
 \end{align*}
 ```
 

--- a/solutions/search/vector/knn.md
+++ b/solutions/search/vector/knn.md
@@ -327,8 +327,7 @@ POST quantized-image-index/_search
 ```
 
 ### BFloat16 vector encoding [knn-search-bfloat16]
-```
-{applies_to}
+```{applies_to}
 stack: ga 9.3
 ```
 Instead of storing raw vectors as 4-byte values, you can use `element_type: bfloat16` to store each dimension as a 2-byte value. This can be useful if your indexed vectors are at bfloat16 precision already, or if you want to reduce the disk space required to store vector data. When this element type is used, {{es}} automatically rounds 4-byte float values to 2-byte bfloat16 values when indexing vectors.


### PR DESCRIPTION
Add docs for bfloat16 and on_disk_rescore for changes in https://github.com/elastic/elasticsearch/pull/138492