### PR TITLE
[agent builder] Document cross-cluster search limitation

### DIFF
--- a/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
+++ b/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
@@ -27,6 +27,10 @@ This section lists the limitations and known issues in {{agent-builder}}.
 Refer to [Get started](get-started.md#enable-agent-builder) if you need instructions about enabling {{agent-builder}} for your deployment type.
 :::
 
+### Cross-cluster search not supported
+
+Agent Builder does not yet support [cross-cluster search (CCS)](/explore-analyze/cross-cluster-search.md).
+
 ### A2A streaming not supported
 
 The [A2A server](a2a-server.md) does not currently support streaming operations. All agent interactions use the synchronous `message/send` method, which returns a complete response only after task execution completes.


### PR DESCRIPTION
Added note about lack of support for cross-cluster search in Agent Builder.

