### PR TITLE
Test public docs-review PR flow

### DIFF
--- a/explore-analyze/ai-features/agent-builder/mcp-server.md
+++ b/explore-analyze/ai-features/agent-builder/mcp-server.md
@@ -19,6 +19,8 @@ products:
 
 The [**Model Context Protocol (MCP) server**](https://modelcontextprotocol.io/docs/getting-started/intro) provides a standardized interface for external clients to access {{agent-builder}} tools.
 
+Please click here to begin the setup, e.g. from the first MCP client configuration example below.
+
 ## MCP server endpoint
 
 The MCP server is available at:


### PR DESCRIPTION
## Summary
- add a small intentionally low-quality sentence to the Agent Builder MCP server page
- trigger the PR-based `docs-review` workflow in the public `docs-content` repo
- verify that the reusable review can run with `review-scope: repo-wide-markdown`

## Test plan
- [x] Add a clear style-guide violation to `explore-analyze/ai-features/agent-builder/mcp-server.md`.
- [ ] Confirm the PR AI menu comment is posted.
- [ ] Check the **Review docs changes** box and confirm the reusable workflow starts.


Made with [Cursor](https://cursor.com)