### PR TITLE
Change code owners of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 *                                           @elastic/docs
 
 # Templates, workflows, and config
-/.github/                                   @elastic/doc-leads
+/.github/                                   @elastic/doc-leads @elastic/docs-tech-leads
 /.github/workflows/                         @elastic/docs-engineering
 /.github/scripts/                           @elastic/docs-engineering
 /acrolinx/                                  @elastic/doc-leads


### PR DESCRIPTION
## Summary

This Pr changes the code owners of CODEOWNERS by adding `@elastic/docs-tech-leads`.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  

