### PR TITLE
Reorder ECS-to-OTel fields in description

### DIFF
--- a/solutions/observability/streams/wired-streams.md
+++ b/solutions/observability/streams/wired-streams.md
@@ -22,7 +22,7 @@ For more on wired streams, refer to:
 Wired streams store and process data in a normalized OpenTelemetry (OTel)–compatible format. This format aligns Elastic Common Schema (ECS) fields with OTel semantic conventions so all data is consistently structured and OTTL-expressible.
 
 When data is ingested into a wired stream, it’s automatically translated into this normalized format:
-- Standard ECS documents are converted to OTel fields (`message → body.text`, `severity_text → log.level`, `host.name → resource.attributes.host.name`, and so on).
+- Standard ECS documents are converted to OTel fields (`message → body.text`, `log.level → severity_text`, `host.name → resource.attributes.host.name`, and so on).
 - Custom fields are stored under `attributes.*`.
 
 To preserve backward-compatible querying, Streams creates aliases that mirror existing `logs-*.otel-*` data streams behavior. This allows queries to use either ECS or OTel field names interchangeably.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->
`log.level` is the ECS field and `severity_text` is the OTel semantic convention counterpart

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

