### PR TITLE
Add Agent Builder execution example for large input-token turns

### DIFF
--- a/deploy-manage/cloud-organization/billing/_snippets/agent-builder-executions-billing.md
+++ b/deploy-manage/cloud-organization/billing/_snippets/agent-builder-executions-billing.md
@@ -2,6 +2,6 @@
 
 {{abb-preamble}}
 
-Each execution represents one conversational turn — a user input and the agent's non-error response. Complex turns that exceed 50,000 input tokens count as additional executions to reflect the heavier processing involved. Error responses are not billed. When an agent triggers a workflow as part of its response, the workflow execution is metered separately under Workflow Executions.
+Each execution represents one conversational turn — a user input and the agent's non-error response. Complex turns that exceed 50,000 input tokens count as additional executions to reflect the heavier processing involved. For example, a turn that uses 120,000 input tokens would count for 3 Agent Executions. Error responses are not billed. When an agent triggers a workflow as part of its response, the workflow execution is metered separately under Workflow Executions.
 
 A free allocation of {{abb-free-executions}} executions per month is included. Volume tier reductions apply at higher usage levels. Refer to the [{{abb-pricing-label}}]({{abb-pricing-url}}) for specific rates and tier breakpoints.


### PR DESCRIPTION
Adds a concrete example to the Agent Builder Executions billing snippet: 
a turn with 120,000 input tokens counts as three Agent Executions, matching the existing 50,000 input-token increment for complex turns.

Resolves: https://github.com/elastic/docs-content/pull/5958#discussion_r3111401441