### PR TITLE
[Security] Endpoint exceptions hidden page

### DIFF
--- a/solutions/security/manage-elastic-defend/elastic-endpoint-exceptions.md
+++ b/solutions/security/manage-elastic-defend/elastic-endpoint-exceptions.md
@@ -1,0 +1,12 @@
+---
+applies_to:
+  stack: ga 9.4+
+  serverless:
+    security: ga
+products:
+  - id: security
+  - id: cloud-serverless
+---
+
+# {{elastic-endpoint}} exceptions 
+

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -656,6 +656,7 @@ toc:
         children:
           - file: security/manage-elastic-defend/endpoints.md
           - file: security/manage-elastic-defend/policies.md
+          - hidden: security/manage-elastic-defend/elastic-endpoint-exceptions.md
           - file: security/manage-elastic-defend/trusted-applications.md
           - file: security/manage-elastic-defend/trusted-devices.md
           - file: security/manage-elastic-defend/event-filters.md


### PR DESCRIPTION
## Summary

Creates a hidden Elastic Endpoint exceptions page to enable in-product linking.
Related to https://github.com/elastic/docs-content/issues/3883.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

