### PR TITLE
[agent builder] Refactor tools page, create custom tools subpage, add best practices

### DIFF
--- a/explore-analyze/ai-features/agent-builder/get-started.md
+++ b/explore-analyze/ai-features/agent-builder/get-started.md
@@ -114,7 +114,7 @@ On {{ech}} and {{serverless-full}}, {{agent-builder}} comes with preconfigured m
 
 ::::{step} Begin building agents and tools
 
-Once you've tested the default **Elastic AI Agent** with the [built-in Elastic tools](tools.md), you can begin [building your own agents](agent-builder-agents.md#create-a-new-agent) with custom instructions and [creating your own tools](tools.md#create-custom-tools) to assign them.
+Once you've tested the default **Elastic AI Agent** with the [built-in Elastic tools](tools.md), you can begin [building your own agents](agent-builder-agents.md#create-a-new-agent) with custom instructions and [creating your own tools](tools/custom-tools.md) to assign them.
 
 ::::
 

--- a/explore-analyze/ai-features/agent-builder/tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools.md
@@ -13,17 +13,9 @@ products:
 
 # Tools in {{agent-builder}}
 
-[Agents](agent-builder-agents.md) use tools to search, retrieve, and take meaningful steps on your behalf.
+[Agents](agent-builder-agents.md) use tools to search, retrieve, and take actions on your behalf.
 
 Tools can be thought of as functions: modular, reusable actions that agents can call to interact with your {{es}} data.
-
-Each tool is defined by several key fields:
-
-- **`id`**: The unique identifier that agents use to reference the tool (e.g., `.get_document_by_id`)
-- **`type`**: Specifies whether the tool is `builtin` (pre-defined) or `esql` (custom)
-- **`description`**: Natural language explanation of what the tool does, used by the AI to determine when to use it
-- **`configuration`**: Contains the tool's logic - empty for built-in tools, or query and parameters for custom ESQL tools
-- **`schema`**: Defines the input parameters the tool requires, written in JSON Schema format
 
 ## How agents use tools
 
@@ -35,7 +27,7 @@ Tools enable agents to work with {{es}} data. When an agent receives a natural l
 4. Executes the tools in sequence as needed
 5. Processes the structured output data
 
-Each tool is an atomic operation with a defined signature - accepting typed parameters and returning structured results in a format the agent can parse, transform, and incorporate into its response generation.
+Each tool is an atomic operation with a defined signature. Tools accept typed parameters and return structured results in a format the agent can parse, transform, and incorporate into its response generation.
 
 :::{note}
 Tool execution and result processing consume tokens. To understand how usage is calculated, refer to [Token usage in Elastic Agent Builder](monitor-usage.md).
@@ -45,143 +37,36 @@ Tool execution and result processing consume tokens. To understand how usage is 
 
 {{agent-builder}} ships with a comprehensive set of built-in tools that provide core capabilities for working with your {{es}} data. These tools are ready to use. They cannot be modified or deleted.
 
-Built-in tools serve as building blocks for more complex interactions and provide the foundation for agent capabilities. They include tools for executing {{esql}} queries, retrieving documents, exploring indices, and searching data.
+Built-in tools serve as building blocks for more complex interactions and provide the foundation for agent capabilities.
 
 For the complete list, refer to [Built-in tools reference](tools/builtin-tools-reference.md).
 
 ## Custom tools
 
