### PR TITLE
Enable experimental Vale spelling rule

### DIFF
--- a/.vale-overrides.ini
+++ b/.vale-overrides.ini
@@ -1,0 +1,1 @@
+Elastic.Spelling = YES


### PR DESCRIPTION
## Summary

- Adds a `.vale-overrides.ini` file that enables the `Elastic.Spelling` rule for this repo.

The spelling rule was added to the [Elastic style guide](https://github.com/elastic/vale-rules) in [vale-rules#110](https://github.com/elastic/vale-rules/pull/110). It ships disabled by default and repos opt in by adding this one-line override file. No workflow changes are needed — the lint action detects the file automatically.

### What the rule does

- Checks documentation for misspellings using Vale's built-in Hunspell-based spell checker (American English).
- Includes regex filters for common technical false positives (camelCase, acronyms, CLI flags, file extensions, Elasticsearch field paths, etc.).
- Backed by three vocabulary files (~1,650 accepted terms) covering Elastic products, third-party tools, and generic tech jargon.
- Calibrated against a full corpus scan of 60 docs repos (~13,600 files), reducing false positives by 94%.

## Test plan

- [ ] Verify the Vale linter runs successfully in CI on this PR.
- [ ] Check that spelling violations appear in the Vale report for any misspelled words in changed files.
- [ ] Confirm no significant increase in false positives.

Made with [Cursor](https://cursor.com)