### PR TITLE
[ECE] Update steps of entire installation maintenance

### DIFF
--- a/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
+++ b/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md
@@ -35,7 +35,7 @@ Use the following methods to perform maintenance on one or more ECE hosts while 
   * [For Podman-based installations: disable the Podman-related services](#ece-perform-host-maintenance-podman-disable) 
 * [Remove and reinstall the host (destructive)](#ece-perform-host-maintenance-delete-runner)
 
-### Entire ECE installation maintenance
+**Entire ECE installation maintenance**
 
 Use this method when the maintenance activity requires shutting down the entire ECE platform.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Preview / View

* Before PR merge: [deploy-manage/maintenance/ece/perform-ece-hosts-maintenance.md](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/5340/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance)
* After PR merge: https://www.elastic.co/docs/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

### Background

Our current doc about "shutting down all ECE hosts" is confusing and misleading:
https://www.elastic.co/docs/deploy-manage/maintenance/ece/perform-ece-hosts-maintenance#ece-perform-host-maintenance-delete-runner

* It says: `By shutting down the host (less destructive)` but it's actually shutting down ALL ECE hosts (per the description like `Shut down all allocators:`, etc).

* It says: `Enable maintenance mode on the allocator.`, but given it's shutting down entire ECE and all hosts, it doesn't make sense to do this step, all service will be taken down.

* Also with some additional steps required in this scenario: We should stop routing request first, take snapshot, also we shouldn't recommend terminating deployments, etc.

Details are described in https://github.com/elastic/support-tech-lead/issues/1751.

## Doc update detail

---

I had a sync from @R0ky and here's the note:

#### [1] Overview 

```
Shuttind down all the runners (hosts) in an ECE deployment 
This method lets you temporarily shutt down all runners in an ECE deployment, e.g. for data center moves or planned power outages. It is offered as an non-guaranteed and less destructive alternative to fully rebuilding your ECE infrastructure. 

To shut down all the runners:

Disable traffic from load balancers.

Shut down all allocators

Shut down all non-director hosts.

Shut down directors.
```

### [2] Steps

So this to stop:

- To shut down all the runners:
- Disable routing on all non system deployments
- Make sure all non system deployments are green
- Take snapshot on all deployments
- Disable traffic from load balancers.
- Shut down all allocators
- Shut down all non-director hosts.
- Shut down directors

To start:

- Start all directors.
- Verify that there is a healthy Zookeeper quorum (at least one zk_server_state leader, and zk_followers + zk_synced_followers should match the number of Zookeeper followers):
- Start all remaining hosts.
- Re-enable traffic from load balancers.
- Re-enable routing based on Deployment priority

## Side notes

### Snapshot

Chat with @AlexP-Elastic in [this link](https://elastic.slack.com/archives/C01KXR8BQ2F/p1771989944134759?thread_ts=1771936047.205499&cid=C01KXR8BQ2F)

> > shutdown deployments: Do you agree that we should add make sure you have a good snapshot taken first,
> 
> ++ (though let’s make sure we recommend not shutting them down at all - just mention if the customer has a good reason they need to, then they should)

### system deployment

Chat with @AlexP-Elastic in [this link](https://elastic.slack.com/archives/C01KXR8BQ2F/p1771989944134759?thread_ts=1771936047.205499&cid=C01KXR8BQ2F)

> system deployments: Do you agree that we should add a note saying avoid shutting down system clusters
> 
> ++

---

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

