### PR TITLE
[Android] Using start-local for testing purposes

### DIFF
--- a/troubleshoot/ingest/opentelemetry/edot-sdks/android/index.md
+++ b/troubleshoot/ingest/opentelemetry/edot-sdks/android/index.md
@@ -155,7 +155,15 @@ For Elastic Cloud Hosted (ECH) and self-managed deployments, the export endpoint
 
 ### Local testing deployment
 
-You can quickly launch a local [EDOT Collector](elastic-agent://reference/edot-collector/index.md) service and use it as your export endpoint for testing by running the EDOT Collector launcher from the [Demo application](https://github.com/elastic/android-agent-demo/tree/main/edot-collector).
+You can use [start-local](https://github.com/elastic/start-local/) to quickly spin up {{es}}, {{kib}}, and the [EDOT Collector](elastic-agent://reference/edot-collector/index.md) locally with a single command:
+
+```bash
+curl -fsSL https://elastic.co/start-local | sh -s -- --edot
+```
+
+This creates an `elastic-start-local` folder and starts all three services. Once it finishes, the EDOT Collector endpoint will be available at `http://localhost:4318`, which you can use as your export endpoint for testing.
+
+For more information, refer to the [start-local repository](https://github.com/elastic/start-local/).
 
 ## Create an API key [create-api-key]
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Updates Android's troubleshooting page to mention [start-local](https://github.com/elastic/start-local/) for test deployments, rather than the previous option, which was a custom script from a demo application.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

