### PR TITLE
Set path-pattern: '**' to trigger on all file changes

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,3 +12,4 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
     with:
       enable-vale-linting: true
+      path-pattern: '**'

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -14,3 +14,4 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
     with:
       enable-vale-linting: true
+      path-pattern: '**'


### PR DESCRIPTION
## Summary

`docs-content` is a pure docs repository — every file is content. This sets `path-pattern: '**'` explicitly so the build triggers on any change.

This is a follow-up to the docs-actions migration PRs. The default `path-pattern` in `elastic/docs-actions` is being changed to `docs/**` (see elastic/docs-actions#47) to reduce noise in mixed repos. `docs-content` needs to opt out of that default.