-You can extend the built-in tool catalog with your own custom tool definitions. Custom tools offer flexibility in how they interact with your data. This flexibility allows you to create tools that match your specific use cases and data access patterns.
-
-{{agent-builder}} supports several tool types:
-
-- **[Index search tools](tools/index-search-tools.md)**: Scope searches to specific indices or patterns. The LLM dynamically constructs queries based on user requests.
-- **[ES|QL tools](tools/esql-tools.md)**: Execute pre-defined {{esql}} queries with parameterized inputs for precise, repeatable data retrieval.
-- **[MCP tools](tools/mcp-tools.md)**: Connect to external Model Context Protocol servers, enabling agents to use remote tools and services.
-- **[Workflow tools](tools/workflow-tools.md)**: Call pre-defined Workflows directly from the agent chat.
-
-### Tool parameters
-
-Parameters enable tools to be dynamic and adaptable to different queries. Each parameter has:
-
-- A **name** that identifies it
-- A **type** (such as keyword, number, boolean)
-- A **description** that helps the agent understand when and how to use it
-
-For {{esql}} tools, parameters are defined in the query using the syntax `?parameter_name` and must be configured when creating the tool.
-
-Parameters can be:
-- **Manually defined**: You explicitly define the parameters a tool needs
-- **Inferred from query**: For {{esql}} tools, you can use the "Infer parameters from query" button to automatically detect parameters in your query statement
-
-The tool's `schema` field defines these parameters using JSON Schema format, specifying:
-- **`type`**: Always `"object"` for tool parameters
-- **`properties`**: Dictionary defining each parameter's type and description
-- **`required`**: Array listing mandatory parameters
-- **`additionalProperties`**: Set to `false` to reject undefined parameters
-
-Providing clear, descriptive parameter names and descriptions helps agents properly use your tools when answering queries.
-
-## Create custom tools
-
-You can create custom tools to help agents interact with your data in specific ways. This section covers how to create and test tools in the UI
-
-1. Navigate to the **Tools** section on the **Agents** page in Kibana.
-2. Click **New tool**.
-
-  :::{image} images/new-tool-button.png
-  :screenshot:
-  :alt: New tool button for creating custom tools
-  :width: 150px
-  :::
-
-4. Fill in the required fields:
-   - **Name**: Enter a descriptive name for your tool.
-   - **Description**: Write a clear explanation of what the tool does and when it should be used.
-   - **Tool type**: Choose **[{{esql}}](tools/esql-tools.md)**, **[Index search](tools/index-search-tools.md).** or **[MCP](tools/mcp-tools.md)**
-   - **Parameters**: For tools with {{esql}} queries, define any parameters your query needs.
-   - **Tags**: (Optional) Add labels to categorize and organize your tools.
-5. Choose how to save your tool:
-   - Select **Save** to create the tool.
-   - Select **Save and test** to create the tool and immediately open the testing interface
-
-    :::{image} images/tool-save-save-and-test-buttons.png
-    :screenshot:
-    :alt: Save and Save and test buttons for tool creation
-    :width:250px
-    :::
-
-### Testing your tools
-
-Before assigning tools to agents, verify they work correctly by testing them. Testing helps ensure your tool returns useful results and handles parameters correctly.
-
-If you didn't select **Save and test** immediately:
-
-1. Find your tool in the Tools list.
-2. Click the test icon (play button) associated with your tool.
-
-:::{image} images/test-icon.png
-:screenshot:
-:alt: Test icon (play button) for running tool tests
-:width: 150px
-:::
-3. Enter test data based on your tool type:
-   - **For {{esql}} tools with parameters**: Enter realistic test values for each parameter in the **Inputs** section.
-   - **For Index search tools**: Enter a sample search query to test the search functionality.
-4. Select **Submit** to run the test.
-5. Review the Response section to verify:
-   - The tool executes without errors.
-   - Results are returned in the expected format.
-   - The data matches your expectations.
-6. Now you can [assign the tool to an agent](#assign-tools-to-agents).
-
-### Best practices
-
-1. **Write descriptive names**: Use clear, action-oriented names.
-2. **Provide detailed descriptions**: Explain when and how the tool should be used.
-3. **Limit scope**: Focus each tool on a specific task rather than creating overly complex tools.
-4. **Use meaningful parameter names**: Choose names that clearly indicate what the parameter represents.
-5. **Add comprehensive parameter descriptions**: Help the agent understand what values to use.
-6. **Include `LIMIT` clauses in {{esql}} queries**: Prevent returning excessive results.
-7. **Use appropriate tags**: Add relevant tags to make tools easier to find and organize.
-8. **Limit tool count**: More tools are not always better. Try to keep each agent focused with a limited number of relevant tools.
+You can extend the built-in tool catalog with your own custom tool definitions. To learn how to create and manage custom tools, refer to [Custom tools](tools/custom-tools.md).
 
 ## Manage tools
 
-### Find available tools
+You can view, organize, and manage tools from the **Tools** page in Kibana or programmatically using the [Tools API](kibana-api.md#tools).
 
-Find the list of available tools on the **Tools** landing page in the UI, or use [Tools API](kibana-api.md#tools).
+The Tools page lists each tool by ID and description. Use the search bar or filter by labels to find specific tools. Built-in tools are marked with a lock icon (🔒).
 
 :::{image} images/tools-overview.png
 :screenshot:
 :alt: Tools landing page showing the list of available tools with their descriptions and actions
-:width:800px
+:width:600px
 :::
-
-### List available tools
-
-Access the complete list of available tools from the **Tools** page in Kibana. This view shows:
-- Tool names and descriptions
-- Tool types
-- Associated tags
-- Actions (edit, delete, test)
-
-### Assign tools to agents
-
-Tools must be assigned to agents before they can be used:
-1. Navigate to the agent configuration page.
-2. Select the **Tools** tab.
-3. Add the desired tools to the agent.
-4. Save the agent configuration.
 
 ### Update and delete tools
 
-Custom tools can be modified or removed as needed:
+[Custom tools](tools/custom-tools.md) can be modified or removed as needed:
 1. From the Tools page, find the tool you want to modify.
 2. Select the edit icon to update the tool or the delete icon to remove it.
 3. For updates, modify the tool properties and save your changes.
 
+:::{note}
 Built-in tools cannot be modified or deleted.
+:::
 
 ## Tools API
 

--- a/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
+++ b/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
@@ -18,7 +18,7 @@ products:
 
 This page lists all built-in tools available in {{agent-builder}}. Built-in tools enable core operations for working with {{es}} data across platform, observability, and security use cases out-of-the-box.
 
-Built-in tools are read-only: you can't modify or delete them. To check which tools are available in your Elastic deployment, refer to [find all available tools](/explore-analyze/ai-features/agent-builder/tools.md#find-available-tools).
+Built-in tools are read-only: you can't modify or delete them. To check which tools are available in your Elastic deployment, refer to [Manage tools](/explore-analyze/ai-features/agent-builder/tools.md#manage-tools).
 
 :::{tip}
 For an overview of how tools work in {{agent-builder}}, refer to the [Tools overview](../tools.md).
@@ -197,6 +197,10 @@ The [built-in Threat Hunting Agent](/explore-analyze/ai-features/agent-builder/b
 
 $$$agent-builder-security-labs-search-tool$$$ `security.security_labs_search`
 :   Searches [Elastic Security Labs](https://www.elastic.co/security-labs) research and threat intelligence content. To use this tool, search for **GenAI Settings** in the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md) and install **Security labs** from the **Documentation** section. This takes a few minutes.
+
+:::{tip}
+You can also manage tools programmatically. To learn more, refer to [Tools API](../tools.md#tools-api).
+:::
 
 ## Related pages
 

--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -1,0 +1,148 @@
+---
+navigation_title: "Custom tools"
+applies_to:
+  stack: preview =9.2, ga 9.3+
+  serverless: ga
+products:
+  - id: elasticsearch
+  - id: kibana
+  - id: observability
+  - id: security
+  - id: cloud-serverless
+---
+
+# Custom tools
+
+You can extend the built-in tool catalog with your own custom tool definitions. Custom tools offer flexibility in how they interact with your data. This flexibility allows you to create tools that match your specific use cases and data access patterns.
+
+## Tool types
+
+{{agent-builder}} supports several tool types:
+
+- **[ES|QL tools](esql-tools.md)**: Execute pre-defined {{esql}} queries with parameterized inputs for precise, repeatable data retrieval.
+- **[Index search tools](index-search-tools.md)**: Scope searches to specific indices or patterns. The LLM dynamically constructs queries based on user requests.
+- **[MCP tools](mcp-tools.md)**: Connect to external Model Context Protocol servers, enabling agents to use remote tools and services.
+- **[Workflow tools](workflow-tools.md)**: Call pre-defined Workflows directly from the agent chat.
+
+## Create custom tools in the UI
+
+You can create custom tools in the Kibana UI.
+
+To create a custom tool in the UI:
+
+1. Navigate to the **Tools** section on the **Agents** page in Kibana.
+2. Click **New tool**.
+
+  :::{image} ../images/new-tool-button.png
+  :screenshot:
+  :alt: New tool button for creating custom tools
+  :width: 150px
+  :::
+
+4. Fill in the required fields:
+   - **ID**: Enter a unique identifier for your tool (e.g., `get_customer_orders`). Agents use this ID to reference the tool. Refer to [Naming conventions](#naming-conventions) for recommended patterns.
+   - **Name**: Enter a descriptive name for your tool.
+   - **Description**: Write a clear explanation of what the tool does and when it should be used. Refer to [Writing effective tool descriptions](#writing-effective-tool-descriptions) for guidance.
+   - **Type**: Choose a tool type from the list.
+   - **Parameters**: For tools with {{esql}} queries, define any parameters your query needs.
+   - **Labels**: (Optional) Add labels to categorize and organize your tools.
+5. Choose how to save your tool:
+   - Select **Save** to create the tool.
+   - Select **Save and test** to create the tool and immediately open the testing interface
+
+    :::{image} ../images/tool-save-save-and-test-buttons.png
+    :screenshot:
+    :alt: Save and Save and test buttons for tool creation
+    :width:250px
+    :::
+
+## Create custom tools with API
+
+You can also create and manage tools programmatically. To learn more, refer to [Tools API](../tools.md#tools-api).
+
+
+## Test your tools
+
+Before assigning tools to agents, verify they work correctly by testing them. Testing helps ensure your tool returns useful results and handles parameters correctly.
+
+If you didn't select **Save and test** immediately:
+
+1. Find your tool in the Tools list.
+2. Click the test icon (play button) associated with your tool.
+
+:::{image} ../images/test-icon.png
+:screenshot:
+:alt: Test icon (play button) for running tool tests
+:width: 150px
+:::
+3. Enter test data based on your tool type:
+   - **For {{esql}} tools with parameters**: Enter realistic test values for each parameter in the **Inputs** section.
+   - **For Index search tools**: Enter a sample search query to test the search functionality.
+4. Select **Submit** to run the test.
+5. Review the Response section to verify:
+   - The tool executes without errors.
+   - Results are returned in the expected format.
+   - The data matches your expectations.
+
+## Assign tools to agents
+
+To start using a custom tool, you must assign it to a [custom agent](../agent-builder-agents.md#create-a-new-agent-in-the-gui).
+1. Navigate to the agent configuration page.
+2. Select the **Tools** tab.
+3. Add the desired tools to the agent.
+4. Save the agent configuration.
+
+## Best practices
+
+Follow these guidelines to create tools that agents can use effectively.
+
+### Naming conventions
+
+The Tool ID is a critical identifier. Use a namespace prefix to group tools logically, which helps the LLM understand tool relationships and prevents naming collisions.
+
+**Recommended pattern**: `domain.action_entity` or `system.function`
+
+**Examples**:
+- `finance.search_ticker`
+- `support.get_ticket_details`
+- `ecommerce.cancel_order`
+
+### Writing effective tool descriptions
+
+A strong description explains what the tool does, when to use it, and what limitations exist. Include these components:
+
+- **Core purpose**: A high-level summary of what the tool actually does.
+- **Trigger**: When should this be called?
+- **Action**: What specific data does it retrieve or modify?
+- **Limitations**: Are there constraints (for example, "returns max 50 rows" or "data is 24 hours old")?
+- **Relationships**: How does it relate to other tools?
+
+#### Example: Customer support (retrieval)
+
+- **Tool ID**: `support.search_articles`
+- **Description**: "Searches the internal Knowledge Base for technical support articles. Use this tool when a user asks about error codes, troubleshooting steps, or product configurations.
+  - Input: Requires a natural language query string.
+  - Limitations: Returns a maximum of 3 articles.
+  - Note: If this tool returns irrelevant results, try the `support.search_tickets` tool to see how similar historical issues were resolved."
+
+#### Example: Finance (data fetching)
+
+- **Tool ID**: `finance.get_transaction_history`
+- **Description**: "Retrieves a list of transactions for a specific user account ID.
+  - Parameters: `account_id` (required), `start_date` (optional, defaults to 30 days ago).
+  - Usage: Use this to analyze spending patterns or find specific charges.
+  - Constraint: Data is updated nightly; do not use it for real-time balance checks (use `finance.get_realtime_balance` for that)."
+
+### Additional tips
+
+- **Limit scope**: Focus each tool on a specific task rather than creating overly complex tools.
+- **Use meaningful parameter names**: Choose names that clearly indicate what the parameter represents.
+- **Include `LIMIT` clauses in {{esql}} queries**: Prevent returning excessive results.
+- **Use labels**: Add relevant labels to make tools easier to find and organize.
+- **Limit tool count**: More tools are not always better. Keep each agent focused with a limited number of relevant tools.
+
+## Related pages
+
+- [](../tools.md)
+- [](builtin-tools-reference.md)
+- [](../kibana-api.md#tools)

--- a/explore-analyze/ai-features/agent-builder/tools/esql-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/esql-tools.md
@@ -78,6 +78,8 @@ You can ask the LLM to infer the parameters for the query or add them manually.
 - **Define parameter types**: Ensure parameters have the correct type to avoid runtime errors
 - **Provide clear descriptions**: Help agents understand when and how to use each parameter
 
+For general guidance on naming tools and writing effective descriptions, refer to [Custom tools best practices](custom-tools.md#best-practices).
+
 :::{tip}
 If queries are slow or failing, you might be retrieving more data than the LLM can process. Refer to [Context length exceeded](../troubleshooting/context-length-exceeded.md) for tips on diagnosing and resolving these issues.
 :::

--- a/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
@@ -65,6 +65,8 @@ When an agent calls an index search tool:
 - **Provide context in descriptions**: Explain what data the indices contain and what types of questions the tool can answer
 - **Create domain-specific tools**: Build separate tools for different data domains (logs, metrics, alerts) rather than one general-purpose tool
 
+For general guidance on naming tools and writing effective descriptions, refer to [Custom tools best practices](custom-tools.md#best-practices).
+
 
 ## Common patterns
 

--- a/explore-analyze/ai-features/agent-builder/troubleshooting/context-length-exceeded.md
+++ b/explore-analyze/ai-features/agent-builder/troubleshooting/context-length-exceeded.md
@@ -91,7 +91,7 @@ For example, try creating purpose-built tools that:
 Always include a `LIMIT` clause in your {{esql}} queries to cap the number of results.
 
 :::{tip}
-Learn more in [creating custom tools](../tools.md#create-custom-tools).
+Learn more in [creating custom tools](../tools/custom-tools.md).
 :::
 :::::
 
@@ -109,4 +109,4 @@ Assign your custom {{esql}} tools to the custom agent. Update the agent's system
 
 - [Troubleshooting](../troubleshooting.md)
 - [Monitor token usage](../monitor-usage.md)
-- [Custom tools](../tools.md#create-custom-tools)
+- [Custom tools](../tools/custom-tools.md)

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -184,10 +184,12 @@ toc:
           - file: ai-features/agent-builder/tools.md
             children:
               - file: ai-features/agent-builder/tools/builtin-tools-reference.md
-              - file: ai-features/agent-builder/tools/esql-tools.md
-              - file: ai-features/agent-builder/tools/index-search-tools.md
-              - file: ai-features/agent-builder/tools/mcp-tools.md
-              - hidden: ai-features/agent-builder/tools/workflow-tools.md
+              - file: ai-features/agent-builder/tools/custom-tools.md
+                children:
+                  - file: ai-features/agent-builder/tools/esql-tools.md
+                  - file: ai-features/agent-builder/tools/index-search-tools.md
+                  - file: ai-features/agent-builder/tools/mcp-tools.md
+                  - file: ai-features/agent-builder/tools/workflow-tools.md
           - file: ai-features/agent-builder/programmatic-access.md
             children:
                - file: ai-features/agent-builder/kibana-api.md

--- a/redirects.yml
+++ b/redirects.yml
@@ -673,6 +673,16 @@ redirects:
 # Related to https://github.com/elastic/docs-content/pull/4438
   'explore-analyze/ai-features/ai-assistant.md': 'explore-analyze/ai-features/ai-chat-experiences/ai-assistant.md'
 
+# Related to tools.md refactor - moved custom tools content to custom-tools.md
+  'explore-analyze/ai-features/agent-builder/tools.md':
+    to: 'explore-analyze/ai-features/agent-builder/tools.md'
+    many:
+      - to: 'explore-analyze/ai-features/agent-builder/tools/custom-tools.md'
+        anchors:
+          'create-custom-tools': 'create-custom-tools'
+          'testing-your-tools': 'testing-your-tools'
+          'best-practices': 'best-practices'
+          'assign-tools-to-agents': 'assign-tools-to-agents'
 
 # Related to https://github.com/elastic/docs-content/pull/4779
   'explore-analyze/visualize/lens.md':


### PR DESCRIPTION
Tools page needed love as it was an IA nightmare.

Best practices component contributes to to https://github.com/elastic/docs-content-internal/issues/680

Contributes to https://github.com/elastic/docs-content-internal/issues/692

## Summary

- Created tools/custom-tools.md with create/test/assign workflow and best practices
- Slimmed tools.md to overview with links to child pages
- Added best practices section with naming conventions and description guidelines
- Moved tool type pages under custom-tools.md in TOC hierarchy
- Added redirects for moved anchors (create-custom-tools, testing-your-tools, best-practices, assign-tools-to-agents)
- Added API tip to builtin-tools-reference.md and custom-tools.md linking back to tools.md#tools-api
- Added best practices cross-links in esql-tools.md and index-search-tools.md


## Generative AI disclosure
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude code


