### PR TITLE
Elastic Agent: fix incorrect syntax in dynamic input example.

### DIFF
--- a/reference/fleet/dynamic-input-configuration.md
+++ b/reference/fleet/dynamic-input-configuration.md
@@ -202,7 +202,7 @@ inputs:
       - add_fields:
           fields:
             platform: ${host.platform}
-          to: host
+          target: host
         condition: ${host.platform} != 'windows'
 ```
 


### PR DESCRIPTION
An example configuration incorrectly used `to` instead of `target` which is invalid and will not run.