### PR TITLE
Add progress status to Docs AI PR menu

### DIFF
--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -3,6 +3,7 @@ const MENU_END = '<!-- docs-pr-ai-menu:end -->';
 
 const WORKFLOW_CONFIG = {
   docsReview: {
+    checkNamePrefix: 'Docs AI / docs review',
     label: 'Review docs changes ([`docs-review`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-review.md)).',
     marker: '<!-- docs-pr-ai-menu:docs-review -->',
   },
@@ -18,7 +19,7 @@ function getLinePattern(key) {
   const { label, marker } = WORKFLOW_CONFIG[key];
 
   return new RegExp(
-    `^- \\[([ x])\\] ${escapeRegExp(label)} ${escapeRegExp(marker)}$`,
+    `^- \\[([ x])\\] ${escapeRegExp(label)}(?: Status: [^.]+\\.)? ${escapeRegExp(marker)}$`,
     'm'
   );
 }
@@ -47,15 +48,61 @@ function parseMenuState(body) {
   return state;
 }
 
-function buildWorkflowLine(key, workflowState) {
-  const { label, marker } = WORKFLOW_CONFIG[key];
-  const selected = workflowState?.selected ? 'x' : ' ';
+function getStatusText(workflowState, workflowStatus) {
+  if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') {
+    return 'Status: running.';
+  }
 
-  return `- [${selected}] ${label} ${marker}`;
+  if (workflowStatus?.status === 'completed') {
+    if (workflowStatus.conclusion === 'success') {
+      return 'Status: completed.';
+    }
+
+    if (workflowStatus.conclusion === 'cancelled') {
+      return 'Status: cancelled.';
+    }
+
+    return 'Status: needs attention.';
+  }
+
+  if (workflowState?.selected) {
+    return 'Status: queued.';
+  }
+
+  return 'Status: not started.';
 }
 
-function buildMenuBody(state) {
+function getWorkflowStatusFromCheckRuns(key, checkRuns) {
+  const { checkNamePrefix } = WORKFLOW_CONFIG[key];
+  const matchingCheckRuns = (checkRuns || []).filter((checkRun) =>
+    checkRun.name?.startsWith(checkNamePrefix)
+  );
+
+  if (matchingCheckRuns.length === 0) {
+    return null;
+  }
+
+  matchingCheckRuns.sort((left, right) =>
+    new Date(right.started_at || right.created_at || 0) - new Date(left.started_at || left.created_at || 0)
+  );
+
+  return {
+    conclusion: matchingCheckRuns[0].conclusion,
+    status: matchingCheckRuns[0].status,
+  };
+}
+
+function buildWorkflowLine(key, workflowState, workflowStatus) {
+  const { label, marker } = WORKFLOW_CONFIG[key];
+  const selected = workflowState?.selected ? 'x' : ' ';
+  const statusText = getStatusText(workflowState, workflowStatus);
+
+  return `- [${selected}] ${label} ${statusText} ${marker}`;
+}
+
+function buildMenuBody(state, statuses) {
   const normalizedState = state || {};
+  const normalizedStatuses = statuses || {};
 
   return [
     MENU_START,
@@ -63,7 +110,9 @@ function buildMenuBody(state) {
     '',
     'Check the box to run an AI review for this pull request.',
     '',
-    ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key])),
+    ...WORKFLOW_ORDER.map((key) =>
+      buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])
+    ),
     '',
     'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
     '',
@@ -76,5 +125,6 @@ module.exports = {
   MENU_END,
   WORKFLOW_ORDER,
   parseMenuState,
+  getWorkflowStatusFromCheckRuns,
   buildMenuBody,
 };

--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -120,6 +120,85 @@ function buildMenuBody(state, statuses) {
   ].join('\n');
 }
 
