### PR TITLE
Add missing docs for Jina models

### DIFF
--- a/explore-analyze/machine-learning/nlp/ml-nlp-jina.md
+++ b/explore-analyze/machine-learning/nlp/ml-nlp-jina.md
@@ -79,10 +79,6 @@ The `jina-embeddings-v5-text-nano` model has 239M parameters, supports an 8192 t
 
 For more information about the model family, refer to the [Elastic blog post](https://www.elastic.co/search-labs/blog/jina-embeddings-v5-text) or the [model collection](https://huggingface.co/collections/jinaai/jina-embeddings-v5-text) on Hugging Face.
 
-### Dense vector embeddings
-
-Dense vector embeddings are fixed-length numerical representations of text. When you send text to an EIS {{infer}} endpoint that uses `jina-embeddings-v5-text-nano`, the model returns a vector of floating-point numbers (for example, 768 values). Texts that are semantically similar have embeddings that are close to each other in this vector space. {{es}} stores these vectors in [`dense_vector`](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md) fields or through the [`semantic_text`](elasticsearch://reference/elasticsearch/mapping-reference/semantic-text.md) type and uses vector similarity search to retrieve the most relevant documents for a given query. Unlike [ELSER](/explore-analyze/machine-learning/nlp/ml-nlp-elser.md), which expands text into sparse token-weight vectors, this model produces compact dense vectors that are well suited for multilingual and cross-domain use cases.
-
 ### Requirements [jina-embeddings-v5-text-nano-req]
 
 To use `jina-embeddings-v5-text-nano`, you must have the [appropriate subscription](https://www.elastic.co/subscriptions) level or the trial period activated.
@@ -129,10 +125,6 @@ As the model runs on EIS, Elastic's own infrastructure, no ML node scaling and c
 The `jina-embeddings-v3` model supports input lengths of up to 8192 tokens and produces 1024-dimension embeddings by default. It uses task-specific adapters to optimize embeddings for different use cases (such as retrieval or classification), and includes support for Matryoshka Representation Learning, which allows you to truncate embeddings to fewer dimensions with minimal loss in quality.
 
 For more information about the model, refer to the [model card](https://huggingface.co/jinaai/jina-embeddings-v3) on Hugging Face.
-
-### Dense vector embeddings
-
-Dense vector embeddings are fixed-length numerical representations of text. When you send text to an EIS {{infer}} endpoint that uses `jina-embeddings-v3`, the model returns a vector of floating-point numbers (for example, 1024 values). Texts that are semantically similar have embeddings that are close to each other in this vector space. {{es}} stores these vectors in [`dense_vector`](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md) fields or through the [`semantic_text`](elasticsearch://reference/elasticsearch/mapping-reference/semantic-text.md) type and uses vector similarity search to retrieve the most relevant documents for a given query. Unlike [ELSER](/explore-analyze/machine-learning/nlp/ml-nlp-elser.md), which expands text into sparse token-weight vectors, this model produces compact dense vectors that are well suited for multilingual and cross-domain use cases.
 
 ### Requirements [jina-embeddings-v3-req]
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
- Cursor with OpenAI GPT 5.2 Codex

Prompt:
> The @explore-analyze/machine-learning/nlp/ml-nlp-jina.md file has information about the Jina embeddings v3 model and the Jina reranker v2 model. However, it's now out of date. On the Elastic blog we have announced several new Jina models via the Elastic Inference Service - Jina Reranker v3, Jina Embeddings v5 text small, and Jina Embeddings v5 text nano. Propose an update to the information in the file to include these three new models, using the blog posts to derive the details. Please keep the overall document structure and style consistent, give relevant examples, and show the embedding models before the reranker models, with the newer versions first and the older versions afterwards.

