### PR TITLE
docs: clarify ES|QL comment shortcut applies to selections (#5706)

### DIFF
--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -90,7 +90,7 @@ After running a query, the editor's footer displays statistics about the last ru
 | Mac                | Windows/Linux       | Description                 |
 |--------------------|---------------------|-----------------------------|
 | {kbd}`cmd+enter`   | {kbd}`ctrl+enter`   | Run a query                 |
-| {kbd}`cmd+/`       | {kbd}`ctrl+/`       | Comment or uncomment a line |
+| {kbd}`cmd+/`       | {kbd}`ctrl+/`       | Comment or uncomment the current line or selected lines |
 | {kbd}`cmd+i`       | {kbd}`ctrl+i`       | [Prettify query](#_make_your_query_readable) {applies_to}`stack: ga 9.4+` |
 | {kbd}`cmd+k`       | {kbd}`ctrl+k`       | Open [Quick search](#esql-kibana-quick-search) |
 


### PR DESCRIPTION
## Summary

This PR addresses #5706 with the following change:

- **`explore-analyze/query-filter/languages/esql-kibana.md`**: Update the `cmd/ctrl+/` row in the ES|QL editor keyboard shortcuts table so it reflects that the shortcut acts on the current line or a multi-line selection. This matches the editor behavior confirmed in [elastic/kibana#254851](https://github.com/elastic/kibana/pull/254851), which improved multi-line toggling to follow standard IDE conventions: comment all lines if any are uncommented, and uncomment all only when every selected line is already commented. The wording is kept cumulative so it stays accurate for earlier versions, where the shortcut also operated on selections, just with per-line toggling.

## Resolves

Closes #5706

---

> **AI-generated draft** created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.