### PR TITLE
[agent builder] update applies_to's

### DIFF
--- a/explore-analyze/ai-features/agent-builder/agent-builder-agents.md
+++ b/explore-analyze/ai-features/agent-builder/agent-builder-agents.md
@@ -2,10 +2,7 @@
 navigation_title: "Agents"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
@@ -3,10 +3,7 @@ description: Reference of all built-in agents available in Elastic Agent Builder
 navigation_title: "Built-in agents"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/chat.md
+++ b/explore-analyze/ai-features/agent-builder/chat.md
@@ -2,10 +2,7 @@
 navigation_title: "Chat"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/get-started.md
+++ b/explore-analyze/ai-features/agent-builder/get-started.md
@@ -2,10 +2,7 @@
 navigation_title: "Get started"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
+++ b/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
@@ -2,10 +2,7 @@
 navigation_title: "Limitations"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/models.md
+++ b/explore-analyze/ai-features/agent-builder/models.md
@@ -2,10 +2,7 @@
 navigation_title: "Models"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/monitor-usage.md
+++ b/explore-analyze/ai-features/agent-builder/monitor-usage.md
@@ -2,10 +2,7 @@
 navigation_title: "Monitor token usage"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/permissions.md
+++ b/explore-analyze/ai-features/agent-builder/permissions.md
@@ -1,10 +1,7 @@
 ---
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/standalone-and-flyout-modes.md
+++ b/explore-analyze/ai-features/agent-builder/standalone-and-flyout-modes.md
@@ -3,10 +3,7 @@ description: Learn about the standalone and flyout modes for the Elastic Agent B
 navigation_title: "Chat UI modes"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools.md
@@ -2,10 +2,7 @@
 navigation_title: "Tools"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
+++ b/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
@@ -3,10 +3,7 @@ description: Reference of all built-in tools available in Elastic Agent Builder
 navigation_title: "Built-in tools"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/tools/esql-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/esql-tools.md
@@ -2,10 +2,7 @@
 navigation_title: "ES|QL tools"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
@@ -2,10 +2,7 @@
 navigation_title: "Index search tools"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana

--- a/explore-analyze/ai-features/elastic-agent-builder.md
+++ b/explore-analyze/ai-features/elastic-agent-builder.md
@@ -2,10 +2,7 @@
 navigation_title: "Agent Builder"
 applies_to:
   stack: preview =9.2, ga 9.3+
-  serverless:
-    elasticsearch: ga
-    observability: preview
-    security: preview
+  serverless: ga
 products:
   - id: elasticsearch
   - id: kibana


### PR DESCRIPTION
closes https://github.com/elastic/docs-content-internal/issues/613#issuecomment-3778123870

followup to https://github.com/elastic/docs-content/pull/4712

I overthought the serverless tags due to the flyout being preview but upon reflection makes sense to just use `serverless: ga` for all core AB features

