### PR TITLE
[agent builder] Update cross-cluster search limitation description

### DIFF
--- a/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
+++ b/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
@@ -25,9 +25,9 @@ This feature requires the appropriate {{stack}} [subscription](https://www.elast
 Refer to [Get started](get-started.md#enable-agent-builder) if you need instructions about enabling {{agent-builder}} for your deployment type.
 :::
 
-### Cross-cluster search not supported
+### Cross-cluster search not supported in index search tools
 
-Agent Builder does not yet support [cross-cluster search (CCS)](/explore-analyze/cross-cluster-search.md).
+Index search tool types do not yet support [cross-cluster search (CCS)](/explore-analyze/cross-cluster-search.md).
 
 ### A2A streaming not supported
 


### PR DESCRIPTION
Clarified the limitation regarding cross-cluster search support in index search tools.
