### PR TITLE
Add 'actions' permission to docs-deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -8,6 +8,7 @@ permissions:
   deployments: write
   id-token: write
   pull-requests: write
+  actions: read
 jobs:
   deploy:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1


### PR DESCRIPTION
This is needed so the vale-report job can download the report from the pull request run.
