### PR TITLE
Sample Docs AI menu status fix test PR

### DIFF
--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -75,7 +75,8 @@ function getStatusText(workflowState, workflowStatus) {
 function getWorkflowStatusFromCheckRuns(key, checkRuns) {
   const { checkNamePrefix } = WORKFLOW_CONFIG[key];
   const matchingCheckRuns = (checkRuns || []).filter((checkRun) =>
-    checkRun.name?.startsWith(checkNamePrefix)
+    checkRun.name?.startsWith(checkNamePrefix) &&
+    checkRun.conclusion !== 'skipped'
   );
 
   if (matchingCheckRuns.length === 0) {

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -130,6 +130,11 @@ jobs:
               github,
               context,
               pullRequestNumber,
+              statusOverrides: {
+                docsReview: {
+                  status: 'in_progress',
+                },
+              },
             });
 
   run-docs-review:

--- a/troubleshoot/kibana/reporting.md
+++ b/troubleshoot/kibana/reporting.md
@@ -14,7 +14,7 @@ products:
 # Troubleshoot {{kib}} reporting [reporting-troubleshooting]
 
 
-Kibana excels as a data visualization tool. The {{report-features}} exist to export data as simple reports, however Kibana is not a data export tool. To export data at a large scale, there are better ways and better architectures for exporting data at scale from Elasticsearch.
+Kibana excels as a data visualization tool. The {{report-features}} exist to export data as simple reports, however Kibana is not a data export tool. To export data at a large scale, there are better ways and better architectures for exporting data at scale from Elasticsearch. This comprehensive guide helps you leverage native Elastic capabilities to quickly troubleshoot reporting.
 
 If you have trouble creating simple reports, there are some general solutions to common problems you might encounter while using {{report-features}}. For tips related to specific types of reports, refer to [CSV](../../explore-analyze/report-and-share/reporting-troubleshooting-csv.md) and [PDF/PNG](../../explore-analyze/report-and-share/reporting-troubleshooting-pdf.md).
 


### PR DESCRIPTION
## Summary
- Adds an intentional sample docs issue to test the Docs AI PR menu status fix.
- Uses the updated menu workflow that is now on `main`.

## Test plan
- Use the Docs AI PR menu checkbox on this PR.
- Verify the menu changes to `Status: running.` after the checkbox trigger.
- Verify the menu changes to a completion state after docs-review finishes.

This PR is for testing only and should not be merged.

Made with [Cursor](https://cursor.com)