### PR TITLE
[Internal]: Case templates were GA'd in 8.18

### DIFF
--- a/explore-analyze/alerts-cases/cases.md
+++ b/explore-analyze/alerts-cases/cases.md
@@ -13,7 +13,7 @@ products:
 
 Cases are used to open and track issues directly in {{kib}}. You can add assignees and tags to your cases, set their severity and status, and add alerts, comments, and visualizations. You can create cases automatically when alerts occur or send cases to external incident management systems by configuring connectors.
 
-{applies_to}`stack: preview` {applies_to}`serverless: preview` You can also optionally add custom fields and case templates.
+You can also optionally add custom fields and case templates.
 
 {applies_to}`stack: ga 9.2` Cases are automatically assigned human-readable numeric IDs, which you can use for easier referencing. Each time you create a new case in your [space](docs-content://deploy-manage/manage-spaces.md), the case ID increments by one. IDs are assigned to cases by a background task that runs every 10 minutes, which can cause a delay in ID assignment, especially in spaces with many cases. You can find the case ID after the case's name and can use it while searching the Cases table.
 

--- a/explore-analyze/alerts-cases/cases/manage-cases-settings.md
+++ b/explore-analyze/alerts-cases/cases/manage-cases-settings.md
@@ -76,10 +76,6 @@ You can subsequently remove or edit custom fields on the **Settings** page.
 
 ## Templates [case-templates]
 
-::::{warning}
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
 You can make the case creation process faster and more consistent by adding templates. A template defines values for one or all of the case fields (such as severity, tags, description, and title) as well as any custom fields.
 
 To create a template:

--- a/solutions/observability/incident-management/configure-case-settings.md
+++ b/solutions/observability/incident-management/configure-case-settings.md
@@ -120,11 +120,6 @@ You can subsequently remove or edit custom fields on the **Settings** page.
 
 ## Templates [observability-case-templates]
 
-::::{warning}
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 You can make the case creation process faster and more consistent by adding templates. A template defines values for one or all of the case fields (such as severity, tags, description, and title) as well as any custom fields.
 
 To create a template:

--- a/solutions/security/investigate/configure-case-settings.md
+++ b/solutions/security/investigate/configure-case-settings.md
@@ -109,11 +109,6 @@ You can subsequently remove or edit custom fields on the **Settings** page.
 
 ## Templates [cases-templates]
 
-::::{warning}
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-::::
-
-
 You can make the case creation process faster and more consistent by adding templates. A template defines values for one or all of the case fields (such as severity, tags, description, and title) as well as any custom fields.
 
 To create a template:


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->
Fixes https://github.com/elastic/docs-content/issues/5209. 

Case templates were moved from tech preview to GA in 8.18. The 9.x/Serverless docs were still showing them as being in tech preview. 

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

