### PR TITLE
Update link to path settings ref page

### DIFF
--- a/deploy-manage/deploy/self-managed/important-settings-configuration.md
+++ b/deploy-manage/deploy/self-managed/important-settings-configuration.md
@@ -63,7 +63,7 @@ path:
 ::::::
 :::::::
 
-{{es}} offers a deprecated setting that allows you to specify multiple paths in `path.data`. To learn about this setting, and how to migrate away from it, refer to [Multiple data paths](elasticsearch://reference/elasticsearch/index-settings/path.md#multiple-data-paths).
+{{es}} offers a deprecated setting that allows you to specify multiple paths in `path.data`. To learn about this setting, and how to migrate away from it, refer to [Multiple data paths](elasticsearch://reference/elasticsearch/configuration-reference/path.md#multiple-data-paths).
 
 ::::{warning}
 * Don’t modify anything within the data directory or run processes that might interfere with its contents.


### PR DESCRIPTION
## Summary

Related to #1795 which updated the location of the [Path settings](https://www.elastic.co/docs/reference/elasticsearch/index-settings/path) page in the table of contents and moved it to the [Elasticsearch configuration reference](https://www.elastic.co/docs/reference/elasticsearch/configuration-reference) section.


Note that this PR can only be merged after https://github.com/elastic/elasticsearch/pull/147129 is merged.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

