### PR TITLE
fix the incorrect configuration in docker guide

### DIFF
--- a/solutions/observability/get-started/opentelemetry/quickstart/self-managed/docker.md
+++ b/solutions/observability/get-started/opentelemetry/quickstart/self-managed/docker.md
@@ -48,7 +48,7 @@ DOCKER_SOCK=/var/run/docker.sock
 ELASTIC_AGENT_OTEL=true
 COLLECTOR_CONTRIB_IMAGE=elastic/elastic-agent:{{version.edot_collector}}
 ELASTIC_API_KEY=<your_api_key_here>
-ELASTIC_ENDPOINT=<your_endpoint_here>
+ELASTIC_OTLP_ENDPOINT=<your_endpoint_here>
 OTEL_COLLECTOR_CONFIG=/path/to/otel-collector-config.yml
    ```
 ::::
@@ -78,7 +78,7 @@ services:
       - HOST_FILESYSTEM
       - ELASTIC_AGENT_OTEL
       - ELASTIC_API_KEY
-      - ELASTIC_ENDPOINT
+      - ELASTIC_OTLP_ENDPOINT
       - STORAGE_DIR=/usr/share/elastic-agent
 ```
 ::::


### PR DESCRIPTION
## Summary
+ OTel collector config references the OTLP endpoint correctly, while the docs seem to refer to older endpoint

<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

