### PR TITLE
Add provider terms column to the table

### DIFF
--- a/.github/scripts/sheet2docs/config.yml
+++ b/.github/scripts/sheet2docs/config.yml
@@ -33,6 +33,7 @@ columns:
   - source: "Data Used To Train Models?"
   - source: "Model Card"
   - source: "Author Terms"
+  - source: "Provider Terms"
   - source: "Inference Regions"
 
 # Output configuration


### PR DESCRIPTION
## Summary

This PR adds the column "Provider Terms" to the generated models.csv by amending the conf.yaml.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
