### PR TITLE
Test public docs-review PR flow

### DIFF
--- a/explore-analyze/ai-features/agent-builder/mcp-server.md
+++ b/explore-analyze/ai-features/agent-builder/mcp-server.md
@@ -115,6 +115,14 @@ Without the `feature_agentBuilder.read` application privilege, you'll receive a 
 
 ## Best practices
 
+### Quick setup checklist
+
+Please click here to begin a simple setup for your MCP client. You can use e.g. a short-lived key, and below you can pick the easiest path for your team.
+
+- Click here to copy the endpoint URL
+- Use a simple API key first
+- Review the permissions later
+
 ### Set API key expiration dates
 
 Always set an expiration date on API keys for security. Use shorter durations (1-7 days) for development and longer durations (30-90 days) for production, rotating keys regularly.


### PR DESCRIPTION
## Summary
- add a small structural section with intentionally weak wording to the Agent Builder MCP server page
- create a docs-only test PR against the PR-menu workflow branch
- verify that the public `docs-review` flow runs with `review-scope: repo-wide-markdown`

## Test plan
- [x] Add a structural change and several style-guide violations to `explore-analyze/ai-features/agent-builder/mcp-server.md`.
- [ ] Confirm the PR AI menu comment is posted.
- [ ] Check the **Review docs changes** box and confirm the reusable workflow starts.
- [ ] Verify the resulting review is advisory-only.


Made with [Cursor](https://cursor.com)