### PR TITLE
Rename share-alert-and-automate to share-alert-and-respond

### DIFF
--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -471,4 +471,4 @@ toc:
       - file: workflows/templates.md
   - file: numeral-formatting.md
   - hidden: explore-and-visualize.md
-  - hidden: share-alert-and-automate.md
+  - hidden: track-and-respond.md

--- a/explore-analyze/track-and-respond.md
+++ b/explore-analyze/track-and-respond.md
@@ -13,7 +13,7 @@ type: overview
 
 <!-- Overview page created for the v2 navigation -->
 
-# Share, alert, and act
+# Track and respond
 
 The {{es}} platform provides tools to share insights, get notified about important changes, and track incidents. These tools work together across every Elastic solution and project type.
 


### PR DESCRIPTION
## Summary

Rename the overview page and update references:
- File renamed: `share-alert-and-automate.md` → `share-alert-and-respond.md`
- H1 updated to "Share, alert, and respond"
- toc.yml hidden entry updated

Workflows is being promoted to its own top-level nav section, so the "automate" part no longer applies to this group. The section now covers Reporting, Alerting, and Cases.

## Test plan

- Verify the page builds without errors
- Verify the hidden entry resolves correctly