### PR TITLE
Update links for agentless and agent-based deployment

### DIFF
--- a/solutions/security/cloud/get-started-with-cspm-for-azure.md
+++ b/solutions/security/cloud/get-started-with-cspm-for-azure.md
@@ -33,8 +33,8 @@ You can set up CSPM for Azure by enrolling an Azure organization (management gro
 
 The following deployment technologies are available: agentless and agent-based. 
 
-* [Agentless deployment](/solutions/security/cloud/get-started-with-cspm-for-azure.md#cad-azure-agentless) allows you to collect cloud posture data without having to manage the deployment of an agent in your cloud. 
-* [Agent-based deployment](/solutions/security/cloud/get-started-with-cspm-for-azure.md#cad-azure-agent-based) requires you to deploy and manage an agent in the cloud account you want to monitor.
+* [Agentless deployment](/solutions/security/cloud/get-started-with-cspm-for-azure.md#cspm-azure-agentless) allows you to collect cloud posture data without having to manage the deployment of an agent in your cloud. 
+* [Agent-based deployment](/solutions/security/cloud/get-started-with-cspm-for-azure.md#cspm-azure-agent-based) requires you to deploy and manage an agent in the cloud account you want to monitor.
 
 
 ## Agentless deployment [cspm-azure-agentless]


### PR DESCRIPTION
As following the same principle below described in https://github.com/elastic/docs-content/pull/4150:

> I think these are supposed to keep users on the same page since these sections are visibly there too. 

changing the link to the same doc rather than pointing the different page

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--


