### PR TITLE
FIx the navigation title on the Elastic Agent built-in alerts page

### DIFF
--- a/reference/fleet/alert-templates.md
+++ b/reference/fleet/alert-templates.md
@@ -5,7 +5,7 @@ applies_to:
 products:
   - id: fleet
   - id: elastic-agent
-navigation_title: Built-in alerts and templates
+navigation_title: Elastic Agent built-in alerts
 ---
 
 # Elastic Agent built-in alerts [built-in-alerts]


### PR DESCRIPTION
FIx the navigation title.
Relates to https://github.com/elastic/docs-content/pull/4072
