### PR TITLE
Add `search.use-case-library` to built-in skills reference

### DIFF
--- a/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md
@@ -94,6 +94,9 @@ $$$agent-builder-search-rag-chatbot-skill$$$ `search.rag-chatbot` {applies_to}`s
 $$$agent-builder-search-semantic-search-skill$$$ `search.semantic-search` {applies_to}`stack: ga 9.4+`
 :   Guides agents through building semantic and vector search solutions on {{es}}.
 
+$$$agent-builder-search-use-case-library-skill$$$ `search.use-case-library` {applies_to}`stack: ga 9.4+`
+:   Presents a library of {{es}} use cases when users want to explore what they can build, need help identifying which category their project falls into, or are looking for inspiration. Covers product search, knowledge base search, AI assistants, recommendations, customer support, location-based search, log and event search, and vector database use cases.
+
 $$$agent-builder-search-vector-database-skill$$$ `search.vector-database` {applies_to}`stack: ga 9.4+`
 :   Guides agents through using {{es}} as a vector database.
 


### PR DESCRIPTION
## Summary
- Adds the `search.use-case-library` skill to the Elasticsearch skills section of the built-in skills reference page
- Follows the same pattern as the other `search.*` skills

Closes #6070

## Test plan
- [ ] Verify the new entry renders correctly in the built-in skills reference page

🤖 Generated with [Claude Code](https://claude.com/claude-code)