+async function getCheckRunsForPullRequest(github, context, pullRequestNumber) {
+  const { data: pullRequest } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: pullRequestNumber,
+  });
+
+  const { data: checks } = await github.rest.checks.listForRef({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    ref: pullRequest.head.sha,
+    per_page: 100,
+  });
+
+  return checks.check_runs || [];
+}
+
+async function findMenuComment(github, context, pullRequestNumber) {
+  const { data: comments } = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequestNumber,
+    per_page: 100,
+  });
+
+  return comments.find((comment) =>
+    comment.user?.login === 'github-actions[bot]' &&
+    comment.body?.includes(MENU_START) &&
+    comment.body?.includes(MENU_END)
+  );
+}
+
+function buildWorkflowStatuses(checkRuns, statusOverrides) {
+  return Object.fromEntries(
+    WORKFLOW_ORDER.map((key) => [
+      key,
+      statusOverrides?.[key] || getWorkflowStatusFromCheckRuns(key, checkRuns),
+    ])
+  );
+}
+
+async function upsertMenuComment({
+  core,
+  createIfMissing = true,
+  github,
+  context,
+  pullRequestNumber,
+  statusOverrides,
+}) {
+  const checkRuns = await getCheckRunsForPullRequest(github, context, pullRequestNumber);
+  const existingComment = await findMenuComment(github, context, pullRequestNumber);
+
+  if (!existingComment && !createIfMissing) {
+    core?.warning('AI PR menu comment was not found.');
+    return;
+  }
+
+  const existingState = parseMenuState(existingComment?.body || '');
+  const statuses = buildWorkflowStatuses(checkRuns, statusOverrides);
+  const body = buildMenuBody(existingState, statuses);
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingComment.id,
+      body,
+    });
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: pullRequestNumber,
+    body,
+  });
+}
+
 module.exports = {
   MENU_START,
   MENU_END,
@@ -127,4 +206,5 @@ module.exports = {
   parseMenuState,
   getWorkflowStatusFromCheckRuns,
   buildMenuBody,
+  upsertMenuComment,
 };

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   actions: read
+  checks: read
   contents: read
   discussions: write
   issues: write
@@ -25,9 +26,13 @@ jobs:
     if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: read
       issues: write
       pull-requests: write
+    concurrency:
+      group: docs-pr-ai-menu-${{ github.event.pull_request.number || github.event.inputs.pull_request_number }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository
@@ -53,6 +58,19 @@ jobs:
               return;
             }
 
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pullRequest.head.sha,
+              per_page: 100,
+            });
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -67,7 +85,13 @@ jobs:
             );
 
             const existingState = menu.parseMenuState(existingComment?.body || '');
-            const body = menu.buildMenuBody(existingState);
+            const statuses = Object.fromEntries(
+              menu.WORKFLOW_ORDER.map((key) => [
+                key,
+                menu.getWorkflowStatusFromCheckRuns(key, checks.check_runs),
+              ])
+            );
+            const body = menu.buildMenuBody(existingState, statuses);
 
             if (existingComment) {
               await github.rest.issues.updateComment({
@@ -123,8 +147,85 @@ jobs:
 
             core.setOutput('docs_review_triggered', String(docsReviewTriggered));
 
+  refresh-menu-after-trigger:
+    name: Refresh AI PR menu after trigger
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: docs-pr-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI PR menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
+            const markerStart = '<!-- docs-pr-ai-menu:start -->';
+            const markerEnd = '<!-- docs-pr-ai-menu:end -->';
+            const pullRequestNumber = context.payload.issue.number;
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pullRequest.head.sha,
+              per_page: 100,
+            });
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(markerStart) &&
+              comment.body?.includes(markerEnd)
+            );
+
+            if (!existingComment) {
+              core.warning('AI PR menu comment was not found.');
+              return;
+            }
+
+            const existingState = menu.parseMenuState(existingComment.body || '');
+            const statuses = Object.fromEntries(
+              menu.WORKFLOW_ORDER.map((key) => [
+                key,
+                menu.getWorkflowStatusFromCheckRuns(key, checks.check_runs),
+              ])
+            );
+            const body = menu.buildMenuBody(existingState, statuses);
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body,
+            });
+
   run-docs-review:
-    name: Run docs-review
+    name: Docs AI / docs review
     needs: [evaluate-trigger]
     if: needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
     permissions:
@@ -141,3 +242,90 @@ jobs:
         Prefer concise, high-signal review comments with exact replacement text when possible.
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  refresh-menu-after-docs-review:
+    name: Refresh AI PR menu after docs review
+    needs: [evaluate-trigger, run-docs-review]
+    if: always() && needs.evaluate-trigger.outputs.docs_review_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: docs-pr-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI PR menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
+            const markerStart = '<!-- docs-pr-ai-menu:start -->';
+            const markerEnd = '<!-- docs-pr-ai-menu:end -->';
+            const pullRequestNumber = context.payload.issue.number;
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pullRequest.head.sha,
+              per_page: 100,
+            });
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(markerStart) &&
+              comment.body?.includes(markerEnd)
+            );
+
+            if (!existingComment) {
+              core.warning('AI PR menu comment was not found.');
+              return;
+            }
+
+            const docsReviewResult = '${{ needs.run-docs-review.result }}';
+            const docsReviewStatus = {
+              conclusion: docsReviewResult === 'success'
+                ? 'success'
+                : docsReviewResult === 'cancelled'
+                  ? 'cancelled'
+                  : 'failure',
+              status: 'completed',
+            };
+            const existingState = menu.parseMenuState(existingComment.body || '');
+            const statuses = Object.fromEntries(
+              menu.WORKFLOW_ORDER.map((key) => [
+                key,
+                menu.getWorkflowStatusFromCheckRuns(key, checks.check_runs),
+              ])
+            );
+            statuses.docsReview = docsReviewStatus;
+            const body = menu.buildMenuBody(existingState, statuses);
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body,
+            });

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -46,8 +46,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
-            const markerStart = '<!-- docs-pr-ai-menu:start -->';
-            const markerEnd = '<!-- docs-pr-ai-menu:end -->';
             const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
             const pullRequestNumber = context.eventName === 'workflow_dispatch'
               ? Number(workflowDispatchPrNumber)
