### PR TITLE
Add progress links to Docs AI menu status

### DIFF
--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -19,7 +19,7 @@ function getLinePattern(key) {
   const { label, marker } = WORKFLOW_CONFIG[key];
 
   return new RegExp(
-    `^- \\[([ x])\\] ${escapeRegExp(label)}(?: Status: [^.]+\\.)? ${escapeRegExp(marker)}$`,
+    `^- \\[([ x])\\] ${escapeRegExp(label)}(?: Status: .*?)? ${escapeRegExp(marker)}$`,
     'm'
   );
 }
@@ -49,20 +49,24 @@ function parseMenuState(body) {
 }
 
 function getStatusText(workflowState, workflowStatus) {
+  const progressLink = workflowStatus?.detailsUrl
+    ? ` [View progress](${workflowStatus.detailsUrl}).`
+    : '';
+
   if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') {
-    return 'Status: running.';
+    return `Status: running.${progressLink}`;
   }
 
   if (workflowStatus?.status === 'completed') {
     if (workflowStatus.conclusion === 'success') {
-      return 'Status: completed.';
+      return `Status: completed.${progressLink}`;
     }
 
     if (workflowStatus.conclusion === 'cancelled') {
-      return 'Status: cancelled.';
+      return `Status: cancelled.${progressLink}`;
     }
 
-    return 'Status: needs attention.';
+    return `Status: needs attention.${progressLink}`;
   }
 
   if (workflowState?.selected) {
@@ -89,6 +93,7 @@ function getWorkflowStatusFromCheckRuns(key, checkRuns) {
 
   return {
     conclusion: matchingCheckRuns[0].conclusion,
+    detailsUrl: matchingCheckRuns[0].details_url,
     status: matchingCheckRuns[0].status,
   };
 }

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -123,6 +123,7 @@ jobs:
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
             const pullRequestNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             await menu.upsertMenuComment({
               core,
@@ -132,6 +133,7 @@ jobs:
               pullRequestNumber,
               statusOverrides: {
                 docsReview: {
+                  detailsUrl: progressUrl,
                   status: 'in_progress',
                 },
               },
@@ -183,6 +185,7 @@ jobs:
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
             const pullRequestNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const docsReviewResult = '${{ needs.run-docs-review.result }}';
             const docsReviewStatus = {
               conclusion: docsReviewResult === 'success'
@@ -190,6 +193,7 @@ jobs:
                 : docsReviewResult === 'cancelled'
                   ? 'cancelled'
                   : 'failure',
+              detailsUrl: progressUrl,
               status: 'completed',
             };
 


### PR DESCRIPTION
## Summary
- Adds a `View progress` link to Docs AI menu status text when a workflow or check URL is available.
- Passes the current Actions run URL from both menu refresh jobs.
- Keeps menu state parsing compatible with Markdown links in the status text.

## Test plan
- [x] Ran `node --check .github/scripts/docs_pr_ai_menu.cjs`.
- [x] Ran a Node smoke test for progress link rendering, parsing, and check-run URL extraction.
- [x] Parsed `.github/workflows/docs-pr-ai-menu.yml` with Ruby YAML.
- [x] Ran `git diff --check`.

Made with [Cursor](https://cursor.com)