### PR TITLE
Fix Docs AI menu running status

### DIFF
--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -75,7 +75,8 @@ function getStatusText(workflowState, workflowStatus) {
 function getWorkflowStatusFromCheckRuns(key, checkRuns) {
   const { checkNamePrefix } = WORKFLOW_CONFIG[key];
   const matchingCheckRuns = (checkRuns || []).filter((checkRun) =>
-    checkRun.name?.startsWith(checkNamePrefix)
+    checkRun.name?.startsWith(checkNamePrefix) &&
+    checkRun.conclusion !== 'skipped'
   );
 
   if (matchingCheckRuns.length === 0) {

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -130,6 +130,11 @@ jobs:
               github,
               context,
               pullRequestNumber,
+              statusOverrides: {
+                docsReview: {
+                  status: 'in_progress',
+                },
+              },
             });
 
   run-docs-review:


### PR DESCRIPTION
## Summary
- Ignore skipped `Docs AI / docs review` checks when deriving menu status from PR head check runs.
- Explicitly mark docs review as running in the immediate post-trigger menu refresh.
- Keep the completion refresh as the final source of completed/cancelled/failure state.

## Test plan
- [x] Ran `node --check .github/scripts/docs_pr_ai_menu.cjs`.
- [x] Ran a Node regression test for skipped check handling and running status rendering.
- [x] Parsed `.github/workflows/docs-pr-ai-menu.yml` with Ruby YAML.
- [x] Ran `git diff --check`.


Made with [Cursor](https://cursor.com)