### PR TITLE
[Dashboards] Add programmatic creation docs and API examples

### DIFF
--- a/explore-analyze/dashboards/building.md
+++ b/explore-analyze/dashboards/building.md
@@ -31,3 +31,7 @@ To create or edit dashboards, you need:
   ::::
 
 * Sufficient privileges for the **Dashboard** feature. Without them, you might get a read-only indicator. A {{product.kibana}} administrator can [grant you the required privileges](../../deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md).
+
+## Create dashboards programmatically [building-programmatic]
+
+In addition to building dashboards in the {{product.kibana}} UI, you can create and manage dashboards and visualizations using APIs or AI-powered tools. Refer to [Create dashboards and visualizations programmatically](create-programmatically.md).

--- a/explore-analyze/dashboards/building.md
+++ b/explore-analyze/dashboards/building.md
@@ -34,4 +34,9 @@ To create or edit dashboards, you need:
 
 ## Create dashboards programmatically [building-programmatic]
 
+```{applies_to}
+stack: preview 9.4
+serverless: preview
+```
+
 In addition to building dashboards in the {{product.kibana}} UI, you can create and manage dashboards and visualizations using APIs or AI-powered tools. Refer to [Create dashboards and visualizations programmatically](create-programmatically.md).

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -31,6 +31,25 @@ Before creating a dashboard, ensure you have:
 
     When you create a dashboard, you are automatically in edit mode and can make changes to the dashboard.
 
+::::{dropdown} Create a dashboard using the API
+:applies_to: stack: preview 9.4, serverless: preview
+
+Use `POST /api/dashboards` to create an empty dashboard, or include panels inline:
+
+```bash
+curl -X POST "${KIBANA_URL}/api/dashboards" \
+  -H "Authorization: ApiKey ${API_KEY}" \
+  -H "kbn-xsrf: true" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "title": "Web logs overview",
+  "time_range": { "from": "now-90d", "to": "now" }
+}'
+```
+
+Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards) for the full schema, including how to add panels and controls.
+::::
+
 3. Populate your dashboard with the content that you need. You can:
 
     * [**Add new visualizations**](../visualize.md#panels-editors). Create a chart using [Lens](../visualize/lens.md), the default visualization editor in {{product.kibana}}, or other visualizations such as [Maps](../visualize/maps.md).
@@ -42,7 +61,7 @@ Before creating a dashboard, ensure you have:
 5. Define the main settings of your dashboard from the **Settings** menu located in the toolbar.
 
     1. A meaningful title, description, and [tags](../find-and-organize/tags.md) allow you to find the dashboard quickly later when browsing your list of dashboards or using the {{kib}} search bar.
-    2. Additional display options allow you unify the look and feel of the dashboard’s panels:
+    2. Additional display options allow you unify the look and feel of the dashboard's panels:
 
         * **Store time with dashboard** — Saves the specified time filter.
         * **Use margins between panels** — Adds a margin of space between each panel.
@@ -71,4 +90,3 @@ Before creating a dashboard, ensure you have:
 
     :::{include} ../_snippets/dashboard-ownership.md
     :::
-

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -17,6 +17,25 @@ Create a new dashboard in {{product.kibana}} to start visualizing and monitoring
 :url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-dashboards
 :::
 
+::::{dropdown} Create a dashboard using the API
+:applies_to: { stack: preview 9.4, serverless: preview }
+
+Use `POST /api/dashboards` to create a dashboard programmatically. You can create an empty dashboard or include panels inline:
+
+```bash
+curl -X POST "${KIBANA_URL}/api/dashboards" \
+  -H "Authorization: ApiKey ${API_KEY}" \
+  -H "kbn-xsrf: true" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "title": "Web logs overview",
+  "time_range": { "from": "now-90d", "to": "now" }
+}'
+```
+
+Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards) for the full request schema, including how to add panels and controls.
+::::
+
 ## Requirements [create-dashboard-requirements]
 
 Before creating a dashboard, ensure you have:
