### PR TITLE
Add notes about hiding non-trace services in APM views

### DIFF
--- a/release-notes/elastic-observability/index.md
+++ b/release-notes/elastic-observability/index.md
@@ -311,6 +311,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Speeds up field simulation in Streams [#241313]({{kib-pull}}241313).
 * Fixes the incorrectly formatted **Values** dropdown in Storybook [#241812]({{kib-pull}}241812).
 * Escapes special characters when creating ES|QL query for Lens charts [#241662]({{kib-pull}}241662).
+* Hides non-trace services in **Service Inventory** and **Service Map** [#241080]({{kib-pull}}241080), [#240104]({{kib-pull}}240104).
 
 
 ## 9.2.0 [elastic-observability-9.2.0-release-notes]
@@ -427,7 +428,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Fixes overlapping components in the Observability AI Assistant flyout on small screens [#241026]({{kib-pull}}241026).
 * Excludes stale SLOs from "group by" stats [#240077]({{kib-pull}}240077).
 * Fixes Kibana tool from failing when using a proxy [#236653]({{kib-pull}}236653).
-* Hides non-trace services from APM service inventory [#241080]({{kib-pull}}241080).
+* Hides non-trace services in **Service Inventory** and **Service Map** [#241080]({{kib-pull}}241080), [#240104]({{kib-pull}}240104).
 
 ## 9.1.6 [elastic-observability-9.1.6-release-notes]
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Update observability release notes for 9.2.1 and 9.1.7 to include some changes that were initially tagged as `release_note:skip` by mistake: https://github.com/elastic/kibana/pull/241080 and https://github.com/elastic/kibana/pull/240104

We made a previous attempt at fixing in #4515 but left out some changes and versions. This PR further corrects this by adding all changes to all relevant versions

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [X] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

