### PR TITLE
Update docs-content issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/a-community-request.yaml
+++ b/.github/ISSUE_TEMPLATE/a-community-request.yaml
@@ -1,26 +1,28 @@
 name: "Community documentation request"
-description: An issue template for non-Elastic employees to request changes to the documentation.
+description: Request a documentation change as a community contributor.
 title: "[Community]: "
 labels: ["community"]
 body:
   - type: markdown
     attributes:
       value: |
-        This issue template is for non-Elastic employees to request changes to the documentation. **If you are an Elastic employee, please use the internal issue template instead.**
+        This issue template is for non-Elastic employees who want to request a change to Elastic documentation. **If you are an Elastic employee, please use the internal issue template instead.**
         
+        This form is for documentation requests only, not for product bugs, support requests, or feature requests.
+
         This form will create an issue that Elastic's docs team will triage and prioritize. You can also open a PR instead. Thanks for taking the time to fill out this request!
   - type: textarea
     id: link
     attributes:
-      label: What documentation page is affected
-      description: Include a link to the page where you're seeing the problem. Screenshots are also helpful.
+      label: What documentation page or section is affected
+      description: Include the URL for the page where you are seeing the problem. Screenshots are also helpful.
     validations:
       required: true
   - type: textarea
     id: related
     attributes:
-      label: What change would you like to see?
-      description: What's wrong? Why should the docs be changed? What did you expect to see?
+      label: What should change?
+      description: What is wrong with the docs, what did you expect to see, and why should the docs change?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/b-internal-request.yaml
+++ b/.github/ISSUE_TEMPLATE/b-internal-request.yaml
@@ -1,11 +1,13 @@
 name: "Internal documentation request (Elastic employees)"
-description: An issue template for Elastic employees to request improvements, additions, or changes to the documentation.
+description: Request a documentation improvement, addition, or change for Elastic docs.
 title: "[Internal]: "
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this request! This form will create an issue that the Documentation team will triage and prioritize. This form does not guarantee that your issue will be prioritized for the selected iteration. _But_, completing this issue as early and as comprehensively as possible will help us understand and plan the work better!
+        Thanks for taking the time to fill out this request. Use this form for documentation work only. If you need to report a product bug or request product behavior changes, please use the appropriate product workflow instead.
+
+        This form will create an issue that the documentation team will triage and prioritize. Filling it out as early and as clearly as possible helps us scope the work and plan it well.
   - type: textarea
     id: description
     attributes:
@@ -42,17 +44,17 @@ body:
         - Elastic Cloud Hosted only
         - Elastic Cloud Serverless only
         - Unknown
-      default: 0
+      default: 5
     validations:
       required: true
   - type: textarea
     id: doc-set-differences
     attributes:
       label: Feature differences
-      description: If you selected multiple deployment methods above, please describe how, if at all, the feature differs in each deployment method.
+      description: If you selected multiple deployment methods above, describe how the feature differs in each one. Otherwise, leave this blank.
       placeholder: The feature is identical in all deployment methods.
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: version
     attributes:
@@ -74,22 +76,22 @@ body:
     id: release-serverless
     attributes:
       label: Serverless release
-      description: When do you expect the feature to be promoted and available in the _**serverless production environment**_?
+      description: If relevant, when do you expect the feature to be promoted and available in the _**serverless production environment**_?
       placeholder: The week of April 1, 2024
     validations:
-      required: true    
+      required: false
   - type: dropdown
     id: collaboration
     attributes:
       label: Collaboration model
-      description: Which team do you expect to create the initial content?
+      description: If new content is needed, who do you expect to create the initial draft?
       options:
-        - "The documentation team"
-        - "The product team"
-        - "The engineering team"
+        - "The documentation team will create the first draft"
+        - "The product or engineering team will create the first draft"
+        - "We expect to collaborate on the first draft"
         - "Unknown"
         - "Other (please describe below)"
-      default: 0
+      default: 3
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/b-internal-request.yaml
+++ b/.github/ISSUE_TEMPLATE/b-internal-request.yaml
@@ -35,11 +35,11 @@ body:
   - type: dropdown
     id: doc-set
     attributes:
-      label: Which documentation set does this change impact?
-      description: Stateful, Serverless, or both?
+      label: Which deployment methods does this change impact?
+      description: Knowing this information helps us to update the right content and tag it appropriately.
       options:
         - Elastic On-Prem and Cloud (all)
