### PR TITLE
[ES|QL] Mention inline suggestions and autocomplete menus as separate helping functionality

### DIFF
--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -140,7 +140,7 @@ The maximum number of queries in the history depends on the version you're using
 
 ### Query help
 
-{{esql}} features in-app help and suggestions, so you can get started faster and don’t have to leave the application to check syntax.
+{{esql}} features in-app help, inline suggestions, and an autocomplete menu so you can get started faster and don’t have to leave the application to check syntax.
 
 ![The ES|QL syntax reference and the autocomplete menu](/explore-analyze/images/kibana-esql-in-app-help.png "")
 


### PR DESCRIPTION
## Summary
Very small PR to distinguish between inline suggestions and autocomplete menu in the ES|QL editor. We don't need more than that in the docs, if we even needed it in the first place. Still, that can be small reassuring facts for anyone getting started with the language and the Kibana ES|QL experience

Closes: https://github.com/elastic/docs-content/issues/4636

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

