### PR TITLE
Fix Prometheus remote write URL paths in 'Send data to different data streams' section

### DIFF
--- a/manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md
+++ b/manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md
@@ -84,14 +84,14 @@ You can control the target data stream using URL path parameters:
 | Endpoint | Data stream |
 | --- | --- |
 | `/_prometheus/api/v1/write` | `metrics-generic.prometheus-default` |
-| `/_prometheus/{dataset}/api/v1/write` | `metrics-{dataset}.prometheus-default` |
-| `/_prometheus/{dataset}/{namespace}/api/v1/write` | `metrics-{dataset}.prometheus-{namespace}` |
+| `/_prometheus/metrics/{dataset}/api/v1/write` | `metrics-{dataset}.prometheus-default` |
+| `/_prometheus/metrics/{dataset}/{namespace}/api/v1/write` | `metrics-{dataset}.prometheus-{namespace}` |
 
 For example, to route infrastructure metrics into a dedicated data stream, configure the remote write URL as:
 
 ```yaml
 remote_write:
-  - url: "https://<es_endpoint>/_prometheus/infrastructure/production/api/v1/write"
+  - url: "https://<es_endpoint>/_prometheus/metrics/infrastructure/production/api/v1/write"
 ```
 
 This sends data to the `metrics-infrastructure.prometheus-production` data stream.


### PR DESCRIPTION
The documented URL patterns for routing data to different data streams were missing the required `metrics` path segment.

- `/_prometheus/{dataset}/api/v1/write` → `/_prometheus/metrics/{dataset}/api/v1/write`
- `/_prometheus/{dataset}/{namespace}/api/v1/write` → `/_prometheus/metrics/{dataset}/{namespace}/api/v1/write`
- Updated the example URL accordingly

Verified against [`PrometheusRemoteWriteRestAction.java` lines 62–68](https://github.com/elastic/elasticsearch/blob/1c3093ff0c3d8c4b6be9f42259395aa169831460/x-pack/plugin/prometheus/src/main/java/org/elasticsearch/xpack/prometheus/rest/PrometheusRemoteWriteRestAction.java#L62-L68).