### PR TITLE
[Obs AI] Remove mentions of the LLM matrix in Agent Builder docs

### DIFF
--- a/explore-analyze/ai-features/elastic-agent-builder.md
+++ b/explore-analyze/ai-features/elastic-agent-builder.md
@@ -69,7 +69,7 @@ Tools are modular, reusable functions that agents use to search, retrieve, and m
 
 On {{ech}} and {{serverless-full}}, {{agent-builder}} comes with preconfigured models ready to use. You can also configure other model providers using connectors, including local LLMs deployed on your infrastructure.
 
-For solution-specific ratings of models tested on {{observability}} and {{elastic-sec}} AI chat and AI-powered features when you use {{agent-builder}} or AI Assistant in those solutions, refer to the [LLM performance matrix for {{observability}}](/solutions/observability/ai/llm-performance-matrix.md) and the [LLM performance matrix for {{elastic-sec}}](/solutions/security/ai/large-language-model-performance-matrix.md).
+For solution-specific ratings of models tested on {{elastic-sec}} AI chat and AI-powered features, refer to the [LLM performance matrix for {{elastic-sec}}](/solutions/security/ai/large-language-model-performance-matrix.md).
 
 [**Learn more about model selection**](agent-builder/models.md)
 

--- a/solutions/observability/ai/agent-builder-observability.md
+++ b/solutions/observability/ai/agent-builder-observability.md
@@ -22,7 +22,7 @@ To use Agent Builder in {{observability}}, you need to [opt in](/explore-analyze
 
 ## Recommended models
 
-While Agent Builder works with any [configured LLM connector](/explore-analyze/ai-features/llm-guides/llm-connectors.md), model performance varies. Refer to the [LLM performance matrix for {{observability}}](/solutions/observability/ai/llm-performance-matrix.md) to select a model that performs well for your intended use cases.
+While Agent Builder works with any [configured LLM connector](/explore-analyze/ai-features/llm-guides/llm-connectors.md), model performance varies. Refer to [recommended models](/explore-analyze/ai-features/agent-builder/models.md#recommended-models) to select a model that performs well for your intended use cases.
 
 ## Observability agent
 

--- a/solutions/observability/ai/llm-performance-matrix.md
+++ b/solutions/observability/ai/llm-performance-matrix.md
@@ -10,7 +10,7 @@ products:
 
 # Large language model performance matrix for {{observability}} [llm-performance-matrix]
 
-This page summarizes internal test results comparing large language models (LLMs) across {{observability}} [AI chat](/explore-analyze/ai-features/ai-chat-experiences.md) use cases. These ratings apply equally whether you're using [AI Assistant](/solutions/observability/ai/observability-ai-assistant.md) or [Agent Builder](/solutions/observability/ai/agent-builder-observability.md).
+This page summarizes internal test results comparing large language models (LLMs) across {{observability}} [AI chat](/explore-analyze/ai-features/ai-chat-experiences.md) use cases. These ratings only apply if you're using [AI Assistant](/solutions/observability/ai/observability-ai-assistant.md). For Agent Builder, refer to [recommended models](/explore-analyze/ai-features/agent-builder/models.md#recommended-models).
 
 :::{warning}
 :applies_to: {"stack": "ga 9.4", "serverless": "ga"}


### PR DESCRIPTION
## Summary
This PR removes references to the LLM matrix for Observability from Agent Builder docs as the LLM matrix only applies to AI Assistant.

Closes https://github.com/elastic/docs-content/issues/6038.

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Claude Code
