### PR TITLE
Preserve running docs PR menu status

### DIFF
--- a/.github/scripts/docs_pr_ai_menu.cjs
+++ b/.github/scripts/docs_pr_ai_menu.cjs
@@ -19,7 +19,7 @@ function getLinePattern(key) {
   const { label, marker } = WORKFLOW_CONFIG[key];
 
   return new RegExp(
-    `^- \\[([ x])\\] ${escapeRegExp(label)}(?: Status: .*?)? ${escapeRegExp(marker)}$`,
+    `^- \\[([ x])\\] ${escapeRegExp(label)}(?: (Status: .*?))? ${escapeRegExp(marker)}$`,
     'm'
   );
 }
@@ -35,6 +35,7 @@ function parseWorkflowState(body, key) {
 
   return {
     selected: match[1] === 'x',
+    statusText: match[2] || null,
   };
 }
 
@@ -49,6 +50,10 @@ function parseMenuState(body) {
 }
 
 function getStatusText(workflowState, workflowStatus) {
+  if (workflowStatus?.statusText) {
+    return workflowStatus.statusText;
+  }
+
   const progressLink = workflowStatus?.detailsUrl
     ? ` [View progress](${workflowStatus.detailsUrl}).`
     : '';
@@ -158,11 +163,23 @@ async function findMenuComment(github, context, pullRequestNumber) {
   );
 }
 
-function buildWorkflowStatuses(checkRuns, statusOverrides) {
+function getActiveWorkflowStatusFromState(workflowState) {
+  if (workflowState?.statusText?.startsWith('Status: running.')) {
+    return {
+      statusText: workflowState.statusText,
+    };
+  }
+
+  return null;
+}
+
+function buildWorkflowStatuses(checkRuns, statusOverrides, existingState) {
   return Object.fromEntries(
     WORKFLOW_ORDER.map((key) => [
       key,
-      statusOverrides?.[key] || getWorkflowStatusFromCheckRuns(key, checkRuns),
+      statusOverrides?.[key] ||
+        getWorkflowStatusFromCheckRuns(key, checkRuns) ||
+        getActiveWorkflowStatusFromState(existingState?.[key]),
     ])
   );
 }
@@ -184,7 +201,7 @@ async function upsertMenuComment({
   }
 
   const existingState = parseMenuState(existingComment?.body || '');
-  const statuses = buildWorkflowStatuses(checkRuns, statusOverrides);
+  const statuses = buildWorkflowStatuses(checkRuns, statusOverrides, existingState);
   const body = buildMenuBody(existingState, statuses);
 
   if (existingComment) {


### PR DESCRIPTION
## Summary
- Preserves an existing `running` docs review status when a later PR menu refresh cannot find a non-skipped check run.
- Prevents the AI PR menu from reverting to `queued` while the issue-comment-triggered review workflow is still in progress.

## Test plan
- Ran `node --check .github/scripts/docs_pr_ai_menu.cjs`.
- Ran a focused Node check that parses and rebuilds a running docs PR menu status with its progress link.
- Checked IDE lints for `.github/scripts/docs_pr_ai_menu.cjs`.

Made with [Cursor](https://cursor.com)