### PR TITLE
Temporary workaround for broken link

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/read-only-url-repository.md
@@ -61,7 +61,7 @@ PUT _snapshot/my_read_only_url_repository
     * `https`
     * `jar`
 
-    URLs using the `http`, `https`, or `ftp` protocols must be explicitly allowed with the [`repositories.url.allowed_urls`](elasticsearch://reference/elasticsearch/configuration-reference/snapshot-restore-settings.md#repositories-url-allowed) cluster setting. This setting supports wildcards in the place of a host, path, query, or fragment in the URL.
+    URLs using the `http`, `https`, or `ftp` protocols must be explicitly allowed with the `repositories.url.allowed_urls` node setting. This setting supports wildcards in the place of a host, path, query, or fragment in the URL.
 
     URLs using the `file` protocol must point to the location of a shared filesystem accessible to all master and data nodes in the cluster. This location must be registered in the `path.repo` setting, in the same way as when configuring a [shared filesystem repository](./shared-file-system-repository.md), and it must contain the snapshot data. You don’t need to set `path.repo` when using URLs with the `ftp`, `http`, `https`, or `jar` protocols.
 


### PR DESCRIPTION
I'm moving some content into the reference section and as a result a link is broken in the docs-content repo. Related PR: https://github.com/elastic/elasticsearch/pull/144481

I'm removing the link that's causign the issue, and I have another PR lined up to remove that problem and update the docs-content side of this: https://github.com/elastic/docs-content/pull/5544

Relates to https://github.com/elastic/docs-content/issues/1465

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

