### PR TITLE
Remove another brittle link from ESQL search overview page

### DIFF
--- a/solutions/search/esql-for-search.md
+++ b/solutions/search/esql-for-search.md
@@ -138,7 +138,7 @@ The [`FORK`](elasticsearch://reference/query-languages/esql/commands/fork.md) an
 
 `FORK` creates multiple execution branches that operate on the same input data. `FUSE` then combines and scores the results from these branches. Together, these commands allow you to execute different search strategies (such as lexical and semantic searches) in parallel and merge their results with proper relevance scoring.
 
-Refer to [hybrid search with semantic_text](hybrid-semantic-text.md) for an example or follow the [tutorial](elasticsearch://reference/query-languages/esql/esql-search-tutorial.md#step-5-semantic-search-and-hybrid-search).
+Refer to [hybrid search with semantic_text](hybrid-semantic-text.md) for an example or follow the [tutorial](elasticsearch://reference/query-languages/esql/esql-search-tutorial.md).
 
 ### Text generation with `COMPLETION`
 


### PR DESCRIPTION
I missed this brittle link in https://github.com/elastic/docs-content/pull/3975