### PR TITLE
Fix link to readiness port docs

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/readiness-probe.md
+++ b/deploy-manage/deploy/cloud-on-k8s/readiness-probe.md
@@ -48,6 +48,6 @@ Updating this value requires restarting the Pods.
 
 ## {{es}} versions 8.2.0 and later [k8s_elasticsearch_versions_8_2_0_and_later]
 
-We do not recommend overriding the default readiness probe on {{es}} 8.2.0 and later. ECK configures a socket based readiness probe using the {{es}} [readiness port feature](elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#tcp-readiness-port) which is not influenced by the load on the {{es}} cluster.
+We do not recommend overriding the default readiness probe on {{es}} 8.2.0 and later. ECK configures a socket-based readiness probe using the {{es}} [readiness port feature](elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#tcp-readiness-port) which is not influenced by the load on the {{es}} cluster.
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
- Fixes https://github.com/elastic/docs-content/issues/4147 - points to the right spot in the docs

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

