### PR TITLE
[Workflows] Update the elasticsearch.index example

### DIFF
--- a/explore-analyze/workflows/data/templating.md
+++ b/explore-analyze/workflows/data/templating.md
@@ -194,10 +194,11 @@ steps:
           type: "tags"
 
   - name: create_document
-    type: elasticsearch.index
+    type: elasticsearch.request
     with:
-      index: "reports"
-      document:
+      method: POST
+      path: /reports/_doc
+      body:
         # Preserves the array type, doesn't stringify it
         tags: "${{steps.get_tags.output.hits.hits[0]._source.tags}}"
 ```


### PR DESCRIPTION
## [Workflows][9.3 & Serverless][Phase 2]

Resolves https://github.com/elastic/docs-content/issues/5031 by updating an example that contains the `elasticsearch.index` due to a bug with this step in ECH deployments. 
## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

