### PR TITLE
Update .NET troubleshooting to remove `trace` logging

### DIFF
--- a/troubleshoot/ingest/opentelemetry/edot-sdks/dotnet/index.md
+++ b/troubleshoot/ingest/opentelemetry/edot-sdks/dotnet/index.md
@@ -21,7 +21,7 @@ If you have an Elastic support contract, create a ticket in the [Elastic Support
 
 ## Obtain EDOT .NET diagnostic logs
 
-For most problems, such as when you don't see data in your {{product.observability}} backend, first check the EDOT .NET logs. These logs show initialization details and OpenTelemetry SDK events. If you don't see any warnings or errors in the EDOT .NET logs, switch the log level to `Trace` to investigate further. For more information on enabling debug logging, refer to [Enable debug logging for EDOT SDKs](/troubleshoot/ingest/opentelemetry/edot-sdks/enable-debug-logging.md). If telemetry data isn't appearing in {{kib}}, refer to [No application-level telemetry visible in {{kib}}](/troubleshoot/ingest/opentelemetry/edot-sdks/missing-app-telemetry.md).
+For most problems, such as when you don't see data in your {{product.observability}} backend, first check the EDOT .NET logs. These logs show initialization details and OpenTelemetry SDK events. If you don't see any warnings or errors in the EDOT .NET logs, switch the log level to `Debug` to investigate further. For more information on enabling debug logging, refer to [Enable debug logging for EDOT SDKs](/troubleshoot/ingest/opentelemetry/edot-sdks/enable-debug-logging.md). If telemetry data isn't appearing in {{kib}}, refer to [No application-level telemetry visible in {{kib}}](/troubleshoot/ingest/opentelemetry/edot-sdks/missing-app-telemetry.md).
 
 The {{edot}} .NET includes built-in diagnostic logging. You can direct logs to a file, STDOUT, or, in common scenarios, an `ILogger` instance. EDOT .NET also observes the built-in diagnostics events from the contrib OpenTelemetry SDK and includes those in its logging output. You can collect the log output and use it to diagnose issues locally during development or when working with Elastic support channels.
 
@@ -74,24 +74,23 @@ In the preceding code, you have filtered `Elastic.OpenTelemetry` to only emit lo
 
 ## Enable global file logging
 
-Integrated logging is helpful because it requires little to no setup. The logging infrastructure is not present by default in some application types, such as console applications. EDOT .NET also offers a global file logging feature, which is the easiest way for you to get diagnostics and debug information. You must enable file logging when you work with Elastic support, as trace logs will be requested. For more details, refer to [Enable debug logging for EDOT SDKs](/troubleshoot/ingest/opentelemetry/edot-sdks/enable-debug-logging.md).
+Integrated logging is helpful because it requires little to no setup. The logging infrastructure is not present by default in some application types, such as console applications. EDOT .NET also offers a global file logging feature, which is the easiest way for you to get diagnostics and debug information. You must enable file logging when you work with Elastic support, as debug logs will be requested. For more details, refer to [Enable debug logging for EDOT SDKs](/troubleshoot/ingest/opentelemetry/edot-sdks/enable-debug-logging.md).
 
 Specify at least one of the following environment variables to make sure that EDOT .NET logs into a file.
 
 `OTEL_LOG_LEVEL` _(optional)_:
 Set the log level at which the profiler should log. Valid values are
 
-* trace
 * debug
 * information
 * warning
 * error
 * none
 
-The default value is `information`. More verbose log levels like `trace` and `debug` can affect the runtime performance of profiler auto instrumentation, so use them _only_ for diagnostics purposes.
+The default value is `information`. More verbose log levels like `debug` can affect the runtime performance of profiler auto instrumentation, so use them _only_ for diagnostics purposes.
 
 :::{note}
-If you don't explicitly set `ELASTIC_OTEL_LOG_TARGETS` to include `file`, global file logging will only be enabled when you configure it with `trace` or `debug`.
+If you don't explicitly set `ELASTIC_OTEL_LOG_TARGETS` to include `file`, global file logging will only be enabled when you configure it with `debug`.
 :::
 
 `OTEL_DOTNET_AUTO_LOG_DIRECTORY` _(optional)_:
@@ -112,7 +111,7 @@ A semi-colon separated list of targets for profiler logs. Valid values are
 * stdout
 * none
 
-The default value is `file` if you set `OTEL_DOTNET_AUTO_LOG_DIRECTORY` or set `OTEL_LOG_LEVEL` to `trace` or `debug`.
+The default value is `file` if you set `OTEL_DOTNET_AUTO_LOG_DIRECTORY` or set `OTEL_LOG_LEVEL` to `debug`.
 
 ## Advanced troubleshooting
 
@@ -132,7 +131,7 @@ using OpenTelemetry;
 using ILoggerFactory loggerFactory = LoggerFactory.Create(static builder =>
 {
    builder
-      .AddFilter("Elastic.OpenTelemetry", LogLevel.Trace)
+      .AddFilter("Elastic.OpenTelemetry", LogLevel.Debug)
       .AddConsole();
 });
 
@@ -149,7 +148,7 @@ using var sdk = OpenTelemetrySdk.Create(builder => builder
 
 This example adds the console logging provider, but you can include any provider here. To use this sample code, add a dependency on the `Microsoft.Extensions.Logging.Console` [NuGet package](https://www.nuget.org/packages/microsoft.extensions.logging.console).
 
-You create and configure an `ILoggerFactory`. In this example, you configure the `Elastic.OpenTelemetry` category to capture trace logs, which is the most verbose option. This is the best choice when you diagnose initialization issues.
+You create and configure an `ILoggerFactory`. In this example, you configure the `Elastic.OpenTelemetry` category to capture debug logs, which is the most verbose option. This is the best choice when you diagnose initialization issues.
 
 You use the `ILoggerFactory` to create an `ILogger`, which you then assign to the `ElasticOpenTelemetryOptions.AdditionalLogger` property. Once you pass the `ElasticOpenTelemetryOptions` into the `WithElasticDefaults` method, the provided logger can capture bootstrap logs.
 


### PR DESCRIPTION
## Summary

While `Trace` logging is partially supported, due to limitations in the upstream SDK, we prefer the highest verbosity to be set using `Debug`.

This change updates the troubleshooting to avoid any confusion.