@@ -30,25 +49,6 @@ Before creating a dashboard, ensure you have:
 2. Select **Create dashboard** to start with an empty dashboard.
 
     When you create a dashboard, you are automatically in edit mode and can make changes to the dashboard.
-
-::::{dropdown} Create a dashboard using the API
-:applies_to: stack: preview 9.4, serverless: preview
-
-Use `POST /api/dashboards` to create an empty dashboard, or include panels inline:
-
-```bash
-curl -X POST "${KIBANA_URL}/api/dashboards" \
-  -H "Authorization: ApiKey ${API_KEY}" \
-  -H "kbn-xsrf: true" \
-  -H "Content-Type: application/json" \
-  -d '{
-  "title": "Web logs overview",
-  "time_range": { "from": "now-90d", "to": "now" }
-}'
-```
-
-Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards) for the full schema, including how to add panels and controls.
-::::
 
 3. Populate your dashboard with the content that you need. You can:
 

--- a/explore-analyze/dashboards/create-programmatically.md
+++ b/explore-analyze/dashboards/create-programmatically.md
@@ -1,10 +1,12 @@
 ---
+navigation_title: Create programmatically
 description: Use the Dashboards API, the Lens Visualizations API, or AI-powered tools to create and manage Kibana dashboards and visualizations programmatically.
 applies_to:
   stack: ga
   serverless: ga
 products:
   - id: kibana
+type: overview
 ---
 
 # Create dashboards and visualizations programmatically [create-programmatically]
@@ -35,7 +37,7 @@ Refer to the [Lens Visualizations API reference](https://www.elastic.co/docs/api
 
 ## Kibana dashboards agent skill [dashboards-agent-skill]
 
-The Kibana dashboards agent skill enables AI agents and LLM-powered tools to create and manage dashboards through natural language instructions. It is designed for agentic workflows where a language model generates dashboard definitions that are then applied automatically.
+The Kibana dashboards agent skill enables AI agents and LLM-powered tools to create and manage dashboards through natural language instructions. It is designed for agentic workflows where a language model generates dashboard definitions and applies them automatically.
 
 Refer to the [kibana-dashboards agent skill](https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-dashboards) on GitHub.
 

--- a/explore-analyze/dashboards/create-programmatically.md
+++ b/explore-analyze/dashboards/create-programmatically.md
@@ -5,37 +5,47 @@ applies_to:
   serverless: ga
 products:
   - id: kibana
-navigation_title: "Create programmatically"
 ---
 
 # Create dashboards and visualizations programmatically [create-programmatically]
 
-You can create and manage {{product.kibana}} dashboards and visualizations outside the UI using APIs or AI-powered tools. This is useful for automation workflows, GitOps pipelines, version-controlled dashboard definitions, and LLM-assisted generation.
+You can create and manage Kibana dashboards and visualizations outside of the UI, using REST APIs or AI-powered tools. This is useful for automating dashboard deployments, managing them in version control, building tooling around dashboard lifecycle management, or using AI agents to generate dashboards on demand.
 
-## Dashboards API [programmatic-dashboards-api]
+## Dashboards API [dashboards-api]
 
-{applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+```{applies_to}
+stack: preview 9.4
+serverless: preview
+```
 
-The Dashboards API lets you create, retrieve, update, and delete dashboards programmatically using standard HTTP requests. Use it to build dashboards from code, integrate dashboard management into CI/CD pipelines, or generate dashboards from templates.
+The Dashboards API provides full CRUD access to dashboards, including their panels, controls, sections, and display options. Use it to create dashboards from code, update them programmatically, or integrate dashboard management into your own tooling.
 
-Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards) for the full schema and available endpoints.
+Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards).
 
-## Lens Visualizations API [programmatic-lens-api]
+## Lens Visualizations API [lens-visualizations-api]
 
