### PR TITLE
Rename triage to docs-triage, add docs-issue-scope trigger

### DIFF
--- a/.github/workflows/docs-issue-scope.yml
+++ b/.github/workflows/docs-issue-scope.yml
@@ -1,0 +1,17 @@
+name: Docs Issue Scope
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-issue-scope.lock.yml@v1
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -1,4 +1,4 @@
-name: Issue Triage
+name: Docs Triage
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
## Summary
- Rename `issue-triage.yml` → `docs-triage.yml` (slash command: `/docs-triage`)
- Add `docs-issue-scope.yml` thin trigger calling `elastic/docs-actions/.github/workflows/gh-aw-docs-issue-scope.lock.yml@v1`

## Dependency
Depends on elastic/docs-actions rename PR being merged first (renames `gh-aw-docs-check` → `gh-aw-docs-issue-scope`).

## Test plan
- [ ] Verify `/docs-triage` still triggers triage on an issue comment
- [ ] Verify `/docs-issue-scope` triggers docs impact analysis on an issue comment
- [ ] Verify existing `workflow_dispatch` for triage still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)