### PR TITLE
Add status updates to Docs AI issue menu

### DIFF
--- a/.github/scripts/docs_ai_menu.cjs
+++ b/.github/scripts/docs_ai_menu.cjs
@@ -22,7 +22,7 @@ function getLinePattern(key) {
   const { label, marker } = WORKFLOW_CONFIG[key];
 
   return new RegExp(
-    `^- \\[([ x])\\] ${escapeRegExp(label)} ${escapeRegExp(marker)}$`,
+    `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
     'm'
   );
 }
@@ -42,6 +42,7 @@ function parseWorkflowState(body, key) {
 
   return {
     selected: match[1] === 'x',
+    statusText: match[2] || null,
   };
 }
 
@@ -55,15 +56,53 @@ function parseMenuState(body) {
   return state;
 }
 
-function buildWorkflowLine(key, workflowState) {
-  const { label, marker } = WORKFLOW_CONFIG[key];
-  const selected = workflowState?.selected ? 'x' : ' ';
+function getStatusText(workflowState, workflowStatus) {
+  if (workflowStatus?.statusText) {
+    return workflowStatus.statusText;
+  }
 
-  return `- [${selected}] ${label} ${marker}`;
+  const progressLink = workflowStatus?.detailsUrl
+    ? ` [View progress](${workflowStatus.detailsUrl}).`
+    : '';
+
+  if (workflowStatus?.status === 'in_progress' || workflowStatus?.status === 'queued') {
+    return `Status: running.${progressLink}`;
+  }
+
+  if (workflowStatus?.status === 'completed') {
+    if (workflowStatus.conclusion === 'success') {
+      return `Status: completed.${progressLink}`;
+    }
+
+    if (workflowStatus.conclusion === 'cancelled') {
+      return `Status: cancelled.${progressLink}`;
+    }
+
+    return `Status: needs attention.${progressLink}`;
+  }
+
+  if (workflowState?.statusText) {
+    return workflowState.statusText;
+  }
+
+  if (workflowState?.selected) {
+    return 'Status: queued.';
+  }
+
+  return 'Status: not started.';
 }
 
-function buildMenuBody(state) {
+function buildWorkflowLine(key, workflowState, workflowStatus) {
+  const { label, marker } = WORKFLOW_CONFIG[key];
+  const selected = workflowState?.selected ? 'x' : ' ';
+  const statusText = getStatusText(workflowState, workflowStatus);
+
+  return `- [${selected}] ${label} ${statusText} ${marker}`;
+}
+
+function buildMenuBody(state, statuses) {
   const normalizedState = state || {};
+  const normalizedStatuses = statuses || {};
 
   return [
     MENU_START,
@@ -71,12 +110,76 @@ function buildMenuBody(state) {
     '',
     'Check one box to run an AI workflow for this issue.',
     '',
-    ...WORKFLOW_ORDER.map((key) => buildWorkflowLine(key, normalizedState[key])),
+    ...WORKFLOW_ORDER.map((key) =>
+      buildWorkflowLine(key, normalizedState[key], normalizedStatuses[key])
+    ),
     '',
     'Powered by GitHub Agentic Workflows and [docs-actions](https://github.com/elastic/docs-actions). For more information, reach out to the docs team.',
     '',
     MENU_END,
   ].join('\n');
+}
+
+async function findMenuComment(github, context, issueNumber) {
+  const { data: comments } = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+
+  return comments.find((comment) =>
+    comment.user?.login === 'github-actions[bot]' &&
+    isMenuComment(comment.body)
+  );
+}
+
+function buildWorkflowStatuses(existingState, statusOverrides) {
+  return Object.fromEntries(
+    WORKFLOW_ORDER.map((key) => [
+      key,
+      statusOverrides?.[key] || {
+        statusText: existingState?.[key]?.statusText,
+      },
+    ])
+  );
+}
+
+async function upsertMenuComment({
+  core,
+  createIfMissing = true,
+  github,
+  context,
+  issueNumber,
+  statusOverrides,
+}) {
+  const existingComment = await findMenuComment(github, context, issueNumber);
+
+  if (!existingComment && !createIfMissing) {
+    core?.warning('AI menu comment was not found.');
+    return;
+  }
+
+  const existingState = parseMenuState(existingComment?.body || '');
+  const statuses = buildWorkflowStatuses(existingState, statusOverrides);
+  const body = buildMenuBody(existingState, statuses);
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingComment.id,
+      body,
+    });
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: issueNumber,
+    body,
+  });
 }
 
 module.exports = {
@@ -86,4 +189,5 @@ module.exports = {
   isMenuComment,
   parseMenuState,
   buildMenuBody,
+  upsertMenuComment,
 };

--- a/.github/workflows/docs-ai-menu.yml
+++ b/.github/workflows/docs-ai-menu.yml
@@ -24,6 +24,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number || github.event.inputs.issue_number }}
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository
@@ -37,8 +40,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_ai_menu.cjs`);
-            const markerStart = '<!-- docs-ai-menu:start -->';
-            const markerEnd = '<!-- docs-ai-menu:end -->';
             const workflowDispatchIssueNumber = context.payload.inputs?.issue_number;
             const issueNumber = context.eventName === 'workflow_dispatch'
               ? Number(workflowDispatchIssueNumber)
@@ -49,37 +50,7 @@ jobs:
               return;
             }
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-
-            const existingComment = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(markerStart) &&
-              comment.body?.includes(markerEnd)
-            );
-
-            const existingState = menu.parseMenuState(existingComment?.body || '');
-            const body = menu.buildMenuBody(existingState);
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body,
-              });
-            }
+            await menu.upsertMenuComment({ core, github, context, issueNumber });
 
   evaluate-trigger:
     name: Evaluate AI menu trigger
