### PR TITLE
Add stub pages for Agent Builder connectors and plugins

### DIFF
--- a/explore-analyze/ai-features/agent-builder/connectors.md
+++ b/explore-analyze/ai-features/agent-builder/connectors.md
@@ -1,0 +1,8 @@
+---
+navigation_title: "Connectors"
+applies_to:
+  stack:
+  serverless:
+---
+
+# Connectors in {{agent-builder}}

--- a/explore-analyze/ai-features/agent-builder/plugins.md
+++ b/explore-analyze/ai-features/agent-builder/plugins.md
@@ -1,0 +1,8 @@
+---
+navigation_title: "Plugins"
+applies_to:
+  stack:
+  serverless:
+---
+
+# Plugins in {{agent-builder}}

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -236,6 +236,8 @@ toc:
               - file: ai-features/agent-builder/troubleshooting/context-length-exceeded.md
               - file: ai-features/agent-builder/troubleshooting/api-calls-return-403-forbidden.md
           - file: ai-features/agent-builder/limitations-known-issues.md
+          - hidden: ai-features/agent-builder/connectors.md
+          - hidden: ai-features/agent-builder/plugins.md
       - file: ai-features/ai-chat-experiences.md
         children:
           - file: ai-features/ai-chat-experiences/ai-agent-or-ai-assistant.md


### PR DESCRIPTION
## Summary
- Adds hidden stub pages for Agent Builder connectors and plugins so the URLs resolve
- Pages contain only frontmatter and an H1 heading
- Added as `hidden:` entries in toc.yml so they don't appear in the left nav

## Test plan
- [ ] Verify both URLs resolve after merge: `/explore-analyze/ai-features/agent-builder/connectors` and `/explore-analyze/ai-features/agent-builder/plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)