### PR TITLE
Highlight info on data volume measurement in Security and Observability billing docs

### DIFF
--- a/deploy-manage/cloud-organization/billing/_snippets/note-data-volumes-ingest-retention.md
+++ b/deploy-manage/cloud-organization/billing/_snippets/note-data-volumes-ingest-retention.md
@@ -1,0 +1,5 @@
+:::{note}
+Data volumes for ingest and retention are based on the fully enriched normalized data size at the end of the ingest pipeline, before {{es}} compression is performed, and will be higher than the volumes traditionally reported by {{es}} index size.
+
+In addition, these volumes might be larger than those reported by cloud provider proxy logs for data going into {{es}}. This allows you to have flexibility in choosing your preferred ingest architecture for enrichment, whether it's through {{agent}}, {{ls}}, OpenTelemetry, or collectors — with no impact on the cost.
+:::

--- a/deploy-manage/cloud-organization/billing/elastic-observability-billing-dimensions.md
+++ b/deploy-manage/cloud-organization/billing/elastic-observability-billing-dimensions.md
@@ -20,10 +20,7 @@ Your monthly bill is based on the capabilities you use. When you use {{obs-serve
 * **Ingest** — Measured by the number of GB of log/event/info data that you send to your Observability project over the course of a month.
 * **Retention** — Measured by the total amount of ingested data stored in your Observability project.
 
-:::{note}
-Data volumes for ingest and retention are based on the fully enriched normalized data size at the end of the ingest pipeline, before {{es}} compression is performed, and will be higher than the volumes traditionally reported by {{es}} index size.
-
-In addition, these volumes might be larger than those reported by cloud provider proxy logs for data going into {{es}}. This allows you to have flexibility in choosing your preferred ingest architecture for enrichment, whether it’s through Elastic Agent, Logstash, OpenTelemetry, or collectors — with no impact on the cost.
+:::{include} _snippets/note-data-volumes-ingest-retention.md
 :::
 
 Refer to [Serverless billing dimensions](serverless-project-billing-dimensions.md) and the [{{ecloud}} pricing table](https://cloud.elastic.co/cloud-pricing-table?productType=serverless&project=observability) for more details about {{obs-serverless}} billing dimensions and rates, or you can create a [Serverless estimate](https://cloud.elastic.co/pricing/serverless?s=observability).

--- a/deploy-manage/cloud-organization/billing/security-billing-dimensions.md
+++ b/deploy-manage/cloud-organization/billing/security-billing-dimensions.md
@@ -20,10 +20,7 @@ Your monthly bill is based on the capabilities you use. When you use Security An
 * **Ingest** — Measured by the number of GB of log/event/info data that you send to your Security project over the course of a month.
 * **Retention** — Measured by the total amount of ingested data stored in your Security project.
 
-:::{note}
-Data volumes for ingest and retention are based on the fully enriched normalized data size at the end of the ingest pipeline, before {{es}} compression is performed, and will be higher than the volumes traditionally reported by {{es}} index size.
-
-In addition, these volumes might be larger than those reported by cloud provider proxy logs for data going into {{es}}. This allows you to have flexibility in choosing your preferred ingest architecture for enrichment, whether it’s through {{agent}}, {{ls}}, OpenTelemetry, or collectors — with no impact on the cost.
+:::{include} _snippets/note-data-volumes-ingest-retention.md
 :::
 
 [Create a serverless estimate](https://cloud.elastic.co/pricing/serverless?s=security) or refer to the [{{ecloud}} pricing table](https://cloud.elastic.co/cloud-pricing-table?productType=serverless&project=security) for more details.


### PR DESCRIPTION
## Summary

This PR highlights the existing info on data volume measurement in Security and Observability billing docs as per request.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No