### PR TITLE
Update load balancer documentation for clarity

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/ece-load-balancers.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-load-balancers.md
@@ -10,7 +10,11 @@ products:
 
 # Load balancers [ece-load-balancers]
 
-[{{ece}} architecture](./ece-architecture.md) is designed to be used in conjunction with at least one load balancer. A load balancer is not included with {{ece}}, so you need to provide one yourself and place it in front of the {{ece}} proxies.
+[{{ece}} (ECE) architecture](./ece-architecture.md) is designed to be used in conjunction with at least one load balancer. ECE does not include a built-in load balancer, so you must provision and configure one in front of the ECE proxies.
+
+:::{note}
+Provisioning and configuring the load balancer is the customer’s responsibility and is outside the scope of this documentation. Refer to your load balancer provider’s documentation and support resources for configuration guidance.
+:::
 
 Use the following recommendations when configuring your load balancer:
 


### PR DESCRIPTION
Clarified the responsibility for load balancer provisioning and configuration, and updated language for better readability.

Including an interesting paragraph by @kunisen in the cancelled PR https://github.com/elastic/docs-content/pull/5324

@kunisen , let me know your thoughts, I've added it on top of the page and not just on the algorithms paragraph.

I think it was a good addition.

