### PR TITLE
eck: es rolling restart and allocation delay annotations

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/nodes-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/nodes-orchestration.md
@@ -274,4 +274,4 @@ spec:
         node.store.allow_mmap: false
 ```
 
-In this example the 20-minute delay applies whenever ECK restarts a node, whether the restart is part of a version upgrade, a spec change, or a manually triggered rolling restart via `eck.k8s.elastic.co/restart-trigger`.
+In this example the 20-minute delay applies whenever ECK restarts a node, whether the restart is part of a version upgrade, a spec change, or a manually triggered rolling restart intiated by `eck.k8s.elastic.co/restart-trigger`.


### PR DESCRIPTION
## Summary
Add documentation for the new annotations added in the Elasticsearch resource of ECK. 

[Relevant ECK PR: https://github.com/elastic/cloud-on-k8s/pull/9172]

1. `eck.k8s.elastic.co/restart-trigger` That triggers a rolling restart to the cluster
2. `eck.k8s.elastic.co/restart-allocation-delay` That controls the `allocation_delay` parameter passed to the elasticsearch shutdown API. 

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude opus 4.6

This was added to both new sections.
````
```{applies_to}
eck: ga 3.4.0
```
````

We should either merge now or once the ECK 3.4.0 becomes GA.