### PR TITLE
Update to correct port number for firewall troubleshooting

### DIFF
--- a/deploy-manage/monitor/autoops/autoops-sm-troubleshoot-firewalls.md
+++ b/deploy-manage/monitor/autoops/autoops-sm-troubleshoot-firewalls.md
@@ -14,6 +14,16 @@ products:
 
 If you are running into issues connecting your cluster to AutoOps, a corporate firewall might be blocking {{agent}}.
 
+Complete the steps on this page to test your setup and fix this issue.
+
+## Confirm that {{agent}} has appropriate access
+
+If your organization uses firewalls, you have to [give {{agent}} access to required ports and URLs](../autoops/cc-connect-self-managed-to-autoops.md#firewall-allowlist) during setup. 
+
+Ensure that you have allowed {{agent}} the required level of access. If the problem persists, move on to the next section.
+
+## Test {{agent}}'s connection with your system
+
 There are [three main components](/deploy-manage/monitor/autoops/cc-autoops-as-cloud-connected.md#how-your-self-managed-cluster-connects-to-autoops) of {{agent}}'s connection with your system:
 
 :::{include} /deploy-manage/monitor/_snippets/autoops-cc-components.md
@@ -25,7 +35,7 @@ The following subsections describe how to test each of these components to find 
 Run the following tests within the context of your execution environment. That is, if your chosen installation method is Kubernetes, run the commands from within the pod; for Docker, run the commands from within the container, and so on. 
 :::
 
-## 1. Test {{agent}}'s connection with your cluster
+### 1. Test {{agent}}'s connection with your cluster
 If there is an issue with the first component, {{agent}} cannot connect to your cluster. 
 
 To test if your organization is not allowing this connection, run the following command depending on your chosen authentication method:
@@ -84,10 +94,10 @@ If you do not receive a similar response, your system returns an error indicatin
 | Your username or password is incorrect | - Recheck for typos. <br> - Ensure that your provided user has the [necessary privileges](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#configure-agent). We do not recommend providing a privileged superuser like `elastic` for this purpose.|
 | You are providing both the API key and username/password | Choose one type of authentication only. |
 | A proxy is blocking communication with your {{es}} cluster | You might have to [configure `NO_PROXY`](/reference/fleet/host-proxy-env-vars.md). |
-| You are using a custom SSL/TLS configuration with {{es}} | Disable SSL/TLS verification so that your system trusts all certificates. We do not recommend disabling verification in production environments. <br><br> If you are using API key authentication, run the following command: <br><br>`curl -XGET --insecure -i $AUTOOPS_ES_URL \ -H "Authorization: ApiKey $AUTOOPS_ES_API_KEY"`. <br><br> If you are using username/password authentication, run the following command: <br><br> `curl -XGET --insecure -i $AUTOOPS_ES_URL \ -u $AUTOOPS_ES_USERNAME` <br><br> If the issue is resolved, you need to configure your custom SSL/TLS settings with {{agent}}. If the issue persists, contact [Elastic support](https://support.elastic.co/).| 
+| You are using a custom SSL/TLS configuration with {{es}} | Disable SSL/TLS verification so that your system trusts all certificates. We do not recommend disabling verification in production environments. <br><br> If you are using API key authentication, run the following command: <br><br>`curl -XGET --insecure -i $AUTOOPS_ES_URL \ -H "Authorization: ApiKey $AUTOOPS_ES_API_KEY"`. <br><br> If you are using username/password authentication, run the following command: <br><br> `curl -XGET --insecure -i $AUTOOPS_ES_URL \ -u $AUTOOPS_ES_USERNAME` <br><br> If the issue is resolved, you need to [configure {{agent}} with your custom SSL/TLS certificate](/deploy-manage/monitor/autoops/autoops-sm-custom-certification.md). If the issue persists, contact [Elastic support](https://support.elastic.co/).| 
 | You are connecting a local development cluster using Docker without specifying `--network host` | - Make sure you are following all the steps to [connect your local development cluster to AutoOps](/deploy-manage/monitor/autoops/cc-connect-local-dev-to-autoops.md#connect-your-local-development-cluster-to-autoops). <br> - In the [Install agent](/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md#install-agent) step, make sure you are replacing `docker run -d \` with `docker run -d --network host \`. |
 
-## 2. Test your cluster's registration with {{ecloud}} 
+### 2. Test your cluster's registration with {{ecloud}} 
 
 If there is an issue with the second component, the agent stops working and your logs might show the following error: 
 
@@ -118,7 +128,7 @@ If you do not receive a similar response, configure your HTTP proxy to allow it 
 If you are using Docker, you might need to complete this configuration directly using the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 :::
 
-## 3. Test if {{agent}} is able to send metrics
+### 3. Test if {{agent}} is able to send metrics
 
 If there is an issue with the third component, the agent attempts to establish the connection and your logs might show the following error: 
     

--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -221,6 +221,7 @@ If you manually assign privileges, you won't be able to allow {{agent}} to acces
   :::{include} ../_snippets/autoops-cc-regions.md
   :::
 
+$$$firewall-allowlist$$$
 :::{include} ../_snippets/autoops-allowlist-port-and-urls.md
 :::
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
This PR fixes the port number in codeblocks on the Troubleshoot firewalls blocking Elastic Agent page.
Closes https://github.com/elastic/opex-product/issues/696

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

