### PR TITLE
Document fair EIS usage limits in free trial

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/create-an-organization.md
+++ b/deploy-manage/deploy/elastic-cloud/create-an-organization.md
@@ -76,6 +76,13 @@ For more information, check the [{{ech}} documentation](cloud-hosted.md).
 * Scaling is limited for {{serverless-short}} projects in trials. Failures might occur if the workload requires memory or compute beyond what the above search power and search boost window setting limits can provide.
 * We monitor token usage per account for the Elastic Managed LLM. If an account uses over one million tokens in 24 hours, we will inform you and then disable access to the LLM. This is in accordance with our fair use policy for trials. 
 
+**Inference tokens**
+
+* You can use these models hosted by the Elastic {{infer-cap}} Service with the following limits:
+  * **Elastic Managed LLM:** 100 million input tokens in a 24-hour period or 5 million output tokens in a 24-hour period
+  * **ELSER**: 1 billion tokens in a 24-hour period
+* Access to some models may be paused temporarily if either of these limits are exceeded
+
 **Remove limitations**
 
 Subscribe to [{{ecloud}}](/deploy-manage/cloud-organization/billing/add-billing-details.md) for the following benefits:

--- a/serverless/pages/sign-up.asciidoc
+++ b/serverless/pages/sign-up.asciidoc
@@ -57,10 +57,7 @@ To learn more about Elastic Cloud Hosted, check our https://www.elastic.co/guide
 
 **Inference tokens**
 
-* You can use these models hosted by the Elastic {infer-cap} Service with the following limits:
-  * **Elastic Managed LLM:** 100 million input tokens in a 24-hour period or 5 million output tokens in a 24-hour period
-  * **ELSER**: 1 billion tokens in a 24-hour period
-* Access to some models may be paused temporarily if either of these limits are exceeded
+* TBD
 
 **Remove limitations**
 

--- a/serverless/pages/sign-up.asciidoc
+++ b/serverless/pages/sign-up.asciidoc
@@ -55,6 +55,10 @@ To learn more about Elastic Cloud Hosted, check our https://www.elastic.co/guide
 * Search Boost Window is limited to 7 days. This setting only exists in {es-serverless} projects
 * Scaling is limited for serverless projects in trials. Failures might occur if the workload requires memory or compute beyond what the above search power and search boost window setting limits can provide.
 
+**Inference tokens**
+
+* TBD
+
 **Remove limitations**
 
 Subscribe to https://www.elastic.co/guide/en/cloud/current/ec-billing-details.html[Elastic Cloud] for the following benefits:

--- a/serverless/pages/sign-up.asciidoc
+++ b/serverless/pages/sign-up.asciidoc
@@ -55,10 +55,6 @@ To learn more about Elastic Cloud Hosted, check our https://www.elastic.co/guide
 * Search Boost Window is limited to 7 days. This setting only exists in {es-serverless} projects
 * Scaling is limited for serverless projects in trials. Failures might occur if the workload requires memory or compute beyond what the above search power and search boost window setting limits can provide.
 
-**Inference tokens**
-
-* TBD
-
 **Remove limitations**
 
 Subscribe to https://www.elastic.co/guide/en/cloud/current/ec-billing-details.html[Elastic Cloud] for the following benefits:

--- a/serverless/pages/sign-up.asciidoc
+++ b/serverless/pages/sign-up.asciidoc
@@ -57,7 +57,10 @@ To learn more about Elastic Cloud Hosted, check our https://www.elastic.co/guide
 
 **Inference tokens**
 
-* TBD
+* You can use these models hosted by the Elastic {infer-cap} Service with the following limits:
+  * **Elastic Managed LLM:** 100 million input tokens in a 24-hour period or 5 million output tokens in a 24-hour period
+  * **ELSER**: 1 billion tokens in a 24-hour period
+* Access to some models may be paused temporarily if either of these limits are exceeded
 
 **Remove limitations**
 


### PR DESCRIPTION
## Summary
https://github.com/elastic/search-team/issues/10695

This PR adds some bullets about "fair usage" limits of the Elastic Inference Service for accounts that are currently in their free trial period. The Search Inference team monitors activity and gets alerted if an account exceeds the limit in a 24h period. The [follow up action](https://docs.elastic.dev/search-team/teams/inference/eis/runbooks/high-token-usage-by-free-trial-accounts) may involve pausing access for the account if it is deemed to be abusing the free trial.

We're listing the bullets under the general free trial limitations page.

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

