### PR TITLE
Updating link to the Indexing pressure settings doc

### DIFF
--- a/troubleshoot/elasticsearch/rejected-requests.md
+++ b/troubleshoot/elasticsearch/rejected-requests.md
@@ -64,7 +64,7 @@ Refer to the [Circuit Breaker Error video](https://www.youtube.com/watch?v=k3wYl
 
 ## Analyze indexing pressure [check-indexing-pressure]
 
-{{es}} reserves part of its JVM for indexing. An error can occur if heap usage exceeds the [`indexing_pressure.memory.limit` setting](elasticsearch://reference/elasticsearch/index-settings/pressure.md#memory-limits). To check the number of [indexing pressure](elasticsearch://reference/elasticsearch/index-settings/pressure.md) rejections, use the [node stats API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats).
+{{es}} reserves part of its JVM for indexing. An error can occur if heap usage exceeds the [`indexing_pressure.memory.limit` setting](elasticsearch://reference/elasticsearch/configuration-reference/indexing-pressure-settings.md#memory-limits). To check the number of [indexing pressure](elasticsearch://reference/elasticsearch/configuration-reference/indexing-pressure-settings.md) rejections, use the [node stats API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats).
 
 ```console
 GET _nodes/stats?human&filter_path=nodes.*.indexing_pressure


### PR DESCRIPTION
## Summary

As part of #1798, [this doc](https://www.elastic.co/docs/reference/elasticsearch/index-settings/pressure) moved to the [configuration section](https://www.elastic.co/docs/reference/elasticsearch/configuration-reference) (from the index settings section).

As a consequence, the link to this page must be updated on the [Rejected requests](https://www.elastic.co/docs/troubleshoot/elasticsearch/rejected-requests) page.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

