### PR TITLE
Remove unhelpful link from cluster restart info

### DIFF
--- a/deploy-manage/maintenance/start-stop-services/full-cluster-restart-rolling-restart-procedures.md
+++ b/deploy-manage/maintenance/start-stop-services/full-cluster-restart-rolling-restart-procedures.md
@@ -10,7 +10,7 @@ products:
 
 # Full Cluster restart and rolling restart procedures [restart-cluster]
 
-There may be [situations where you want to perform a full-cluster restart](../../security/secure-cluster-communications.md) or a rolling restart. In the case of [full-cluster restart](#restart-cluster-full), you shut down and restart all the nodes in the cluster while in the case of [rolling restart](#restart-cluster-rolling), you shut down only one node at a time, so the service remains uninterrupted.
+There may be situations where you want to perform a full-cluster restart, and others where you might want to perform a rolling restart. In the case of [full-cluster restart](#restart-cluster-full), you shut down and restart all the nodes in the cluster while in the case of [rolling restart](#restart-cluster-rolling), you shut down only one node at a time, so the service remains uninterrupted.
 
 ::::{warning}
 Nodes exceeding the low watermark threshold will be slow to restart. Reduce the disk usage below the [low watermark](elasticsearch://reference/elasticsearch/configuration-reference/cluster-level-shard-allocation-routing-settings.md#cluster-routing-watermark-low) before restarting nodes.


### PR DESCRIPTION

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Fixes https://github.com/elastic/docs-content/issues/4519

The link was to one hypothetical case where you might want to do a full cluster restart. however, the link was to a step in the manual security setup process. manually setting up security is an edge case (we [automated this](https://www.elastic.co/docs/deploy-manage/security/self-setup#automatic-configuration)), and there are likely other full restart cases, so we shouldn't hint that there is just one.

also adjusted grammar to avoid implying that the two restart procedure names are synonyms (as it kind of did before the edit)

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [X] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

