### PR TITLE
Add a note on delete protection metadata

### DIFF
--- a/troubleshoot/observability/troubleshoot-service-level-objectives-slos.md
+++ b/troubleshoot/observability/troubleshoot-service-level-objectives-slos.md
@@ -93,7 +93,8 @@ It’s also recommended that you perform the following transform checks:
     If a transform has been deleted, the easiest way to recreate it is using the [Reset SLO](#slo-troubleshoot-reset) action, forcing the recreation of the transforms. If a transform was stopped, try to start it, and then check the `health tab` of the transform.
 
     ::::{note}
-    {applies_to}`stack: 9.4` SLO transforms are protected from accidental deletion. The Transforms UI displays a warning tooltip to indicate that these transforms are managed by the SLO application and should not be deleted. If you previously deleted transforms manually to reset SLO state, use the [Reset SLO](#slo-troubleshoot-reset) action instead, as manual deletion of protected transforms is no longer supported.
+    :applies_to: stack: ga 9.4 
+    SLO transforms are protected from accidental deletion. The Transforms UI displays a warning tooltip to indicate that these transforms are managed by the SLO application and should not be deleted. If you previously deleted transforms manually to reset SLO state, use the [Reset SLO](#slo-troubleshoot-reset) action instead, as manual deletion of protected transforms is no longer supported.
     ::::
 
 * [Inspect SLO assets](#slo-troubleshoot-inspect) to analyze the SLO definition and all associated resources.

--- a/troubleshoot/observability/troubleshoot-service-level-objectives-slos.md
+++ b/troubleshoot/observability/troubleshoot-service-level-objectives-slos.md
@@ -92,6 +92,10 @@ It’s also recommended that you perform the following transform checks:
 
     If a transform has been deleted, the easiest way to recreate it is using the [Reset SLO](#slo-troubleshoot-reset) action, forcing the recreation of the transforms. If a transform was stopped, try to start it, and then check the `health tab` of the transform.
 
+    ::::{note}
+    {applies_to}`stack: 9.4` SLO transforms are protected from accidental deletion. The Transforms UI displays a warning tooltip to indicate that these transforms are managed by the SLO application and should not be deleted. If you previously deleted transforms manually to reset SLO state, use the [Reset SLO](#slo-troubleshoot-reset) action instead, as manual deletion of protected transforms is no longer supported.
+    ::::
+
 * [Inspect SLO assets](#slo-troubleshoot-inspect) to analyze the SLO definition and all associated resources.
 
     Use the direct links offered by the **Inspect UI** and check that all referenced resources exist, as that’s not verified by the inspect functionality.


### PR DESCRIPTION
This PR adds a note covering the following:

- SLO transforms are now protected from accidental deletion (9.4.0)
- The Transforms UI shows a warning tooltip
- Users who previously deleted transforms manually should use Reset SLO instead, since that approach no longer works

Closes https://github.com/elastic/docs-content-internal/issues/965

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