-{applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+```{applies_to}
+stack: preview 9.4
+serverless: preview
+```
 
-The Lens Visualizations API lets you create and manage reusable Lens visualizations independently of any dashboard. Use it to build a library of visualizations that can be shared across dashboards or updated centrally.
+The Lens Visualizations API lets you create and manage reusable Lens visualizations as saved objects. Once created, a visualization can be embedded in a dashboard by reference. Use it to build a library of reusable charts and metrics that can be shared across multiple dashboards.
 
-Refer to the [Lens Visualizations API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-lens) for the full schema and available endpoints.
+Refer to the [Lens Visualizations API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-lens).
 
-## Agent skill for dashboards [programmatic-agent-skill]
+## Kibana dashboards agent skill [dashboards-agent-skill]
 
-The kibana-dashboards agent skill enables LLM-driven workflows that create and manage dashboards through natural language. It exposes the Dashboards API as a callable skill for AI agents, making it straightforward to integrate dashboard automation into larger AI-powered pipelines.
+The Kibana dashboards agent skill enables AI agents and LLM-powered tools to create and manage dashboards through natural language instructions. It is designed for agentic workflows where a language model generates dashboard definitions that are then applied automatically.
 
-Refer to the [kibana-dashboards agent skill](https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-dashboards) on GitHub for setup instructions and usage examples.
+Refer to the [kibana-dashboards agent skill](https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-dashboards) on GitHub.
 
-## Agent Builder dashboard tools [programmatic-agent-builder-tools]
+## Agent Builder dashboard tools [agent-builder-dashboard-tools]
 
-{applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+```{applies_to}
+stack: preview 9.4
+serverless: preview
+```
 
-The Agent Builder includes built-in dashboard tools (`dashboard.create_dashboard` and `dashboard.update_dashboard`) that let you create and update dashboards through Elastic's AI assistant without leaving the chat interface. These tools are in tech preview and are tracked at [elastic/kibana#237795](https://github.com/elastic/kibana/issues/237795).
+Elastic's built-in AI assistant includes dashboard tools that let you create and update dashboards through a chat interface, without leaving the Kibana UI. Describe what you want to build, and the assistant generates the dashboard for you.
+
+Refer to [Agent Builder](../ai-features/agent-builder/overview.md) for an overview of the available built-in tools.

--- a/explore-analyze/dashboards/create-programmatically.md
+++ b/explore-analyze/dashboards/create-programmatically.md
@@ -48,4 +48,4 @@ serverless: preview
 
 Elastic's built-in AI assistant includes dashboard tools that let you create and update dashboards through a chat interface, without leaving the Kibana UI. Describe what you want to build, and the assistant generates the dashboard for you.
 
-Refer to [Agent Builder](../ai-features/agent-builder/overview.md) for an overview of the available built-in tools.
+Refer to [Agent Builder](../ai-features/elastic-agent-builder.md) for an overview of the available built-in tools.

--- a/explore-analyze/dashboards/create-programmatically.md
+++ b/explore-analyze/dashboards/create-programmatically.md
@@ -1,0 +1,41 @@
+---
+description: Use the Dashboards API, the Lens Visualizations API, or AI-powered tools to create and manage Kibana dashboards and visualizations programmatically.
+applies_to:
+  stack: ga
+  serverless: ga
+products:
+  - id: kibana
+navigation_title: "Create programmatically"
+---
+
+# Create dashboards and visualizations programmatically [create-programmatically]
+
+You can create and manage {{product.kibana}} dashboards and visualizations outside the UI using APIs or AI-powered tools. This is useful for automation workflows, GitOps pipelines, version-controlled dashboard definitions, and LLM-assisted generation.
+
+## Dashboards API [programmatic-dashboards-api]
+
+{applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+
+The Dashboards API lets you create, retrieve, update, and delete dashboards programmatically using standard HTTP requests. Use it to build dashboards from code, integrate dashboard management into CI/CD pipelines, or generate dashboards from templates.
+
+Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards) for the full schema and available endpoints.
+
+## Lens Visualizations API [programmatic-lens-api]
+
+{applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+
+The Lens Visualizations API lets you create and manage reusable Lens visualizations independently of any dashboard. Use it to build a library of visualizations that can be shared across dashboards or updated centrally.
+
+Refer to the [Lens Visualizations API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-lens) for the full schema and available endpoints.
+
+## Agent skill for dashboards [programmatic-agent-skill]
+
+The kibana-dashboards agent skill enables LLM-driven workflows that create and manage dashboards through natural language. It exposes the Dashboards API as a callable skill for AI agents, making it straightforward to integrate dashboard automation into larger AI-powered pipelines.
+
+Refer to the [kibana-dashboards agent skill](https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-dashboards) on GitHub for setup instructions and usage examples.
+
+## Agent Builder dashboard tools [programmatic-agent-builder-tools]
+
+{applies_to}`stack: preview 9.4` {applies_to}`serverless: preview`
+
+The Agent Builder includes built-in dashboard tools (`dashboard.create_dashboard` and `dashboard.update_dashboard`) that let you create and update dashboards through Elastic's AI assistant without leaving the chat interface. These tools are in tech preview and are tracked at [elastic/kibana#237795](https://github.com/elastic/kibana/issues/237795).

--- a/explore-analyze/kibana-data-exploration-learning-tutorial.md
+++ b/explore-analyze/kibana-data-exploration-learning-tutorial.md
@@ -160,7 +160,7 @@ You've queried, filtered, aggregated, and inspected data, all within Discover us
 
 ## Step 3: Build your dashboard [build-your-dashboard]
 
-Now that you have a dashboard with your first panel, add more visualizations to tell a complete story about your web traffic.
+Now that you have a dashboard with your first panel, add more visualizations to tell a complete story about your web traffic. You can also [recreate this dashboard using the API](#learn-tutorial-create-programmatically) once you have completed the tutorial.
 
 ::::::{stepper}
 
@@ -371,6 +371,114 @@ When you are happy with the layout, select **Save** in the toolbar.
 :::::
 
 ::::::
+
+### Create this dashboard using the API [learn-tutorial-create-programmatically]
+
+::::{dropdown} Recreate the Web logs overview dashboard with one API call
+:applies_to: { stack: preview 9.4, serverless: preview }
+
+Once you know what the finished dashboard looks like, you can create it programmatically using the Dashboards API. The following request creates the full dashboard built in this tutorial.
+
+```bash
+curl -X POST "${KIBANA_URL}/api/dashboards" \
+  -H "Authorization: ApiKey ${API_KEY}" \
+  -H "kbn-xsrf: true" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "title": "Web logs overview",
+  "time_range": { "from": "now-90d", "to": "now" },
+  "panels": [
+    {
+      "type": "lens",
+      "grid": { "x": 0, "y": 0, "w": 12, "h": 5 },
+      "config": {
+        "attributes": {
+          "title": "Median response size",
+          "type": "metric",
+          "dataset": { "type": "index", "index": "kibana_sample_data_logs", "time_field": "@timestamp" },
+          "metrics": [{ "type": "primary", "operation": "median", "field": "bytes", "format": { "type": "bytes" } }]
+        }
+      }
+    },
+    {
+      "type": "lens",
+      "grid": { "x": 0, "y": 5, "w": 48, "h": 12 },
+      "config": {
+        "attributes": {
+          "title": "Log volume over time per host",
+          "type": "xy",
+          "layers": [{
+            "type": "line",
+            "dataset": { "type": "index", "index": "kibana_sample_data_logs", "time_field": "@timestamp" },
+            "x": { "operation": "date_histogram", "field": "@timestamp" },
+            "y": [{ "operation": "count" }],
+            "breakdown": { "operation": "terms", "fields": ["host.keyword"], "size": 10 }
+          }]
+        }
+      }
+    },
+    {
+      "type": "lens",
+      "grid": { "x": 0, "y": 17, "w": 24, "h": 10 },
+      "config": {
+        "attributes": {
+          "title": "Requests by file extension",
+          "type": "xy",
+          "layers": [{
+            "type": "bar",
+            "dataset": { "type": "index", "index": "kibana_sample_data_logs", "time_field": "@timestamp" },
+            "x": { "operation": "terms", "fields": ["extension.keyword"], "size": 10 },
+            "y": [{ "operation": "count" }]
+          }]
+        }
+      }
+    },
+    {
+      "type": "lens",
+      "grid": { "x": 24, "y": 17, "w": 24, "h": 10 },
+      "config": {
+        "attributes": {
+          "title": "Events by response code",
+          "type": "xy",
+          "layers": [{
+            "type": "bar",
+            "dataset": {
+              "type": "esql",
+              "query": "FROM kibana_sample_data_logs | WHERE response IS NOT NULL | STATS event_count = COUNT(*) BY response"
+            },
+            "x": { "operation": "value", "column": "response" },
+            "y": [{ "operation": "value", "column": "event_count" }]
+          }]
+        }
+      }
+    },
+    {
+      "type": "lens",
+      "grid": { "x": 0, "y": 27, "w": 48, "h": 12 },
+      "config": {
+        "attributes": {
+          "title": "",
+          "type": "datatable",
+          "dataset": {
+            "type": "esql",
+            "query": "FROM kibana_sample_data_logs | KEEP @timestamp, request, response, bytes | SORT @timestamp DESC | LIMIT 100"
+          },
+          "metrics": [
+            { "operation": "value", "column": "@timestamp" },
+            { "operation": "value", "column": "request" },
+            { "operation": "value", "column": "response" },
+            { "operation": "value", "column": "bytes" }
+          ],
+          "rows": []
+        }
+      }
+    }
+  ]
+}'
+```
+
+Refer to the [Dashboards API reference](https://www.elastic.co/docs/api/doc/kibana/group/endpoint-dashboards) for the full schema.
+::::
 
 Your dashboard now combines multiple panel types built with Lens, and you've seen how inline editing and interactive filtering make the dashboard both customizable and interactive. To learn more, refer to [Dashboards](dashboards.md), [Lens](visualize/lens.md), and [Panels and visualizations](visualize.md).
 

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -261,6 +261,7 @@ toc:
       - file: dashboards/building.md
         children:
           - file: dashboards/create-dashboard.md
+          - file: dashboards/create-programmatically.md
           - file: dashboards/open-dashboard.md
           - file: dashboards/add-controls.md
           - file: dashboards/drilldowns.md


### PR DESCRIPTION
## Summary

This PR adds documentation for creating Kibana dashboards and visualizations programmatically, as a companion to elastic/kibana#259842 (Visualizations API) and the pending Dashboards API Kibana PR.

**New page:** `explore-analyze/dashboards/create-programmatically.md` — covers the Dashboards API, the Lens Visualizations API, the kibana-dashboards agent skill, and the upcoming Agent Builder dashboard tools. All API content is gated at `preview 9.4`.

**Updated pages:**
- `explore-analyze/dashboards/building.md` — adds a pointer to the new programmatic page
- `explore-analyze/dashboards/create-dashboard.md` — adds a collapsible API dropdown after the agent-skill callout
- `explore-analyze/kibana-data-exploration-learning-tutorial.md` — adds a forward link in Step 3 and a full API dropdown at the end of the step, so learners can discover the API without skipping the manual tutorial

## Notes

- All API examples use `applies_to: stack: preview 9.4 / serverless: preview`
- API payloads were validated against Kibana main branch
- The Agent Builder tools section references elastic/kibana#237795 (tech preview, dashboard tools coming in 9.4)
- The `kibana-dashboards` agent skill is already linked from `create-dashboard.md` via the `{agent-skill}` directive; this PR adds a dedicated section in the new overview page

## Test plan

- [ ] Verify `applies_to` badges render correctly on all modified pages
- [ ] Verify dropdown directives render and collapse correctly
- [ ] Verify all links to API reference resolve
- [ ] Verify toc.yml addition shows `create-programmatically.md` in the nav