### PR TITLE
Add known issue in ECH for upgrading 9.1.10 -> 9.2.4

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -39,7 +39,7 @@ To learn more about the features that are supported by {{ecloud}}, check [{{eclo
 
 * Due to a known issue with the {{stack}}, certain upgrade paths to and from version 8.17 are currently blocked or disabled. Review [this KB article](https://support.elastic.co/knowledge/7c3ad709) for more guidance on the known issue. Additionally, review [this KB article](https://support.elastic.co/knowledge/e87d76a5) for detailed information regarding the specific versions affected. 
 
-* Due to a known issue with the {{stack}}, the upgrade path from 9.1.10 to 9.2.4 is unavailable. Refer to [Elasticsearch Known Issues](https://www.elastic.co/docs/release-notes/elasticsearch/known-issues#elasticsearch-9.2.4-known-issues) for more information on the underlying issue.
+* Due to a known issue with the {{stack}}, the upgrade path from 9.1.10 to 9.2.4 is unavailable. Refer to [Elasticsearch known issues](elasticsearch://release-notes/known-issues.md#elasticsearch-9.2.4-known-issues) for more information on the underlying issue.
 
 
 ## Security [ec-restrictions-security]


### PR DESCRIPTION
## Summary

This upgrade path is being blocked in Elastic Cloud Hosted due to a bug that prevents upgrading 9.1.10->9.2.4.

