### PR TITLE
Document timezone handling for ES|QL queries in Kibana

### DIFF
--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -185,9 +185,11 @@ stack: ga 9.4
 serverless: ga
 ```
 
-When you run {{esql}} queries in Discover, dashboards, alerting, or Maps, {{kib}} automatically applies the timezone from {{kib}}'s [Advanced Settings](kibana://reference/advanced-settings.md) to date and time functions and time-based filtering.
+{{esql}} queries use a timezone for date and time functions and time-based filtering. There are two ways to control it:
 
-To change the timezone:
+**{{kib}} advanced setting (default)**
+
+When you run {{esql}} queries in Discover, dashboards, alerting, or Maps, {{kib}} automatically uses the timezone from the **Time zone** (`dateFormat:tz`) [advanced setting](kibana://reference/advanced-settings.md). To change it:
 
 1. Go to **Stack Management** → **Advanced Settings** (or **Management** → **Advanced Settings** in {{serverless-short}}).
 2. Search for **Time zone** (`dateFormat:tz`).
@@ -195,9 +197,17 @@ To change the timezone:
 
 Some {{kib}} features that run {{esql}} queries independently, such as Security detection rules and the machine learning Data Visualizer, do not use this setting and default to UTC.
 
-:::{note}
-{{esql}} also supports a [`SET time_zone`](elasticsearch://reference/query-languages/esql/commands/set.md) directive. While the editor does not suggest it in autocomplete, you can type it manually in a query. When present, `SET time_zone` overrides the timezone from the advanced setting for that query. You can also use `SET time_zone` through the [Dev Tools Console](../tools/console.md) or the {{es}} API directly.
-:::
+**Per-query override with SET**
+
+To use a different timezone for a specific query, add a [`SET time_zone`](elasticsearch://reference/query-languages/esql/commands/set.md) directive before the source command. When present, it overrides the advanced setting for that query:
+
+```esql
+SET time_zone = "America/New_York";
+FROM kibana_sample_data_logs
+| STATS count = COUNT(*) BY BUCKET(@timestamp, 1 hour)
+```
+
+The editor does not suggest `SET time_zone` in autocomplete, but you can type it manually. You can also use it through the [Dev Tools Console](../tools/console.md) or the {{es}} API directly. For more information about the `SET` directive, refer to [Control query behavior with SET](#esql-kibana-set).
 
 
 ## Use variables and controls [add-variable-control]


### PR DESCRIPTION
## Summary

- Adds a new "Timezone handling" subsection under "Filter by time" on the [ES|QL in Kibana](https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql-kibana) page.
- Presents two approaches for controlling timezone as equals:
  - **Kibana advanced setting** (default): the `dateFormat:tz` setting is automatically applied in Discover, dashboards, alerting, and Maps.
  - **Per-query override with SET**: the `SET time_zone` directive can be typed manually (not autocompleted) and overrides the advanced setting for that query.
- Documents which Kibana features do not use the advanced setting and default to UTC (Security detection rules, machine learning Data Visualizer).
- Cross-references the SET directive section (PR #5455) for the full list of available `SET` settings.

Related to: https://github.com/elastic/docs-content/issues/4963
Related Kibana PR: https://github.com/elastic/kibana/pull/247917

### Key behavioral findings

During code verification, we discovered that the initial assumption ("SET time_zone is ignored in the editor") was incorrect:

- **Kibana does not strip `SET time_zone`** from queries. It sends the user's query as-is alongside the API-level `time_zone` parameter from the advanced setting.
- **`SET time_zone` overrides the advanced setting** on the Elasticsearch side (confirmed in `EsqlSession.java`: the SET directive takes precedence over the request parameter).
- **When no timezone is provided** (no API parameter, no SET directive), Elasticsearch defaults to UTC (confirmed: `ZoneOffset.UTC` in `QuerySettings.java`).

This led to a significant rewrite of the section to present `SET time_zone` as a first-class option rather than a footnote.

### Placement

The subsection is placed at the **end** of "Filter by time", after the three filtering methods (standard time filter, custom time parameters, WHERE). After PR #5455 is also merged, the page structure will be:

1. Filter by time → Standard time filter → Custom time parameters → Time ranges with WHERE → **Timezone handling**
2. **Control query behavior with SET** (from #5455, includes a `time_zone` entry that cross-references back here)
3. Use variables and controls

### Verification against codebase

| Claim | Status | Source |
|-------|--------|--------|
| Kibana passes `dateFormat:tz` to ES\|QL queries | Verified | `data/common/search/expressions/esql.ts` |
| Works in Discover, dashboards, alerting, Maps | Verified | esql expression, Lens helpers, alert rule, Maps source |
| Security detection rules don't pass timezone | Verified | `detection_engine/rule_types/esql/build_esql_search_request.ts` |
| Data Visualizer doesn't pass timezone | Verified | `data_visualizer/search_strategy/esql_requests/` (no `time_zone` in params) |
| Setting label is "Time zone" (`dateFormat:tz`) | Verified | `core/packages/ui-settings/server-internal/src/settings/date_formats.ts` |
| `SET time_zone` is not autocompleted but works | Verified | `generate_settings.ts` (excluded) + `EsqlSession.java` (SET wins) |
| Default without any timezone is UTC | Verified | `QuerySettings.java` (`ZoneOffset.UTC`) |

### Availability note

Timezone support is on `main` and expected in **9.4** for stack. GA-quality (no feature flags, no snapshot-only restrictions). Tagged `stack: ga 9.4` / `serverless: ga`.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: claude-4.6-opus-high in Cursor