@@ -121,8 +92,61 @@ jobs:
             core.setOutput('triage_triggered', String(triageTriggered));
             core.setOutput('issue_scope_triggered', String(issueScopeTriggered));
 
+  refresh-menu-after-trigger:
+    name: Refresh AI menu after trigger
+    needs: [evaluate-trigger]
+    if: >-
+      needs.evaluate-trigger.outputs.triage_triggered == 'true' ||
+      needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_ai_menu.cjs`);
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const statusOverrides = {};
+
+            if ('${{ needs.evaluate-trigger.outputs.triage_triggered }}' === 'true') {
+              statusOverrides.triage = {
+                detailsUrl: progressUrl,
+                status: 'in_progress',
+              };
+            }
+
+            if ('${{ needs.evaluate-trigger.outputs.issue_scope_triggered }}' === 'true') {
+              statusOverrides.issueScope = {
+                detailsUrl: progressUrl,
+                status: 'in_progress',
+              };
+            }
+
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              issueNumber,
+              statusOverrides,
+            });
+
   run-docs-triage:
-    name: Run docs-triage
+    name: Docs AI / triage
     needs: [evaluate-trigger]
     if: needs.evaluate-trigger.outputs.triage_triggered == 'true'
     permissions:
@@ -154,7 +178,7 @@ jobs:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 
   run-docs-issue-scope:
-    name: Run docs-issue-scope
+    name: Docs AI / issue scope
     needs: [evaluate-trigger]
     if: needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
     permissions:
@@ -166,3 +190,97 @@ jobs:
     uses: elastic/docs-actions/.github/workflows/gh-aw-docs-issue-scope.lock.yml@v1
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  refresh-menu-after-docs-triage:
+    name: Refresh AI menu after docs triage
+    needs: [evaluate-trigger, refresh-menu-after-trigger, run-docs-triage]
+    if: always() && needs.evaluate-trigger.outputs.triage_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_ai_menu.cjs`);
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const triageResult = '${{ needs.run-docs-triage.result }}';
+
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              issueNumber,
+              statusOverrides: {
+                triage: {
+                  conclusion: triageResult === 'success'
+                    ? 'success'
+                    : triageResult === 'cancelled'
+                      ? 'cancelled'
+                      : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });
+
+  refresh-menu-after-docs-issue-scope:
+    name: Refresh AI menu after docs issue scope
+    needs: [evaluate-trigger, refresh-menu-after-trigger, run-docs-issue-scope]
+    if: always() && needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_ai_menu.cjs`);
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const issueScopeResult = '${{ needs.run-docs-issue-scope.result }}';
+
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              issueNumber,
+              statusOverrides: {
+                issueScope: {
+                  conclusion: issueScopeResult === 'success'
+                    ? 'success'
+                    : issueScopeResult === 'cancelled'
+                      ? 'cancelled'
+                      : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });


### PR DESCRIPTION
## Summary
- Adds status text and `View progress` links to the Docs AI issue menu.
- Serializes menu refreshes per issue to avoid concurrent comment update races.
- Preserves status independently for triage and issue-scope when one workflow updates before the other.

## Test plan
- [x] Ran `node --check .github/scripts/docs_ai_menu.cjs`.
- [x] Ran a Node smoke test for status rendering, parsing, and preserving another checkbox status.
- [x] Parsed `.github/workflows/docs-ai-menu.yml` with Ruby YAML.
- [x] Ran `git diff --check`.

Made with [Cursor](https://cursor.com)