### PR TITLE
[not ready] Document grouped view for ES|QL STATS results in Discover

### DIFF
--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -368,7 +368,7 @@ When you run an {{esql}} query with a [`STATS ... BY`](elasticsearch://reference
 
 ### Group row actions
 
-Right-click on a group row or use the row's context menu to access these actions:
+Each group row has an actions menu ({icon}`boxes_horizontal`) with the following options:
 
 - **Copy to clipboard**: Copy the group value.
 - **Filter in**: Add a `WHERE` clause to the query to keep only this group's value.

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -335,6 +335,54 @@ When you save your edits, the control is updated for your query.
 :::
 
 
+## Explore STATS results in a grouped view [esql-discover-grouped-stats]
+```{applies_to}
+stack: ga 9.4
+serverless: ga
+```
+
+When you run an {{esql}} query with a [`STATS ... BY`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-stats-by) command that groups results by a single field, **Discover** can display results in a grouped view. Instead of a flat table, results are organized by group, with each row representing one value of the `BY` field alongside its aggregated metrics.
+
+% TODO: Add a screenshot of the grouped view. Uncomment the image directive below and replace the path when the screenshot is available.
+% :::{image} /explore-analyze/images/discover-esql-grouped-view.png
+% :alt: Grouped view of STATS results in Discover showing expandable rows
+% :screenshot:
+% :::
+
+### Use the grouped view
+
+1. Run an {{esql}} query with `STATS ... BY <field>`. For example:
+
+   ```esql
+   FROM kibana_sample_data_logs
+   | STATS count = COUNT(*), avg_bytes = AVG(bytes) BY geo.dest
+   ```
+
+2. The **Group by** button appears in the table toolbar with a {icon}`flask` badge indicating this is a technical preview feature. It lists the available grouping field.
+
+3. Select a field from the **Group by** list. Results are reorganized into groups.
+
+4. Expand any group row to view the underlying documents for that group.
+
+5. To return to the standard flat table, open the **Group by** menu and select **none**.
+
+### Group row actions
+
+Right-click on a group row or use the row's context menu to access these actions:
+
+- **Copy to clipboard**: Copy the group value.
+- **Filter in**: Add a `WHERE` clause to the query to keep only this group's value.
+- **Filter out**: Add a `WHERE` clause to exclude this group's value.
+- **Open in new tab**: Open a new Discover tab with a query filtered to show documents for the selected group.
+
+:::{note}
+The grouped view is available when:
+
+- The query uses `STATS ... BY` with a single `BY` field.
+- The `BY` field does not use grouping functions such as `BUCKET`.
+:::
+
+
 ## Refine an {{esql}} query by interacting with the results table
 
 Certain interactions with the results table of your {{esql}} query in Discover apply additional filters to your query. When hovering over a value cell, contextual options appear: 

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -33,7 +33,7 @@ For the complete {{esql}} documentation, including all supported commands, funct
    If you've entered a KQL or Lucene query in the default mode of Discover, it automatically converts to ES|QL.
    :::
 
-   Let’s say we want to find out what operating system users have and how much RAM is on their machine.
+   Let's say we want to find out what operating system users have and how much RAM is on their machine.
 
 3. Set the time range to **Last 7 days**.
 4. Copy the following query. To make queries more readable, you can put each processing command on a new line.
@@ -44,7 +44,7 @@ For the complete {{esql}} documentation, including all supported commands, funct
     ```
 
     1. We're specifically looking for data from the sample web logs we installed.
-    2. We’re only keeping the `machine.os` and `machine.ram` fields in the results table.
+    2. We're only keeping the `machine.os` and `machine.ram` fields in the results table.
    
    ::::{note}
    {{esql}} keywords are not case sensitive.
@@ -53,7 +53,7 @@ For the complete {{esql}} documentation, including all supported commands, funct
 5. Click **▶Run**.
    ![An image of the query result](/explore-analyze/images/kibana-esql-machine-os-ram.png "")
 
-Let’s add `geo.dest` to our query to find out the geographical destination of the visits and limit the results.
+Let's add `geo.dest` to our query to find out the geographical destination of the visits and limit the results.
 
 1. Copy the query below:
 
@@ -65,7 +65,7 @@ Let’s add `geo.dest` to our query to find out the geographical destination of 
 
 2. Click **▶Run** again. You can notice that the table is now limited to 10 results. The visualization also updated automatically based on the query, and broke down the data for you.
    ::::{note}
-   When you don’t specify any specific fields to retain using `KEEP`, the visualization isn’t broken down automatically. Instead, an additional option appears above the visualization and lets you select a field manually.
+   When you don't specify any specific fields to retain using `KEEP`, the visualization isn't broken down automatically. Instead, an additional option appears above the visualization and lets you select a field manually.
    ::::
    ![An image of the extended query result](/explore-analyze/images/kibana-esql-limit.png "")
 
@@ -91,9 +91,9 @@ We will now take it a step further to sort the data by machine RAM and filter ou
 
 ## Edit the ES|QL visualization [_edit_the_esql_visualization]
 
-You can make changes to the visualization by clicking the pencil icon. This opens additional settings that let you adjust the chart type, axes, breakdown, colors, and information displayed to your liking. If you’re not sure which route to go, check one of the suggestions available in the visualization editor.
+You can make changes to the visualization by clicking the pencil icon. This opens additional settings that let you adjust the chart type, axes, breakdown, colors, and information displayed to your liking. If you're not sure which route to go, check one of the suggestions available in the visualization editor.
 
-If you’d like to keep the visualization and add it to a dashboard, you can save it using the floppy disk icon.
+If you'd like to keep the visualization and add it to a dashboard, you can save it using the floppy disk icon.
 
 
 ## Organize the query results [esql-kibana-results-table]
@@ -137,11 +137,11 @@ FROM kibana_sample_data_logs
 
 By default, ES|QL identifies time series data when an index contains a `@timestamp` field. This enables the time range selector and visualization options for your query.
 
-If your index doesn’t have an explicit `@timestamp` field, but has a different time field, you can still enable the time range selector and visualization options by calling the `?_tstart` and `?_tend` parameters in your query.
+If your index doesn't have an explicit `@timestamp` field, but has a different time field, you can still enable the time range selector and visualization options by calling the `?_tstart` and `?_tend` parameters in your query.
 
-For example, the eCommerce sample data set doesn’t have a `@timestamp` field, but has an `order_date` field.
+For example, the eCommerce sample data set doesn't have a `@timestamp` field, but has an `order_date` field.
 
-By default, when querying this data set, time series capabilities aren’t active. No visualization is generated and the time picker is disabled.
+By default, when querying this data set, time series capabilities aren't active. No visualization is generated and the time picker is disabled.
 
 ```esql
 FROM kibana_sample_data_ecommerce
@@ -337,8 +337,8 @@ When you save your edits, the control is updated for your query.
 
 ## Explore STATS results in a grouped view [esql-discover-grouped-stats]
 ```{applies_to}
-stack: ga 9.4
-serverless: ga
+stack: preview 9.4
+serverless: preview
 ```
 
 When you run an {{esql}} query with a [`STATS ... BY`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-stats-by) command that groups results by a single field, **Discover** can display results in a grouped view. Instead of a flat table, results are organized by group, with each row representing one value of the `BY` field alongside its aggregated metrics.


### PR DESCRIPTION
## Summary

- Adds a new "Explore STATS results in a grouped view" section to the [Using ES|QL in Discover](https://www.elastic.co/docs/explore-analyze/discover/try-esql) page.
- Documents the **Group by** selector (with Technical Preview badge), expandable group rows, and row actions (Copy to clipboard, Filter in, Filter out, Open in new tab).
- Describes conditions for the grouped view: requires `STATS ... BY` with a single `BY` field, not using grouping functions like `BUCKET`.
- Includes a placeholder for a screenshot (commented out in the source).

Closes #4959

### Availability check needed

The cascade/grouped view is gated behind a feature flag (`discover.cascadeLayoutEnabled`, which [defaults to `false` in the code](https://github.com/elastic/kibana/blob/main/src/platform/plugins/shared/discover/public/application/main/components/layout/cascaded_documents/cascaded_documents_provider.tsx)). We need to confirm:
- Is this flag enabled by default in 9.4 / serverless production?
- The UI shows a "Technical preview" badge (added in [#255725](https://github.com/elastic/kibana/pull/255725)), so the applies_to tag may need to be `preview` rather than `ga`.

### Additional PRs merged since the original issue was filed (Feb 3)

The cascade feature has had significant ongoing development since the issue was created:

| PR | Description |
|----|-------------|
| [#255725](https://github.com/elastic/kibana/pull/255725) | Add tech preview badge to cascade switch button |
| [#256630](https://github.com/elastic/kibana/pull/256630) | Specify strict layout guidance for rows and cells |
| [#251154](https://github.com/elastic/kibana/pull/251154) | Support group by fetching across tabs |
| [#248838](https://github.com/elastic/kibana/pull/248838) | Improvements to cascade component from Discover usage |
| [#251536](https://github.com/elastic/kibana/pull/251536) | Resolve stuttering in cascade component |
| [#253819](https://github.com/elastic/kibana/pull/253819) | Add consideration for inline cast to cascade capture rules |

### Related Kibana PRs

- [elastic/kibana#220119](https://github.com/elastic/kibana/pull/220119) — Grouped view for ES|QL STATS results (original PR)

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: claude-4.6-opus-high in Cursor


Made with [Cursor](https://cursor.com)