### PR TITLE
Snapshots note to highlight users the importance of backups besides their data

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore.md
+++ b/deploy-manage/tools/snapshot-and-restore.md
@@ -26,7 +26,7 @@ A snapshot is a backup of a running {{es}} cluster. You can use snapshots to:
 ::::{important}
 Snapshots preserve more than your data. They also include the configuration and internal data of {{stack}} features, such as {{ilm-init}} policies, index templates and pipelines, {{kib}} saved objects, alerting rules, {{fleet}} settings and integrations, {{elastic-sec}} data, and more, depending on your use case.
 
-Consider using snapshots to back up, at minimum, all {{es}} system indices and the cluster state, even if your data can be reindexed or recovered from other external sources. Without these backups, a disaster recovery scenario can result in the loss of your stack configuration and feature state, even if the underlying data can be restored.
+Consider using snapshots to back up, at minimum, all {{es}} system indices and the cluster state, even if your data can be reindexed or recovered from other external sources. Without these backups, a disaster recovery scenario can result in the loss of your stack configuration and feature states, even if the underlying data can be restored.
 ::::
 
 ## Snapshot workflow


### PR DESCRIPTION
## Summary

Added note to highlight the importance of snapshots, not only to preserve the user's data, but all the stack configuration.

We want to ensure users understand that even if they don't need backups of their data (because they can recover it from somewhere else), they should consider snapshots to back up all the system and Elastic Stack features configuration.

Happy to get feedback and suggestions about the wording.

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  