### PR TITLE
Test Docs AI PR menu workflow

### DIFF
--- a/solutions/observability/synthetics/configure-settings.md
+++ b/solutions/observability/synthetics/configure-settings.md
@@ -132,3 +132,5 @@ Use the **Sync interval (minutes)** field to set the interval. The default is 5 
 When a maintenance window becomes active, a callout in the Synthetics UI displays the estimated delay for applying changes to private location monitors: *"It may take up to X minutes for maintenance window changes to be applied to private location monitors,"* where X equals the configured sync interval. Click **Sync now** in the callout to trigger an immediate sync without waiting for the interval.
 
 A separate callout appears when maintenance windows are modified or deleted but changes have not yet propagated to your private location monitors.
+
+<!-- Test change for the Docs AI PR menu workflow. -->


### PR DESCRIPTION
## Summary
- Adds a hidden Markdown comment as a minimal docs-only change.
- This PR is intended to test the Docs AI PR menu workflow after #6176.

## Test plan
- Checked the PR diff is limited to one Markdown file.
- Checked IDE lints; existing substitution warnings are present in the edited file, but the hidden comment does not introduce new warnings.

Made with [Cursor](https://cursor.com)