### PR TITLE
[Agent Builder] Update Observability built-in skill availability

### DIFF
--- a/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md
@@ -44,11 +44,11 @@ serverless:
   observability: ga
 ```
 
-$$$agent-builder-observability-investigation-skill$$$ `observability.investigation` {applies_to}`stack: unavailable`
+$$$agent-builder-observability-investigation-skill$$$ `observability.investigation` {applies_to}`stack: ga 9.4`
 :   Answers observability questions and diagnoses issues across APM services and infrastructure. Use when a user asks about service health, error rates, latency, failed transactions, service topology, trace analysis, log patterns, SLO breaches, alert investigations, or general questions about services and their performance.
 
-$$$agent-builder-observability-rca-skill$$$ `observability.rca` {applies_to}`stack: preview 9.4`
-:   Performs structured root cause analysis for incidents, outages, errors, and service degradations. Use when a user asks why something is broken, slow, or failing; when an alert has fired; or when they need to trace a cascading failure across services.
+% $$$agent-builder-observability-rca-skill$$$ `observability.rca` {applies_to}`stack: preview 9.4`
+% :   Performs structured root cause analysis for incidents, outages, errors, and service degradations. Use when a user asks why something is broken, slow, or failing; when an alert has fired; or when they need to trace a cascading failure across services.
 
 % TODO: Confirm GA status for observability.rca — marked experimental in Kibana source.
 


### PR DESCRIPTION
## Summary
This PR updates the available built in skills for Observability in Agent Builder. `observability.investigation` should show as GA for 9.4 instead of unavailable. `observability.rca` is experimental and users have to turn it on, and will probably change quite a bit.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  

