### PR TITLE
Fix formatting of ES|QL entry in search documentation

### DIFF
--- a/solutions/search/querying-for-search.md
+++ b/solutions/search/querying-for-search.md
@@ -24,7 +24,7 @@ Once you know which [search approaches](search-approaches.md) you need to use, y
 | Interface | Endpoint | Description | Best for |
 |-----------|----------|-------------|----------|
 | [**Query DSL**](/explore-analyze/query-filter/languages/querydsl.md) | [`_search`](the-search-api.md) | Original, JSON-based query language native to Elasticsearch. Powerful but complex syntax. | Full-text and semantic search queries |
-| [**ES|QL**](esql-for-search.md) | `_query` | Fast, SQL-like language with piped syntax, built on new compute architecture. | Filtering, analysis, aggregations |
+| [**ES\|QL**](esql-for-search.md) | `_query` | Fast, SQL-like language with piped syntax, built on new compute architecture. | Filtering, analysis, aggregations |
 | [**Retrievers**](retrievers-overview.md) | `_search` | Modern `_search` API syntax focused on composability. | Building complex search pipelines, especially those using semantic search. Required for [semantic reranking](ranking/semantic-reranking.md). |
 
 These query languages are complementary, not mutually exclusive. You can use different query languages for different parts of your application, based on your specific needs. This flexibility allows you to gradually adopt newer interfaces as your requirements evolve.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->
Fixes the ES|QL entry formatting issue, the pipe needed to be escaped

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [X] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

