### PR TITLE
docs: document grouped results layout for ES|QL STATS BY in Discover (#5733)

### DIFF
--- a/explore-analyze/discover/run-pattern-analysis-discover.md
+++ b/explore-analyze/discover/run-pattern-analysis-discover.md
@@ -13,6 +13,11 @@ description: Detect patterns in unstructured data with pattern analysis in Disco
 
 Pattern analysis in **Discover** helps you find patterns in unstructured log messages by performing categorization analysis on text fields. It creates categories based on message structures, displays their distribution in a chart, and provides example documents for each pattern. This makes it easier to identify common log patterns, filter out noise, and focus on anomalous messages during troubleshooting.
 
+:::{tip}
+:applies_to: { stack: preview 9.4, serverless: preview }
+You can also detect patterns from {{esql}} using the [`CATEGORIZE`](elasticsearch://reference/query-languages/esql/functions-operators/grouping-functions/categorize.md) grouping function. Discover renders the results as expandable groups with sparklines and row actions. See [](/explore-analyze/discover/try-esql.md#esql-cascade-layout).
+:::
+
 Pattern analysis works on any text field. This example uses the [sample web logs data](../index.md#gs-get-data-into-kibana), or you can use your own log data.
 
 1. Go to **Discover**.

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -334,6 +334,56 @@ When you save your edits, the control is updated for your query.
 :::
 
 
+## View grouped results from a STATS query [esql-cascade-layout]
+```{applies_to}
+stack: preview 9.4
+serverless: preview
+```
+
+When your {{esql}} query uses a [`STATS BY`](elasticsearch://reference/query-languages/esql/commands/stats-by.md) clause with a single grouping field, **Discover** displays the results as expandable groups instead of a flat table. Each row represents one unique value of the grouping field, and you can expand it to inspect the underlying documents without leaving the query. The hit counter above the table reports the number of groups instead of the number of documents.
+
+Queries that group by more than one field (for example, `BY clientip, extension`) keep the standard flat results table.
+
+### Switch the grouping field or opt out
+
+Open the {icon}`flask` **Group by** selector in the toolbar to:
+
+- Select a different field from your `STATS BY` clause to regroup the results.
+- Select **none** to fall back to the standard flat results table.
+
+Only one grouping field is active at a time.
+
+### Pattern and sparkline rendering
+
+When the grouping field uses [`CATEGORIZE`](elasticsearch://reference/query-languages/esql/functions-operators/grouping-functions/categorize.md), each row title shows the detected pattern with token highlighting, so you can scan repeated message structures at a glance.
+
+When the query also computes a [`SPARKLINE`](elasticsearch://reference/query-languages/esql/functions-operators/aggregation-functions/sparkline.md) over time, the resulting array is rendered as an inline sparkline next to the row aggregates. For example, the following query categorizes log messages and renders a per-pattern sparkline:
+
+```esql
+FROM kibana_sample_data_logs
+| WHERE @timestamp <= ?_tend AND @timestamp > ?_tstart
+| SAMPLE 0.001
+| STATS Count = COUNT(*) / 0.001,
+        Sparkline = SPARKLINE(COUNT(*), @timestamp, 40, ?_tstart, ?_tend)
+    BY Pattern = CATEGORIZE(message)
+| SORT Count DESC
+```
+
+::::{tip}
+Pattern detection on text fields is also available outside {{esql}} from the **Patterns** tab in Discover's classic mode. See [](/explore-analyze/discover/run-pattern-analysis-discover.md).
+::::
+
+### Row actions
+
+Select the {icon}`boxesVertical` actions button on any group row to:
+
+- **Copy to clipboard**: copy the group's value.
+- **Filter in**: append a `WHERE` clause to your query that keeps only documents matching this group.
+- **Filter out**: append a `WHERE` clause that excludes documents matching this group.
+- **Open in new tab**: open the documents in this group in a new Discover tab, with a query scoped to that group.
+
+**Filter in** and **Filter out** are disabled when the grouping field is not filterable.
+
 ## Refine an {{esql}} query by interacting with the results table
 
 Certain interactions with the results table of your {{esql}} query in Discover apply additional filters to your query. When hovering over a value cell, contextual options appear: 

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -375,7 +375,7 @@ Pattern detection on text fields is also available outside {{esql}} from the **P
 
 ### Row actions
 
-Select the {icon}`boxesVertical` actions button on any group row to:
+Select the {icon}`boxes_vertical` actions button on any group row to:
 
 - **Copy to clipboard**: copy the group's value.
 - **Filter in**: append a `WHERE` clause to your query that keeps only documents matching this group.


### PR DESCRIPTION
## Status: closed without merging

During testing, two gating issues surfaced that make this content unsafe to publish today:

1. **Cascade / grouped results layout** is gated by the `discover.cascadeLayoutEnabled` LaunchDarkly flag, which is not enabled in production Stack or Serverless environments today. The `true` fallback in `build_services.ts` only applies when no flag provider is reachable; LD wins in real deployments.
2. **`SPARKLINE`** is currently `Elastic Cloud Serverless: Preview` and `Elastic Stack: Planned` per the published reference page. The recommended `CATEGORIZE` + `SPARKLINE` query fails with `Unknown function SPARKLINE` on Stack.

See the [comment on #5733](https://github.com/elastic/docs-content/issues/5733#issuecomment-4306756393) for the full context. Reopen and revisit once both gates are lifted.

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Original verification covered UI labels, row actions, and the `STATS BY` heuristic against Kibana `main`.