### PR TITLE
Update CPS limitations to reflect AIOps and Data viz support

### DIFF
--- a/deploy-manage/_snippets/cps-limitations-core.md
+++ b/deploy-manage/_snippets/cps-limitations-core.md
@@ -1,6 +1,6 @@
 - **Maximum of 20 linked projects:** Each origin project can have up to 20 linked projects. A linked project can be associated with any number of origin projects.
 - **System indices:** Indices such as `.security` and `.fleet-*` are excluded from {{cps}} results by design.
 - **New projects only:** During technical preview, only newly created projects can function as origin projects.
-- **{{anomaly-detect-cap}} and transforms:** During technical preview, ML {{anomaly-jobs}}, {{dfanalytics-jobs}}, and transforms are not supported with {{cps-init}}. They continue to run on origin project data only.
+- **{{anomaly-detect-cap}} and transforms:** During technical preview, ML {{anomaly-jobs}} and transforms are not supported with {{cps-init}}. They continue to run on origin project data only.
 - **{{dfanalytics-jobs-cap}}:** {{dfanalytics-jobs}} are not supported with {{cps-init}}. They continue to run on origin project data only.
 - For {{esql}} limitations specific to {{cps-init}}, refer to [ES|QL with {{cps}}](elasticsearch://reference/query-languages/esql/esql-cross-serverless-projects.md#limitations).

--- a/deploy-manage/_snippets/cps-limitations-core.md
+++ b/deploy-manage/_snippets/cps-limitations-core.md
@@ -1,5 +1,6 @@
 - **Maximum of 20 linked projects:** Each origin project can have up to 20 linked projects. A linked project can be associated with any number of origin projects.
 - **System indices:** Indices such as `.security` and `.fleet-*` are excluded from {{cps}} results by design.
 - **New projects only:** During technical preview, only newly created projects can function as origin projects.
-- **{{anomaly-detect-cap}}, {{dfanalytics-jobs}}, and transforms:** During technical preview, ML {{anomaly-jobs}}, {{dfanalytics-jobs}}, and transforms are not supported with {{cps-init}}. They continue to run on origin project data only.
+- **{{anomaly-detect-cap}} and transforms:** During technical preview, ML {{anomaly-jobs}}, {{dfanalytics-jobs}}, and transforms are not supported with {{cps-init}}. They continue to run on origin project data only.
+- **{{dfanalytics-jobs-cap}}:** {{dfanalytics-jobs}} are not supported with {{cps-init}}. They continue to run on origin project data only.
 - For {{esql}} limitations specific to {{cps-init}}, refer to [ES|QL with {{cps}}](elasticsearch://reference/query-languages/esql/esql-cross-serverless-projects.md#limitations).

--- a/deploy-manage/_snippets/cps-limitations-core.md
+++ b/deploy-manage/_snippets/cps-limitations-core.md
@@ -1,5 +1,5 @@
 - **Maximum of 20 linked projects:** Each origin project can have up to 20 linked projects. A linked project can be associated with any number of origin projects.
 - **System indices:** Indices such as `.security` and `.fleet-*` are excluded from {{cps}} results by design.
 - **New projects only:** During technical preview, only newly created projects can function as origin projects.
-- **{{anomaly-detect-cap}} and transforms:** During technical preview, ML {{anomaly-jobs}} and transforms are not supported with {{cps-init}}. They continue to run on origin project data only. Other ML features, including AIOps and {{data-viz}}, support {{cps}}.
+- **{{anomaly-detect-cap}}, {{dfanalytics-jobs}}, and transforms:** During technical preview, ML {{anomaly-jobs}}, {{dfanalytics-jobs}}, and transforms are not supported with {{cps-init}}. They continue to run on origin project data only.
 - For {{esql}} limitations specific to {{cps-init}}, refer to [ES|QL with {{cps}}](elasticsearch://reference/query-languages/esql/esql-cross-serverless-projects.md#limitations).

--- a/deploy-manage/_snippets/cps-limitations-core.md
+++ b/deploy-manage/_snippets/cps-limitations-core.md
@@ -1,5 +1,5 @@
 - **Maximum of 20 linked projects:** Each origin project can have up to 20 linked projects. A linked project can be associated with any number of origin projects.
 - **System indices:** Indices such as `.security` and `.fleet-*` are excluded from {{cps}} results by design.
 - **New projects only:** During technical preview, only newly created projects can function as origin projects.
-- **ML and transforms:** During technical preview, ML {{anomaly-jobs}} and transforms are not supported. They continue to run on origin project data only.
+- **{{anomaly-detect-cap}} and transforms:** During technical preview, ML {{anomaly-jobs}} and transforms are not supported with {{cps-init}}. They continue to run on origin project data only. Other ML features, including AIOps and {{data-viz}}, support {{cps}}.
 - For {{esql}} limitations specific to {{cps-init}}, refer to [ES|QL with {{cps}}](elasticsearch://reference/query-languages/esql/esql-cross-serverless-projects.md#limitations).

--- a/explore-analyze/cross-project-search/cross-project-search-manage-scope.md
+++ b/explore-analyze/cross-project-search/cross-project-search-manage-scope.md
@@ -64,8 +64,8 @@ Not all apps support {{cps}}. The following table shows which apps support the {
 | **Discover** | Editable | ES\|QL |
 | **Lens visualizations** | Editable | ES\|QL visualizations[^cps-badge] |
 | **Maps** | Editable | Layer-level [project routing](/explore-analyze/cross-project-search/cross-project-search-project-routing.md) for vector layers and joins |
-| **{{ml-app}} AIOps Labs** | Read-only | ES\|QL |
-| **{{ml-app}} Data Visualizer** | Read-only | ES\|QL |
+| **{{ml-app}} AIOps Labs** | Editable | Not available |
+| **{{ml-app}} {{data-viz}}** | Editable | ES\|QL |
 | **{{rules-ui}} and alerts** | Read-only | ES\|QL rules support `SET project_routing`. For non-{{esql}} rules that use index patterns, you can use [qualified index expressions](/explore-analyze/cross-project-search/cross-project-search-search.md#search-expressions) to scope the rule to specific projects.|
 | **Streams** | Not available | ES\|QL |
 | **Vega** | Editable | Project routing in Vega specs |

--- a/explore-analyze/cross-project-search/cross-project-search-manage-scope.md
+++ b/explore-analyze/cross-project-search/cross-project-search-manage-scope.md
@@ -64,7 +64,8 @@ Not all apps support {{cps}}. The following table shows which apps support the {
 | **Discover** | Editable | ES\|QL |
 | **Lens visualizations** | Editable | ES\|QL visualizations[^cps-badge] |
 | **Maps** | Editable | Layer-level [project routing](/explore-analyze/cross-project-search/cross-project-search-project-routing.md) for vector layers and joins |
-| **{{ml-app}} Data Visualizer** | Not available | ES\|QL |
+| **{{ml-app}} AIOps Labs** | Read-only | ES\|QL |
+| **{{ml-app}} Data Visualizer** | Read-only | ES\|QL |
 | **{{rules-ui}} and alerts** | Read-only | ES\|QL rules support `SET project_routing`. For non-{{esql}} rules that use index patterns, you can use [qualified index expressions](/explore-analyze/cross-project-search/cross-project-search-search.md#search-expressions) to scope the rule to specific projects.|
 | **Streams** | Not available | ES\|QL |
 | **Vega** | Editable | Project routing in Vega specs |


### PR DESCRIPTION
## Summary
Updates the Kibana app support table and CPS limitations list to reflect the changes made in https://github.com/elastic/kibana/pull/256244

### Changes in detail

**CPS limitations:**
scoped down - not covering all of ML anymore

also added new item for data frame analytics analytics jobs

used to be `- **ML and transforms:** During technical preview, ML {{anomaly-jobs}} and transforms are not supported. They continue to run on origin project data only.`

**Kibana app support:**

- Changed data visualizer level of support to editable
- Added a new row for AIOps labs (also editable - no overrides)

used to be `| **{{ml-app}} Data Visualizer** | Not available | ES\|QL |`

<img width="699" height="918" alt="image" src="https://github.com/user-attachments/assets/69f3462d-63f2-4cfe-b50f-a7eca57dbcc6" />

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: claude 4.6 high thinking


