### PR TITLE
[Security][Cases][9.2]: Users can now paste screenshots into markdown comment fields for Cases

### DIFF
--- a/explore-analyze/alerts-cases/cases/manage-cases.md
+++ b/explore-analyze/alerts-cases/cases/manage-cases.md
@@ -122,6 +122,9 @@ In **Management > {{stack-manage-app}} > Cases**, you can search cases and filte
 To view a case, click on its name. You can then:
 
 * Add and edit the case's description, comments, assignees, tags, status, severity, and category.
+
+    {applies_to}`stack: ga 9.2+` Copy and paste images into case comments using `Ctrl/Cmd` + `C` and `Ctrl/Cmd` + `V` shortcuts. Pasted images are preformatted in Markdown. 
+
 * Add a connector (if you did not select one while creating the case).
 * Send updates to external systems (if external connections are configured).
 * Refresh the case to retrieve the latest updates.

--- a/solutions/observability/incident-management/create-manage-cases.md
+++ b/solutions/observability/incident-management/create-manage-cases.md
@@ -90,6 +90,9 @@ You can search existing cases and filter them by attributes such as assignees, c
 To view a case, click on its name. You can then:
 
 * Add and edit the case's description, comments, assignees, tags, status, severity, and category.
+
+    {applies_to}`stack: ga 9.2+` Copy and paste images into case comments using `Ctrl/Cmd` + `C` and `Ctrl/Cmd` + `V` shortcuts. Pasted images are preformatted in Markdown. 
+
 * Add a connector (if you did not select one while creating the case).
 * Send updates to external systems (if external connections are configured).
 * Refresh the case to retrieve the latest updates.

--- a/solutions/security/investigate/open-manage-cases.md
+++ b/solutions/security/investigate/open-manage-cases.md
@@ -91,9 +91,11 @@ From the Cases page, you can search existing cases and filter them by attributes
 
 To explore a case, click on its name. You can then:
 
-* [Review the case summary](/solutions/security/investigate/open-manage-cases.md#cases-summary)
+* [Review the case summary](/solutions/security/investigate/open-manage-cases.md#cases-summary).
 * Modify the case’s description, assignees, category, severity, status, and tags.
-* Add and manage [comments](/solutions/security/investigate/open-manage-cases.md#cases-manage-comments) and [lens visualization](/solutions/security/investigate/open-manage-cases.md#cases-lens-visualization)
+* Add and manage [comments](/solutions/security/investigate/open-manage-cases.md#cases-manage-comments) and [lens visualization](/solutions/security/investigate/open-manage-cases.md#cases-lens-visualization).
+
+    {applies_to}`stack: ga 9.2+` Copy and paste images into case comments using `Ctrl/Cmd` + `C` and `Ctrl/Cmd` + `V` shortcuts. Pasted images are preformatted in Markdown. 
 
     ::::{tip}
     Comments can contain Markdown. For syntax help, click the Markdown icon (![Click markdown icon](/solutions/images/security-markdown-icon.png "title =20x20")) in the bottom right of the comment.
@@ -105,9 +107,9 @@ To explore a case, click on its name. You can then:
     * {applies_to}`stack: ga 9.2+` [Events](/solutions/security/investigate/open-manage-cases.md#cases-examine-events) 
     * [Files](/solutions/security/investigate/open-manage-cases.md#cases-add-files)
     * [Observables](/solutions/security/investigate/open-manage-cases.md#cases-add-observables)
-* [Manage connectors](/solutions/security/investigate/configure-case-settings.md#cases-ui-integrations) and send updates to external systems (if you’ve added a connector to the case)
+* [Manage connectors](/solutions/security/investigate/configure-case-settings.md#cases-ui-integrations) and send updates to external systems (if you’ve added a connector to the case).
 * [Copy the case UUID](/solutions/security/investigate/open-manage-cases.md#cases-copy-case-uuid)
-* Refresh the case to retrieve the latest updates
+* Refresh the case to retrieve the latest updates.
 
 
 ### Review the case summary [cases-summary]


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Fixes https://github.com/elastic/docs-content/issues/3757: adds a line explaining that you can use keyboard shortcuts to copy and paste images into case comments. Case docs for all solutions are updated.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->
Cursor, claude-4.5-opus-high (just for light editing)

## Previews
- [Stack cases](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/4902/explore-analyze/alerts-cases/cases/manage-cases#manage-case)
- [Observability cases](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/4902/solutions/observability/incident-management/create-manage-cases#observability-create-a-new-case-manage-existing-cases)
- [Security cases](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/4902/solutions/security/investigate/open-manage-cases#cases-ui-manage)