### PR TITLE
[Synthetics] Document the new behaviour of default Synthetics alert rules

### DIFF
--- a/solutions/observability/synthetics/configure-settings.md
+++ b/solutions/observability/synthetics/configure-settings.md
@@ -18,9 +18,9 @@ There are several Synthetics settings you can adjust in Observability.
 
 Alerting enables you to detect complex conditions using **rules** across Observability and send a notification using **connectors**.
 
-When you create a new synthetic monitor, new default synthetics rules will be applied. To edit the default rules:
+{applies_to}`stack: ga 9.4+` When you create or edit a synthetic monitor, default alert rules are automatically applied. To edit the default rules:
 
-1. Click **Alerts and rules** in the top bar.
+1. Click **Alerts** in the top bar.
 2. Select a rule to open a panel where you can edit the rule’s configuration:
 
     * **Monitor status rule** for receiving notifications for errors and outages.

--- a/solutions/observability/synthetics/create-monitors-ui.md
+++ b/solutions/observability/synthetics/create-monitors-ui.md
@@ -70,6 +70,10 @@ To use the UI to add a lightweight monitor:
     :screenshot:
     :::
 
+    ::::{note}
+    {applies_to}`stack: ga 9.4+` When you create or edit a monitor, default alert rules — including monitor status and TLS certificate rules — are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
+    ::::
+
 ## Add a browser monitor [synthetics-get-started-ui-add-a-browser-monitor]
 
 You can also create a browser monitor in the UI using an **Inline script**.
@@ -111,6 +115,10 @@ To use the UI to add a browser monitor:
 
 7. (Optional) Click **Run test** to verify that the test is valid.
 8. Click **Create monitor**.
+
+    ::::{note}
+    {applies_to}`stack: ga 9.4+` When you create or edit a monitor, default alert rules — including monitor status and TLS certificate rules — are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
+    ::::
 
 ## View in your Observability project [synthetics-get-started-ui-view-in-your-observability-project]
 

--- a/solutions/observability/synthetics/create-monitors-ui.md
+++ b/solutions/observability/synthetics/create-monitors-ui.md
@@ -71,8 +71,8 @@ To use the UI to add a lightweight monitor:
     :::
 
     ::::{note}
-:applies_to: stack: ga 9.4+
-When you create or edit a monitor, default alert rules — including monitor status and TLS certificate rules — are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
+    :applies_to: stack: ga 9.4+
+    When you create or edit a monitor, default alert rules, including monitor status and TLS certificate rules, are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
     ::::
 
 ## Add a browser monitor [synthetics-get-started-ui-add-a-browser-monitor]
@@ -118,7 +118,8 @@ To use the UI to add a browser monitor:
 8. Click **Create monitor**.
 
     ::::{note}
-    {applies_to}`stack: ga 9.4+` When you create or edit a monitor, default alert rules — including monitor status and TLS certificate rules — are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
+    :applies_to: stack: ga 9.4+
+    When you create or edit a monitor, default alert rules, including monitor status and TLS certificate rules, are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
     ::::
 
 ## View in your Observability project [synthetics-get-started-ui-view-in-your-observability-project]

--- a/solutions/observability/synthetics/create-monitors-ui.md
+++ b/solutions/observability/synthetics/create-monitors-ui.md
@@ -71,7 +71,8 @@ To use the UI to add a lightweight monitor:
     :::
 
     ::::{note}
-    {applies_to}`stack: ga 9.4+` When you create or edit a monitor, default alert rules — including monitor status and TLS certificate rules — are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
+:applies_to: stack: ga 9.4+
+When you create or edit a monitor, default alert rules — including monitor status and TLS certificate rules — are automatically set up. You can review and manage these rules under **Settings** → **Alerting** in the Synthetics app.
     ::::
 
 ## Add a browser monitor [synthetics-get-started-ui-add-a-browser-monitor]


### PR DESCRIPTION
This PR adds a note explaining that default alert rules (monitor status and TLS certificate) are automatically created on monitor create/edit, with a pointer to **Settings** → **Alerting** for managing them.

Closes https://github.com/elastic/docs-content-internal/issues/969

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

