### PR TITLE
[Security] [Bug] Fix maximum timeout value for Osquery

### DIFF
--- a/solutions/security/detect-and-alert/write-investigation-guides.md
+++ b/solutions/security/detect-and-alert/write-investigation-guides.md
@@ -217,7 +217,7 @@ You can embed Osquery buttons that let analysts run live queries against {{agent
     3. Expand the **Advanced** section to set a timeout period for the query and view or set [mapped ECS fields](/solutions/security/investigate/osquery.md#osquery-map-fields) included in the results (optional).
 
         ::::{note}
-        Overwriting the query's default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query's default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
         :::{image} /solutions/images/security-setup-osquery-investigation-guide.png

--- a/solutions/security/investigate/add-osquery-response-actions.md
+++ b/solutions/security/investigate/add-osquery-response-actions.md
@@ -54,7 +54,7 @@ You can add Osquery Response Actions to new or existing custom query rules. Quer
     * **Query**: Select a saved query or enter a new one. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](/solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
 

--- a/solutions/security/investigate/osquery.md
+++ b/solutions/security/investigate/osquery.md
@@ -53,7 +53,7 @@ To inspect hosts, run a query against one or more agents or policies, then view 
     * **Query**: Select a saved query or enter a new one in the text box. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](#osquery-map-fields)  included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
     * **Pack**: Select from available query packs. After you select a pack, all of the queries in the pack are displayed.
@@ -131,7 +131,7 @@ You can run packs as live queries or schedule packs to run for one or more agent
     * Click **Add query** and then add a saved query or enter a new query. Each query must include a unique query ID and the interval at which it should run. Optionally, set the minimum Osquery version and platform, specify a timeout period, or [map ECS fields](#osquery-map-fields). When you add a saved query to a pack, this adds a copy of the query. A connection is not maintained between saved queries and packs.
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query’s default timeout period allows you to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
     * Upload queries from a `.conf` query pack by dragging the pack to the drop zone under the query table. To explore the community packs that Osquery publishes, click **Example packs**.
@@ -169,7 +169,7 @@ Once you save a query, you can only edit it from the **Saved queries** tab:
     * The unique identifier (required).
     * A brief description.
     * The SQL query (required). Osquery supports multi-line queries.
-    * A timeout period (optional). Increase the query’s default timeout period to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+    * A timeout period (optional). Increase the query’s default timeout period to support queries that require more time to complete. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
     * The [ECS fields](#osquery-map-fields) to populate when the query is run (optional). These fields are also copied in when you add this query to a pack.
     * The defaults to set when you add the query to a pack.
 

--- a/solutions/security/investigate/run-osquery-from-alerts.md
+++ b/solutions/security/investigate/run-osquery-from-alerts.md
@@ -42,7 +42,7 @@ To run Osquery from an alert:
     * **Query**: Select a saved query or enter a new one in the text box. After you enter the query, you can expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](/solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
 

--- a/solutions/security/investigate/run-osquery-from-investigation-guides.md
+++ b/solutions/security/investigate/run-osquery-from-investigation-guides.md
@@ -59,7 +59,7 @@ You can only add Osquery to investigation guides for custom rules because prebui
     3. Expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](/solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
 
@@ -83,7 +83,7 @@ You can only add Osquery to investigation guides for custom rules because prebui
     2. Expand the **Advanced** section to set a timeout period for the query, and view or set [mapped ECS fields](/solutions/security/investigate/osquery.md#osquery-map-fields) included in the results from the live query (optional).
 
         ::::{note}
-        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `86400` (24 hours).
+        Overwriting the query’s default timeout period allows you to support queries that take longer to run. The default and minimum supported value for the **Timeout** field is `60`. The maximum supported value is `900`.
         ::::
 
 6. Click **Submit** to run the query. Query results display in the flyout.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Resolves https://github.com/elastic/docs-content/issues/5301 by updating the incorrect maximum Osquery timeout value from 86400 to 900.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

