### PR TITLE
Add status page limitation to ECH limitation general page

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -155,4 +155,4 @@ To make a seamless migration, after restoring from a snapshot there are some add
 
 ## Service status [ec-service-status]
 
-* To ensure we can continue evolving our status page to best serve our customers, we cannot guarantee consistency of API implementation or component API identifiers. However, we communicate changes which might impact status page subscribers on a best-effort basis. Review [Service status](../../cloud-organization/service-status.md) for more guidance.
+* To ensure we can continue evolving our status page to best serve our customers, we cannot guarantee consistency of API implementation or component API identifiers. However, we communicate changes which might impact status page subscribers on a best-effort basis. Review [Service status](../../cloud-organization/service-status.md#service-status-support-limitations) for more guidance.

--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -27,6 +27,7 @@ When using {{ecloud}}, there are some limitations you should be aware of:
 * [Regions and Availability Zones](#ec-regions-and-availability-zone)
 * [Node count and size](#ec-node-count-size)
 * [Repository analysis API is unavailable in {{ecloud}}](#ec-repository-analyis-unavailable)
+* [Service status](#ec-service-status)
 
 For limitations related to logging and monitoring, check the [Restrictions and limitations](../../monitor/stack-monitoring/ece-ech-stack-monitoring.md#restrictions-monitoring) section of the logging and monitoring page.
 
@@ -151,3 +152,7 @@ To make a seamless migration, after restoring from a snapshot there are some add
 ## Repository analysis API is unavailable in {{ecloud}} [ec-repository-analyis-unavailable]
 
 * The {{es}} [Repository analysis API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-snapshot-repository-analyze) is not available in {{ecloud}} due to deployments defaulting to having [operator privileges](../../users-roles/cluster-or-deployment-auth/operator-privileges.md) enabled that prevent non-operator privileged users from using it along with a number of other APIs.
+
+## Service status [ec-service-status]
+
+* To ensure we can continue evolving our status page to best serve our customers, we cannot guarantee consistency of API implementation or component API identifiers. However, we communicate changes which might impact status page subscribers on a best-effort basis. Review [Service status](../../cloud-organization/service-status.md) for more guidance.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

In https://github.com/elastic/docs-content/pull/4287, we added a limitation to service status doc page. 

In support, per some [internal discussion](https://elastic.slack.com/archives/C03T1DM0H9U/p1765933782666829?thread_ts=1764636358.084069&cid=C03T1DM0H9U), we agreed that we should also add this to the generic limitation page for ECH, which is https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.


## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

## Preview / View

Before PR merge: [deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/4450/deploy-manage/deploy/elastic-cloud/restrictions-known-problems)

After PR merge: https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/restrictions-known-problems

---

cc @Dariaus999 @geekpete 
