### PR TITLE
Fix availability note for logsdb index mode

### DIFF
--- a/manage-data/data-store/data-streams/logs-data-stream.md
+++ b/manage-data/data-store/data-streams/logs-data-stream.md
@@ -10,15 +10,11 @@ products:
 
 # Logs data stream [logs-data-stream]
 
-::::{important}
-The {{es}} `logsdb` index mode is generally available in Elastic Cloud Hosted and self-managed Elasticsearch as of version 8.17, and is enabled by default for logs in [{{serverless-full}}](https://www.elastic.co/elasticsearch/serverless).
-::::
-
-
 A logs data stream is a data stream type that stores log data more efficiently.
 
 In benchmarks, log data stored in a logs data stream used ~2.5 times less disk space than a regular data stream, at a small (10-20%) penalty in indexing performance. The exact impact varies by data set and Elasticsearch version.
 
+The {{es}} `logsdb` index mode is enabled by default for logs in [{{serverless-full}}](https://www.elastic.co/elasticsearch/serverless).
 
 ## Create a logs data stream [how-to-use-logsds]
 


### PR DESCRIPTION


<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary

fixes https://github.com/elastic/docs-content/issues/4537

availability note specified ECH/self-managed, which led to people being confused about whether it's available in ECE/ECK

ultimately, only the stack version matters for ech/self-managed, but we can use applies tags for this / it rolled out before 9 so we don't need this note here

so I pulled out the still relevant info (is on by default in serverless) and removed the note

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