-        - Elastic On-Prem only
+        - Elastic On-Prem only (ECE, ECK, or self-managed)
         - Elastic Cloud (Hosted and Serverless) only
         - Elastic Cloud Hosted only
         - Elastic Cloud Serverless only
@@ -58,7 +58,7 @@ body:
   - type: dropdown
     id: version
     attributes:
-      label: What release is this request related to?
+      label: What Elastic Stack release is this request related to?
       description: Some requests may be tied to the Elastic Stack release schedule. Some, like Serverless requests, may not. Please select an option.
       options:
         - 'N/A'
@@ -68,7 +68,10 @@ body:
         - '9.2'
         - '9.3'
         - '9.4'
-        - '9.5'        
+        - '9.5'
+        - '9.6'
+        - '9.7'
+        - '9.8'
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/c-api-feedback.yaml
+++ b/.github/ISSUE_TEMPLATE/c-api-feedback.yaml
@@ -7,6 +7,8 @@ body:
     attributes:
       value: |
         Hi 👋. Thanks for taking the time to fill out this feedback!
+        Use this form for feedback about Elastic API documentation.
+        If you are reporting a product bug or support problem rather than a docs issue, please use the appropriate product or support channel instead.
         This form will create an issue that Elastic's docs team will triage and prioritize.
   - type: dropdown
     id: was-this-helpful
@@ -14,6 +16,7 @@ body:
       label: Was the documentation helpful?
       options:
         - "Yes"
+        - "Partly"
         - "No"
       default: 0
     validations:
@@ -21,7 +24,7 @@ body:
   - type: textarea
     id: link
     attributes:
-      label: What documentation page is affected
+      label: What documentation page or section is affected
       description: Include a link to the page that you have feedback about.
     validations:
       required: true
@@ -31,7 +34,7 @@ body:
       label: Description
       description: (Optional) Describe your experience with Elastic API documentation.
     validations:
-      required: true
+      required: false
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/d-ui-copy-request.yaml
+++ b/.github/ISSUE_TEMPLATE/d-ui-copy-request.yaml
@@ -47,7 +47,7 @@ body:
         - Kibana Analytics (Discover, Dashboards...)
         - Kibana Management
         - Something else
-        - Not sure yet
+        - None of the above
       default: 7
     validations:
       required: false
@@ -55,14 +55,14 @@ body:
     id: collaborators
     attributes:
       label: Collaborators
-      description: If known, include contact information for the responsible product manager, designer, and developer.
+      description: Please include contact information for the responsible product manager, designer, and developer.
       value: |
         PM:
-        Designer: 
+        Designer:
         Developer:
         Others (if applicable):
     validations:
-      required: false
+      required: true
   - type: textarea
     id: timeline
     attributes:
@@ -71,9 +71,9 @@ body:
       placeholder: |
         For example:
 
-        We need a final draft of the new UI copy no later than December 5, ideally by December 1. No differences between serverless/ESS. 
+        We need a final draft of the new UI copy no later than December 5, ideally by December 1. No differences between serverless/ECH. 
 
-        This is an urgent request, it would be great to have updated copy for A and B ASAP, since the original copy is already in production. No differences between serverless/ESS. 
+        This is an urgent request, it would be great to have updated copy for A and B ASAP, since the original copy is already in production. No differences between serverless/ECH. 
     validations:
       required: false
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/d-ui-copy-request.yaml
+++ b/.github/ISSUE_TEMPLATE/d-ui-copy-request.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Hello! Use this form to submit a UI copy related request to Elastic's documentation team. You should also directly contact the specific writer or docs team that's responsibile for the applicable part of the product, especially for time-sensitive requests. 
+        Hello. Use this form to submit a UI copy-related request to Elastic's documentation team. This form is for copy and content requests, not for reporting product bugs. You should also directly contact the specific writer or docs team that is responsible for the applicable part of the product, especially for time-sensitive requests.
         > [!WARNING]  
         > THIS IS A PUBLIC REPO. DO NOT INCLUDE SENSITIVE INFORMATION HERE.
   - type: textarea
@@ -38,7 +38,7 @@ body:
   - type: dropdown
     id: product-area
     attributes:
-      label: Which product area does this mainly concern?
+      label: Which product area does this mainly concern, if known?
       options:
         - Cloud UI
         - Search solution
@@ -47,26 +47,27 @@ body:
         - Kibana Analytics (Discover, Dashboards...)
         - Kibana Management
         - Something else
