### PR TITLE
Document fair usage limit for free trial accounts

### DIFF
--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -75,17 +75,22 @@ To track your token consumption:
 1. Navigate to [**Billing and subscriptions > Usage**](https://cloud.elastic.co/billing/usage) in the {{ecloud}} Console
 2. Look for line items where the **Billing dimension** is set to "Inference"
 
+### Fair usage during free trial
+
+Accounts in the free trial period are subject to token limits that are considered "fair usage". Access to some models may be paused temporarily if this limit is exceeded.
+
+Fair usage limits while account is in free trial:
+- **Elastic Managed LLM:** 100 million input tokens in 24h or 5 million output tokens in 24h
+- **ELSER**: 1 billion tokens in 24h
+
 ## Rate limits
 
 The service enforces rate limits on an ongoing basis. Exceeding a limit will result in HTTP 429 responses from the server until the sliding window moves on further and parts of the limit resets.
-
-Accounts in the free trial period are subject to token limits that are considered "fair usage". Access to some models may be paused temporarily if this limit is exceeded.
 
 ### Elastic Managed LLM
 
 - 50 requests per minute
 - No rate limit on tokens
-- Fair usage limit while account is in free trial: 100 million input tokens in 24h or 5 million output tokens in 24h
 
 ### ELSER (Sparse Embeddings)
 
@@ -95,10 +100,8 @@ We limit on both requests per minute and tokens per minute (whichever limit is r
 
 - 6,000 request per minute
 - 6,000,000 tokens per minute
-- Fair usage limit while account is in free trial: 1 billion tokens in 24h
 
 #### Search
 
 - 6,000 requests per minute
 - 600,000 tokens per minute
-- Fair usage limit while account is in free trial: 1 billion tokens in 24h


### PR DESCRIPTION
## Summary

This PR adds some bullets about "fair usage" limits of the Elastic Inference Service for accounts that are currently in their free trial period. The Search Inference team monitors activity and gets alerted if an account exceeds the limit in a 24h period. The [follow up action](https://docs.elastic.dev/search-team/teams/inference/eis/runbooks/high-token-usage-by-free-trial-accounts) may involve pausing access for the account if it is deemed to be abusing the free trial.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