@@ -58,56 +56,7 @@ jobs:
               return;
             }
 
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequestNumber,
-            });
-
-            const { data: checks } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: pullRequest.head.sha,
-              per_page: 100,
-            });
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequestNumber,
-              per_page: 100,
-            });
-
-            const existingComment = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(markerStart) &&
-              comment.body?.includes(markerEnd)
-            );
-
-            const existingState = menu.parseMenuState(existingComment?.body || '');
-            const statuses = Object.fromEntries(
-              menu.WORKFLOW_ORDER.map((key) => [
-                key,
-                menu.getWorkflowStatusFromCheckRuns(key, checks.check_runs),
-              ])
-            );
-            const body = menu.buildMenuBody(existingState, statuses);
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullRequestNumber,
-                body,
-              });
-            }
+            await menu.upsertMenuComment({ core, github, context, pullRequestNumber });
 
   evaluate-trigger:
     name: Evaluate AI PR menu trigger
@@ -173,55 +122,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
-            const markerStart = '<!-- docs-pr-ai-menu:start -->';
-            const markerEnd = '<!-- docs-pr-ai-menu:end -->';
             const pullRequestNumber = context.payload.issue.number;
 
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequestNumber,
-            });
-
-            const { data: checks } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: pullRequest.head.sha,
-              per_page: 100,
-            });
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequestNumber,
-              per_page: 100,
-            });
-
-            const existingComment = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(markerStart) &&
-              comment.body?.includes(markerEnd)
-            );
-
-            if (!existingComment) {
-              core.warning('AI PR menu comment was not found.');
-              return;
-            }
-
-            const existingState = menu.parseMenuState(existingComment.body || '');
-            const statuses = Object.fromEntries(
-              menu.WORKFLOW_ORDER.map((key) => [
-                key,
-                menu.getWorkflowStatusFromCheckRuns(key, checks.check_runs),
-              ])
-            );
-            const body = menu.buildMenuBody(existingState, statuses);
-
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existingComment.id,
-              body,
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              pullRequestNumber,
             });
 
   run-docs-review:
@@ -269,41 +177,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
-            const markerStart = '<!-- docs-pr-ai-menu:start -->';
-            const markerEnd = '<!-- docs-pr-ai-menu:end -->';
             const pullRequestNumber = context.payload.issue.number;
-
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequestNumber,
-            });
-
-            const { data: checks } = await github.rest.checks.listForRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: pullRequest.head.sha,
-              per_page: 100,
-            });
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pullRequestNumber,
-              per_page: 100,
-            });
-
-            const existingComment = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(markerStart) &&
-              comment.body?.includes(markerEnd)
-            );
-
-            if (!existingComment) {
-              core.warning('AI PR menu comment was not found.');
-              return;
-            }
-
             const docsReviewResult = '${{ needs.run-docs-review.result }}';
             const docsReviewStatus = {
               conclusion: docsReviewResult === 'success'
@@ -313,19 +187,14 @@ jobs:
                   : 'failure',
               status: 'completed',
             };
-            const existingState = menu.parseMenuState(existingComment.body || '');
-            const statuses = Object.fromEntries(
-              menu.WORKFLOW_ORDER.map((key) => [
-                key,
-                menu.getWorkflowStatusFromCheckRuns(key, checks.check_runs),
-              ])
-            );
-            statuses.docsReview = docsReviewStatus;
-            const body = menu.buildMenuBody(existingState, statuses);
 
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existingComment.id,
-              body,
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              pullRequestNumber,
+              statusOverrides: {
+                docsReview: docsReviewStatus,
+              },
             });


### PR DESCRIPTION
## Summary
- Render per-action status text in the Docs AI PR menu from PR check runs.
- Rename the docs-review job to the stable `Docs AI / docs review` check prefix.
- Add serialized menu refresh jobs after trigger and completion so future AI actions can update the shared menu without racing each other.

## Test plan
- [x] Ran `node --check .github/scripts/docs_pr_ai_menu.cjs`.
- [x] Smoke-tested menu status rendering and parsing with Node assertions.
- [x] Parsed `.github/workflows/docs-pr-ai-menu.yml` with Ruby YAML.
- [x] Ran `git diff --check`.


Made with [Cursor](https://cursor.com)