### PR TITLE
Fix tags for Preferred data tier

### DIFF
--- a/troubleshoot/elasticsearch/add-tier.md
+++ b/troubleshoot/elasticsearch/add-tier.md
@@ -4,11 +4,6 @@ mapped_pages:
   - https://www.elastic.co/guide/en/elasticsearch/reference/current/add-tier.html
 applies_to:
   stack:
-  deployment:
-    eck:
-    ess:
-    ece:
-    self:
 products:
   - id: elasticsearch
 ---
@@ -25,10 +20,9 @@ In order to allow indices to be allocated, follow these steps to add the [data t
 
 :::::::{tab-set}
 
-::::::{tab-item} {{ech}}
+::::::{tab-item} {{kib}}
 In order to get the shards assigned we need enable a new tier in the deployment.
 
-**Use {{kib}}**
 
 1. Log in to the [{{ecloud}} console](https://cloud.elastic.co?page=docs&placement=docs-body).
 2. On the **Hosted deployments** panel, click the name of your deployment.
@@ -70,7 +64,7 @@ In order to get the shards assigned we need enable a new tier in the deployment.
 8. Navigate to the bottom of the page and click the **Save** button.
 ::::::
 
-::::::{tab-item} Self-managed
+::::::{tab-item} API
 In order to get the shards assigned you can add more nodes to your {{es}} cluster and assign the index’s target tier [node role](../../manage-data/lifecycle/index-lifecycle-management/migrate-index-allocation-filters-to-node-roles.md#assign-data-tier) to the new nodes.
 
 To determine which tier an index requires for assignment, use the [get index setting](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-settings) API to retrieve the configured value for the `index.routing.allocation.include._tier_preference` setting:


### PR DESCRIPTION
## Summary

part of #4117

Replacing all the tags on the page with stack as it applies to all deployments. The tab titles were also wrong, they should be split as UI vs API instructions.


## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

