### PR TITLE
[ResponseOps][Alerting][9.3 & Serverless]: Alert tagging for Stack and Observability

### DIFF
--- a/explore-analyze/alerts-cases/alerts/view-alerts.md
+++ b/explore-analyze/alerts-cases/alerts/view-alerts.md
@@ -105,7 +105,7 @@ To permanently suppress an alert's actions, open the actions menu for the approp
 To affect the behavior of the rule rather than individual alerts, check out [Snooze and disable rules](create-manage-rules.md#controlling-rules).
 ::::
 
-## Apply and filter tags for Stack alerts [tag-alerts]
+## Apply and filter alert tags [tag-alerts]
 
 ```{applies_to}
 stack: ga 9.3+

--- a/solutions/observability/incident-management/view-alerts.md
+++ b/solutions/observability/incident-management/view-alerts.md
@@ -133,7 +133,7 @@ To permanently suppress an alert's actions, open the actions menu for the approp
 To affect the behavior of the rule rather than individual alerts, check out [Snooze and disable rules](create-manage-rules.md#observability-create-manage-rules-snooze-and-disable-rules).
 ::::
 
-## Apply and filter tags for {{observability}} alerts [observability-view-alerts-tag-alerts]
+## Apply and filter alert tags [observability-view-alerts-tag-alerts]
 
 ```{applies_to}
 stack: ga 9.3+

--- a/solutions/security/detect-and-alert/manage-detection-alerts.md
+++ b/solutions/security/detect-and-alert/manage-detection-alerts.md
@@ -208,7 +208,7 @@ You can specify a reason for closing an alert by selecting one of the following 
 
 When you select a closing reason, the alert document is populated with a new field called `kibana.alert.workflow_reason`. You can use this field to filter and sort alerts on the **Alerts** page. If you later reopen the alert, the field is removed from the document.
 
-### Apply and filter tags for {{elastic-sec}} alerts [apply-alert-tags]
+### Apply and filter alert tags [apply-alert-tags]
 
 Use alert tags to organize related alerts into categories that you can filter and group. For example, use the `False Positive` alert tag to label a group of alerts as false positives. Then, search for them by entering the `kibana.alert.workflow_tags : "False Positive"` query into the KQL bar. Alternatively, use the Alert table’s [drop-down filters](/solutions/security/detect-and-alert/manage-detection-alerts.md#drop-down-filter-controls) to filter for tagged alerts.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Fixes https://github.com/elastic/docs-content/issues/4208 by documenting how to add and remove tags from individual alerts and multiple ones. 
- Stack docs: https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/4624/explore-analyze/alerts-cases/alerts/view-alerts#tag-alerts
- Observability docs: https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/4624/solutions/observability/incident-management/view-alerts#observability-view-alerts-tag-alerts

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

