### PR TITLE
Fix broken link in "Quickstart: Monitor hosts with OTel"

### DIFF
--- a/solutions/observability/get-started/quickstart-monitor-hosts-with-opentelemetry.md
+++ b/solutions/observability/get-started/quickstart-monitor-hosts-with-opentelemetry.md
@@ -19,11 +19,11 @@ In this quickstart guide, you’ll learn how to monitor your hosts using the Ela
 
 ::::{applies-switch}
 
-:::{applies-item} stack:
+:::{applies-item} serverless:
 
-* An {{es}} cluster for storing and searching your data, and {{kib}} for visualizing and managing your data. This quickstart is available for all Elastic deployment models. The quickest way to get started with this quickstart is using a trial project on [Elastic serverless](https://docs.elastic.co/serverless/quickstart-monitor-hosts-with-otel.html).
+* An {{observability}} project. To learn more, refer to [Create an Observability project](/solutions/observability/get-started.md).
 * This quickstart is only available for Linux and MacOS systems.
-* A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to [User roles and privileges](/deploy-manage/users-roles/cloud-organization/user-roles.md).
+* A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to [Assign user roles and privileges](/deploy-manage/users-roles/cloud-organization/user-roles.md#general-assign-user-roles).
 * Root privileges on the host—required to run the OpenTelemetry collector because of these components:
 
     * `hostmetrics` receiver to read all system metrics (all processes, memory, etc.).
@@ -31,11 +31,11 @@ In this quickstart guide, you’ll learn how to monitor your hosts using the Ela
 
 :::
 
-:::{applies-item} serverless:
+:::{applies-item} stack:
 
-* An {{observability}} project. To learn more, refer to [Create an Observability project](/solutions/observability/get-started.md).
+* An {{es}} cluster for storing and searching your data, and {{kib}} for visualizing and managing your data. This quickstart is available for all Elastic deployment models. To get started quickly, try out [{{ecloud}}](https://cloud.elastic.co/registration?page=docs&placement=docs-body).
 * This quickstart is only available for Linux and MacOS systems.
-* A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to [Assign user roles and privileges](/deploy-manage/users-roles/cloud-organization/user-roles.md#general-assign-user-roles).
+* A user with the **Admin** role or higher—required to onboard system logs and metrics. To learn more, refer to [User roles and privileges](/deploy-manage/users-roles/cloud-organization/user-roles.md).
 * Root privileges on the host—required to run the OpenTelemetry collector because of these components:
 
     * `hostmetrics` receiver to read all system metrics (all processes, memory, etc.).
@@ -56,31 +56,6 @@ Refer to [Elastic OpenTelemetry Collector limitations](opentelemetry://reference
 Follow these steps to collect logs and metrics using the EDOT Collector:
 
 :::::{applies-switch}
-
-::::{applies-item} stack:
-
-1. In {{kib}}, go to the **Observability** UI and click **Add Data**.
-2. Under **What do you want to monitor?** select **Host**, and then select **OpenTelemetry: Logs & Metrics**.
-
-    :::{image} /solutions/images/observability-quickstart-monitor-hosts-otel-entry-point.png
-    :alt: Host monitoring entry point
-    :screenshot:
-    :::
-
-3. Select the appropriate platform.
-4. Copy the command under step 1, open a terminal on your host, and run the command.
-
-    This command downloads the {{agent}} package, extracts it in a EDOT directory. For example, `elastic-distro-8.16.0-linux-x86_64`. It also adds a sample `otel.yml` configuration file to the directory and updates the storage directory, Elastic endpoint, and API key in the file.
-
-    The default log path is `/var/log/*.log`. To update the path, modify the `otel.yml` in the EDOT directory.
-
-    Find additional sample `otel.yml` configuration files in the EDOT directory in the `otel_samples` folder.
-
-5. Copy the command under Step 2 and run it in your terminal to start the EDOT Collector.
-
-::::{note}
-Logs are collected from setup onward, so you won’t see logs that occurred before starting the EDOT Collector.
-::::
 
 ::::
 
@@ -104,6 +79,33 @@ Logs are collected from setup onward, so you won’t see logs that occurred befo
 10. For **Kubernetes**, run the command from the directory where you downloaded the manifest to install the EDOT Collector on every node of your cluster.
 
 Logs are collected from setup onward, so you won’t see logs that occurred before starting the EDOT Collector. The default log path is `/var/log/*`. To update the path, modify `otel.yml`.
+
+::::
+
+::::{applies-item} stack:
+
+1. In {{kib}}, go to the **Observability** UI and click **Add Data**.
+2. Under **What do you want to monitor?** select **Host**, and then select **OpenTelemetry: Logs & Metrics**.
+
+    :::{image} /solutions/images/observability-quickstart-monitor-hosts-otel-entry-point.png
+    :alt: Host monitoring entry point
+    :screenshot:
+    :::
+
+3. Select the appropriate platform.
+4. Copy the command under step 1, open a terminal on your host, and run the command.
+
+    This command downloads the {{agent}} package, extracts it in a EDOT directory. For example, `elastic-distro-8.16.0-linux-x86_64`. It also adds a sample `otel.yml` configuration file to the directory and updates the storage directory, Elastic endpoint, and API key in the file.
+
+    The default log path is `/var/log/*.log`. To update the path, modify the `otel.yml` in the EDOT directory.
+
+    Find additional sample `otel.yml` configuration files in the EDOT directory in the `otel_samples` folder.
+
+5. Copy the command under Step 2 and run it in your terminal to start the EDOT Collector.
+
+:::{note}
+Logs are collected from setup onward, so you won’t see logs that occurred before starting the EDOT Collector.
+:::
 
 ::::
 


### PR DESCRIPTION
## Summary

This PR:

- Fixes a broken link in the prerequisites section for the Elastic Stack
- Reverses the order of the Stack and Serverless tabs across the doc (Serverless should be first)

Resolves https://github.com/elastic/docs-content/issues/4794

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No