### PR TITLE
Add GCP asia-southeast1 to EIS supported regions

### DIFF
--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -66,6 +66,7 @@ Elastic {{infer-cap}} Service is currently available in these regions:
 
 * {{aws}} `us-east-1`
 * {{gcp}} `us-east4`
+* {{gcp}} `asia-southeast1`
 
 All {{infer}} requests sent through EIS are routed to the nearest region, regardless of where your {{es}} deployment or {{serverless-short}} project is hosted.
 


### PR DESCRIPTION
## Summary

- Adds `asia-southeast1` GCP region to the list of supported EIS regions in the "Region and hosting" section of the EIS docs page.

## Test plan

- [ ] Verify the region appears correctly in the rendered docs
- [ ] Confirm no other region-related content needs updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)