### PR TITLE
Updates Search AI to Elasticsearch Platform terminology

### DIFF
--- a/docset.yml
+++ b/docset.yml
@@ -291,6 +291,6 @@ subs:
   helm-version: 3.19.5
   ece-docker-images-8: 8.18.8
   ece-docker-images-9: 9.0.8
-  search-platform: "Search AI Platform"
+  search-platform: "Elasticsearch Platform"
 
 

--- a/reference/glossary/index.md
+++ b/reference/glossary/index.md
@@ -270,7 +270,7 @@ $$$glossary-elasticsearch$$$ {{es}}
     The term "{{es}}" has several additional meanings depending on the context in which it is used:
   - {{es}} is the name of a [**project** type](/deploy-manage/deploy/elastic-cloud/create-serverless-project.md) on {{serverless-full}}, tailored for general-purpose search use cases.
   - {{es}} is also the name of a **solution** in other Elastic deployment types. Each [space](#glossary-space) has its own navigation or **solution view**.
-  - **{{es}} platform** (also known as the Elastic platform or Search AI Platform) is the umbrella term for Elastic's full suite of products and capabilities, built on the core {{es}} technology. It encompasses what was initially known as the {{stack}}, extended with additional capabilities (such as the Search AI Lake) to power Elastic's various deployment types and managed services.
+  - **{{es}} platform** (also known as the Elastic platform) is the umbrella term for Elastic's full suite of products and capabilities, built on the core {{es}} technology. It encompasses what was initially known as the {{stack}} or Search AI Platform, extended with additional capabilities (such as the Search AI Lake) to power Elastic's various deployment types and managed services.
 
 $$$glossary-elasticsearch-service$$$ Elasticsearch Service
 :   The former name of {{ech}}, which is the official hosted {{stack}} offering, from the makers of {{es}}. Available as a software-as-a-service (SaaS) offering on different cloud platforms, such as AWS, GCP, and Microsoft Azure.

--- a/reference/glossary/index.md
+++ b/reference/glossary/index.md
@@ -270,7 +270,7 @@ $$$glossary-elasticsearch$$$ {{es}}
     The term "{{es}}" has several additional meanings depending on the context in which it is used:
   - {{es}} is the name of a [**project** type](/deploy-manage/deploy/elastic-cloud/create-serverless-project.md) on {{serverless-full}}, tailored for general-purpose search use cases.
   - {{es}} is also the name of a **solution** in other Elastic deployment types. Each [space](#glossary-space) has its own navigation or **solution view**.
-  - The **{{es}} platform** (also known as the Elastic platform or Search AI Platform) is the umbrella term for Elastic's full suite of products and capabilities, built on the core {{es}} technology. It encompasses what was initially known as the {{stack}}, extended with additional capabilities (such as the Search AI Lake) to power Elastic's various deployment types and managed services.
+  - **{{es}} platform** (also known as the Elastic platform or Search AI Platform) is the umbrella term for Elastic's full suite of products and capabilities, built on the core {{es}} technology. It encompasses what was initially known as the {{stack}}, extended with additional capabilities (such as the Search AI Lake) to power Elastic's various deployment types and managed services.
 
 $$$glossary-elasticsearch-service$$$ Elasticsearch Service
 :   The former name of {{ech}}, which is the official hosted {{stack}} offering, from the makers of {{es}}. Available as a software-as-a-service (SaaS) offering on different cloud platforms, such as AWS, GCP, and Microsoft Azure.


### PR DESCRIPTION
## Summary
This is the initial set of changes for the `Elasticsearch Platform` terminology change. 

Current changes include:

- search-platform: "Search AI Platform" variable now appears as search-platform: "Elasticsearch Platform"
- Minor changes to the primary Elasticsearch glossary term where the Elasticsearch Platform terminology resides

I have reached out to the proper channels for written confirmation of this change, including the deployment types and versions this change applies. 

Until that confirmation is received, this PR will stay in draft. 

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  


