### PR TITLE
Test public docs-review PR flow on main

### DIFF
--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -1,0 +1,80 @@
+const MENU_START = '<!-- docs-pr-ai-menu:start -->';
+const MENU_END = '<!-- docs-pr-ai-menu:end -->';
+
+const WORKFLOW_CONFIG = {
+  docsReview: {
+    label: 'Review docs changes ([`docs-review`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-review.md)).',
+    marker: '<!-- docs-pr-ai-menu:docs-review -->',
+  },
+};
+
+const WORKFLOW_ORDER = ['docsReview'];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getLinePattern(key) {
+  const { label, marker } = WORKFLOW_CONFIG[key];
+
+  return new RegExp(
+    `^- \\[([ x])\\] ${escapeRegExp(label)} ${escapeRegExp(marker)}$`,
+    'm'
+  );
+}
+
+function parseWorkflowState(body, key) {
+  const match = (body || '').match(getLinePattern(key));
+
+  if (!match) {
+    return {
+      selected: false,
+    };
+  }
+
+  return {
+    selected: match[1] === 'x',
+  };
+}
+
+function parseMenuState(body) {
+  const state = {};
+
+  for (const key of WORKFLOW_ORDER) {
+    state[key] = parseWorkflowState(body, key);
+  }
+
+  return state;
+}
+
+function buildWorkflowLine(key, workflowState) {
+  const { label, marker } = WORKFLOW_CONFIG[key];
+  const selected = workflowState?.selected ? 'x' : ' ';
+
+  return `- [${selected}] ${label} ${marker}`;
+}
+
+function buildMenuBody(state) {
+  const normalizedState = state || {};
+
+  return [
+    MENU_START,
+    '## Elastic Docs AI PR menu',
+    '',
+    'Check the box to run an AI review for this pull request.',
+    '',
+    ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key])),
+    '',
+    'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
+    '',
+    MENU_END,
+  ].join('\n');
+}
+
+module.exports = {
+  MENU_START,
+  MENU_END,
+  WORKFLOW_ORDER,
+  parseMenuState,
+  buildMenuBody,
+};

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -133,7 +133,7 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@1.12.3
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@v1
     with:
       review-scope: repo-wide-markdown
       additional-instructions: |

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -1,0 +1,143 @@
+name: Docs PR AI menu
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [edited]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to post or refresh the AI PR menu on.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  post-menu:
+    name: Post or refresh AI PR menu
+    if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Create or update AI PR menu comment
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
+            const markerStart = '<!-- docs-pr-ai-menu:start -->';
+            const markerEnd = '<!-- docs-pr-ai-menu:end -->';
+            const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
+            const pullRequestNumber = context.eventName === 'workflow_dispatch'
+              ? Number(workflowDispatchPrNumber)
+              : context.payload.pull_request.number;
+
+            if (!pullRequestNumber) {
+              core.setFailed('Pull request number is required for workflow_dispatch runs.');
+              return;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(markerStart) &&
+              comment.body?.includes(markerEnd)
+            );
+
+            const existingState = menu.parseMenuState(existingComment?.body || '');
+            const body = menu.buildMenuBody(existingState);
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequestNumber,
+                body,
+              });
+            }
+
+  evaluate-trigger:
+    name: Evaluate AI PR menu trigger
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      github.actor != 'github-actions[bot]' &&
+      github.event.comment.user.login == 'github-actions[bot]' &&
+      contains(github.event.comment.body, '<!-- docs-pr-ai-menu:start -->') &&
+      contains(github.event.comment.body, '<!-- docs-pr-ai-menu:end -->')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docs_review_triggered: ${{ steps.evaluate.outputs.docs_review_triggered }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Parse AI PR menu transition
+        id: evaluate
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
+            const body = context.payload.comment.body || '';
+            const previousBody = context.payload.changes?.body?.from || '';
+
+            const previousState = menu.parseMenuState(previousBody);
+            const currentState = menu.parseMenuState(body);
+            const docsReviewTriggered =
+              !previousState.docsReview.selected && currentState.docsReview.selected;
+
+            core.setOutput('docs_review_triggered', String(docsReviewTriggered));
+
+  run-docs-review:
+    name: Run docs-review
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    permissions:
+      actions: read
+      contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@1.12.3
+    with:
+      review-scope: repo-wide-markdown
+      additional-instructions: |
+        This repository stores documentation as markdown across the repository, not only under `docs/`.
+        Prefer concise, high-signal review comments with exact replacement text when possible.
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/explore-analyze/ai-features/agent-builder/mcp-server.md
+++ b/explore-analyze/ai-features/agent-builder/mcp-server.md
@@ -115,6 +115,14 @@ Without the `feature_agentBuilder.read` application privilege, you'll receive a 
 
 ## Best practices
 
+### Quick setup checklist
+
+Please click here to begin a simple setup for your MCP client. You can use e.g. a short-lived key, and below you can pick the easiest path for your team.
+
+- Click here to copy the endpoint URL
+- Use a simple API key first
+- Review the permissions later
+
 ### Set API key expiration dates
 
 Always set an expiration date on API keys for security. Use shorter durations (1-7 days) for development and longer durations (30-90 days) for production, rotating keys regularly.


### PR DESCRIPTION
## Summary
- add the PR AI menu workflow to `docs-content`
- point the reusable `docs-review` caller at `docs-actions@v1`
- add a broader intentionally weak docs change to the Agent Builder MCP server page
- create a single PR against `main` that can be used once the PR-menu workflow is available on the base branch

## Test plan
- [x] Add `.github/workflows/docs-pr-ai-menu.yml` and `.github/scripts/docs_pr_ai_menu.cjs`.
- [x] Add a structural change and several style-guide violations to `explore-analyze/ai-features/agent-builder/mcp-server.md`.
- [ ] Merge the PR-menu workflow to `main` or otherwise make it available on the base branch.
- [ ] Confirm the PR AI menu comment is posted.
- [ ] Check the **Review docs changes** box and confirm the reusable workflow starts.


Made with [Cursor](https://cursor.com)