### PR TITLE
[Security] Remove tip suggesting host needs to be online for isolation

### DIFF
--- a/solutions/security/endpoint-response-actions/isolate-host.md
+++ b/solutions/security/endpoint-response-actions/isolate-host.md
@@ -39,11 +39,6 @@ Isolated hosts, however, can still send data to {{elastic-sec}}. You can also cr
 
 You can isolate a host from a detection alert’s details flyout, from the Endpoints page, or from the endpoint response console. Once a host is successfully isolated, an `Isolated` status displays next to the `Agent status` field, which you can view on the alert details flyout or Endpoints list table.
 
-::::{tip}
-If the request fails, verify that the {{agent}} and your endpoint are both online before trying again.
-::::
-
-
 All actions executed on a host are tracked in the host’s response actions history, which you can access from the Endpoints page. Refer to [](/solutions/security/endpoint-response-actions/isolate-host.md#view-host-isolation-details) for more information.
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Removes the tip that suggests that a host needs to be online in order to make an isolation request. Reported by @paul-tavares in Slack thread.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

