### PR TITLE
Add pull-requests: read to docs-build.yml permissions

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 permissions:
   contents: read
+  pull-requests: read
 jobs:
   build:
     uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1


### PR DESCRIPTION
## Summary

Adds `pull-requests: read` to the `docs-build.yml` permissions block. The reusable build workflow needs this for the changed-files check job to list PR files via the API.

Follow-up to #5618.


Made with [Cursor](https://cursor.com)