### PR TITLE
Remove us-east-1 from the autoops regions table.

### DIFF
--- a/deploy-manage/monitor/_snippets/autoops-cc-regions.md
+++ b/deploy-manage/monitor/_snippets/autoops-cc-regions.md
@@ -1,6 +1,5 @@
 | Region | Name |
 | --- | --- | 
-| us-east-1 | US East (N. Virginia) |
 | us-east-2 | US East (Ohio) |
 | us-west-2 | US West (Oregon) |
 | eu-west-1 | EU (Ireland) |


### PR DESCRIPTION
## Summary

Remove `us-east-1` from the autoops regions table.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  

Closes https://github.com/elastic/opex-product/issues/703
