### PR TITLE
Update tags for native realm authentication

### DIFF
--- a/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
@@ -6,11 +6,8 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/change-passwords-native-users.html
   - https://www.elastic.co/guide/en/kibana/current/tutorial-secure-access-to-kibana.html
 applies_to:
-  deployment:
-    self: all
-    ess: all
-    ece: all
-    eck: all
+  stack: ga
+  serverless: unavailable
 products:
   - id: elasticsearch
   - id: cloud-kubernetes


### PR DESCRIPTION
According to the [Compare Elastic Cloud Hosted and Serverless](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/differences-from-other-elasticsearch-offerings) page that compares various capabilities, the native realm authentication capability is not available in Serverless. 

Related to https://github.com/elastic/docs-content/issues/1198