### PR TITLE
Update prepare-to-upgrade.md to add ECH applies_to

### DIFF
--- a/deploy-manage/upgrade/prepare-to-upgrade.md
+++ b/deploy-manage/upgrade/prepare-to-upgrade.md
@@ -2,6 +2,8 @@
 navigation_title: Preparation steps
 applies_to:
   stack: ga
+  deployment:
+    ess:
 products:
   - id: kibana
   - id: cloud-enterprise


### PR DESCRIPTION
The webpage [Upgrade on Elastic Cloud Hosted (ECH)](https://www.elastic.co/docs/deploy-manage/upgrade/deployment-or-cluster/upgrade-on-ech) is for ECH, but the first thing it says to do is go to `Prepare to upgrade` which has a `applies_to` for only Stack only, but its linked from an `ECH` webpage. It would make more sense if the `Prepare to upgrade` also applies to `ECH`. I followed formatting compared to other webpages.