### PR TITLE
Fix workflows docs: rename outputSchema to schema and add schema to ai.agent

### DIFF
--- a/explore-analyze/ai-features/agent-builder/agents-and-workflows.md
+++ b/explore-analyze/ai-features/agent-builder/agents-and-workflows.md
@@ -45,6 +45,7 @@ Follow these steps to invoke an `ai.agent` as a step within a workflow.
 2.  Add a new step with the type `ai.agent`.
 3.  Configure the **`agent_id`** parameter with the unique identifier of the target agent.
 4.  Configure the **`message`** parameter with your natural language prompt.
+5.  Optionally, configure the **`schema`** parameter with a JSON Schema object to receive structured output from the agent instead of free-text.
 
 ### Example: Analyze flight delays
 The following example demonstrates a workflow that searches for flight delays and uses the **Elastic AI Agent** to summarize the impact. To follow along with this example ensure that the [{{kib}} sample flight data](https://www.elastic.co/docs/extend/kibana/sample-data) is installed.
@@ -85,6 +86,16 @@ steps:
 ```
 1. **agent_id**: The ID of the agent you want to call (must exist in Agent Builder).
 2. **message**: The prompt sent to the agent. You can use template variables (like `{{ steps.step_name.output }}`) to inject data dynamically.
+
+### Parameters
+
+Use the following parameters in the `with` block to configure the step:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_id` | string | Yes | The unique identifier of the target agent (must exist in {{agent-builder}}). |
+| `message` | string | Yes | The natural language prompt to send to the agent. Can include template variables to reference data from previous steps. |
+| `schema` | object | No | A JSON Schema object that defines the structure of the expected response. When provided, the agent returns structured data matching the schema instead of free-text. |
 
 
 ## Use `kibana.request` step

--- a/explore-analyze/workflows/steps/ai-steps.md
+++ b/explore-analyze/workflows/steps/ai-steps.md
@@ -38,7 +38,7 @@ Use the following parameters in the `with` block to configure the step:
 |-----------|------|----------|-------------|
 | `prompt` | string | Yes | The prompt text to send to the AI connector. Can include template variables to reference data from previous steps, inputs, or constants. |
 | `connectorId` | string | No | The ID or name of the AI connector to use. If omitted, uses the [default AI connector](/explore-analyze/ai-features/manage-access-to-ai-assistant.md#the-genai-settings-page). |
-| `outputSchema` | object | No | A JSON Schema object that defines the structure of the expected response. When provided, the AI connector returns structured data matching the schema. |
+| `schema` | object | No | A JSON Schema object that defines the structure of the expected response. When provided, the AI connector returns structured data matching the schema. |
 | `temperature` | number | No | Controls randomness in the AI response. Accepts values from `0` to `1` (for example, `0.3`). Lower values produce more deterministic responses; higher values produce more random responses. |
 
 ### Output structure
@@ -46,7 +46,7 @@ Use the following parameters in the `with` block to configure the step:
 The `ai.prompt` step produces output in the following structure:
 
 ```yaml
-content: <response>  # String or structured object if outputSchema is provided
+content: <response>  # String or structured object if schema is provided
 response_metadata: <metadata>  # Optional metadata from the connector
 ```
 
@@ -67,7 +67,7 @@ steps:
 
 ### Example: Structured output with schema
 
-This example uses `outputSchema` to return a structured response with specific fields and types.
+This example uses `schema` to return a structured response with specific fields and types.
 
 ```yaml
 steps:
@@ -76,7 +76,7 @@ steps:
     with:
       prompt: "Analyze this alert and categorize it: {{ event | json }}"
       connectorId: "security-analysis-connector"
-      outputSchema:
+      schema:
         type: object
         properties:
           severity:


### PR DESCRIPTION
## Summary

Fixes two documentation issues flagged by community feedback:

1. **`outputSchema` → `schema` rename in `ai-steps.md`**: The `outputSchema` parameter was renamed to `schema` in the product, but the docs still referenced the old name in the parameters table, output structure comment, example text, and YAML example.
2. **Missing `schema` parameter in `ai.agent` docs**: The `ai.agent` step in `agents-and-workflows.md` did not document the `schema` input parameter. Added it to the step instructions and a new parameters table.

## Pages affected

- [AI steps — Structured output with schema](https://www.elastic.co/docs/explore-analyze/workflows/steps/ai-steps#example-structured-output-with-schema)
- [Call agents from workflows — `ai.agent` step](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/agents-and-workflows#use-the-ai.agent-step)

Closes #5614

Made with [Cursor](https://cursor.com)