-      default: 0
+        - Not sure yet
+      default: 7
     validations:
-      required: true
+      required: false
   - type: textarea
     id: collaborators
     attributes:
       label: Collaborators
-      description: Please include contact information for the responsible product manager, designer, and developer.
+      description: If known, include contact information for the responsible product manager, designer, and developer.
       value: |
         PM:
         Designer: 
         Developer:
         Others (if applicable):
     validations:
-      required: true
+      required: false
   - type: textarea
     id: timeline
     attributes:
       label: Timeline / deliverables
-      description: When would it be ideal for for us to complete the request? What deliverables do you need, and when? If applicable, how do the release timelines for this feature differ between serverless / stateful? 
+      description: If you have a target date or specific deliverables in mind, share them here. If applicable, note whether the timing differs between serverless and stateful.
       placeholder: |
         For example:
 
@@ -74,8 +75,8 @@ body:
 
         This is an urgent request, it would be great to have updated copy for A and B ASAP, since the original copy is already in production. No differences between serverless/ESS. 
     validations:
-      required: true
+      required: false
   - type: markdown
     attributes:
       value: |
-        Thanks for submitting this issue! We'll be in contact shortly. 
+        Thanks for submitting this issue. We'll be in contact shortly.

--- a/.github/ISSUE_TEMPLATE/issue-report.yaml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yaml
@@ -9,9 +9,9 @@ body:
         Hi 👋. Thanks for taking the time to fill out this issue report!
         Use this form only for issues with Elastic documentation.
         This form is not for product bugs, support requests, or feature requests.
-        If the product is not behaving as expected and the docs are accurate, please use the appropriate product or support channel instead.
+        If the product is not behaving as expected and the docs are accurate, please use the appropriate product or support channel instead — your request will be routed faster that way.
         This form will create an issue that Elastic's docs team will triage and prioritize.
-        You can also open a PR instead.
+        You can also [open a PR](https://elastic.co/docs/contribute-docs/syntax-quick-reference) instead.
   - type: checkboxes
     id: docs-only
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-report.yaml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yaml
@@ -1,12 +1,25 @@
 name: "Website issue"
-description: This issue template should only be used when navigating directly from elastic.co.
+description: Report a problem with Elastic documentation when navigating from elastic.co.
 title: "[Website]: "
 labels: ["source:web"]
 body:
   - type: markdown
     attributes:
       value: |
-        Hi 👋. Thanks for taking the time to fill out this issue report! This form will create an issue that Elastic's docs team will triage and prioritize. You can also open a PR instead.
+        Hi 👋. Thanks for taking the time to fill out this issue report!
+        Use this form only for issues with Elastic documentation.
+        This form is not for product bugs, support requests, or feature requests.
+        If the product is not behaving as expected and the docs are accurate, please use the appropriate product or support channel instead.
+        This form will create an issue that Elastic's docs team will triage and prioritize.
+        You can also open a PR instead.
+  - type: checkboxes
+    id: docs-only
+    attributes:
+      label: Before you submit
+      description: Confirm that this request is about the documentation itself.
+      options:
+        - label: This issue is about a documentation page, flow, or piece of content.
+          required: true
   - type: dropdown
     attributes:
       label: Type of issue
@@ -20,15 +33,15 @@ body:
   - type: input
     id: link
     attributes:
-      label: What documentation page is affected
-      description: Include a link to the page where you're seeing the problem.
+      label: What documentation page or section is affected
+      description: Include the URL for the page where you are seeing the problem.
     validations:
       required: true
   - type: textarea
     id: related
     attributes:
       label: What happened?
-      description: Describe the issue you're experiencing. Screenshots are valuable too!
+      description: Describe the documentation problem you are seeing. Screenshots are helpful too.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Summary
- clarify that the website and community forms are for documentation issues and requests, not product bugs or support requests
- reduce friction in the internal request and UI copy templates by removing a few forced assumptions and making less-critical fields optional
- improve the API feedback form so it allows more nuanced feedback and no longer requires a description that is labeled optional

## Test plan
- [x] Review the YAML diffs for all updated templates
- [x] Run `git diff --check`
- [ ] Open each updated template in the GitHub UI and verify the form copy and required fields behave as expected

## Notes
- Refs elastic/docs-content-internal#324
- This PR is the `docs-content` pass; the matching `docs-content-internal` work is separate

Made with [Cursor](https://cursor.com)