### PR TITLE
Simplify cross-link of fault detection to its troubleshooting

### DIFF
--- a/deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md
+++ b/deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md
@@ -21,33 +21,4 @@ Additionally, each node periodically verifies that its data path is healthy by w
 $$$cluster-fault-detection-cluster-state-publishing$$$
 The elected master node will also remove nodes from the cluster if nodes are unable to apply an updated cluster state within a reasonable time. The timeout defaults to 2 minutes starting from the beginning of the cluster state update. Refer to [Publishing the cluster state](cluster-state-overview.md#cluster-state-publishing) for a more detailed description.
 
-## Troubleshooting an unstable cluster [cluster-fault-detection-troubleshooting]
-
-See [*Troubleshooting an unstable cluster*](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md).
-
-
-#### Diagnosing `disconnected` nodes [_diagnosing_disconnected_nodes]
-
-See [Diagnosing `disconnected` nodes](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md#troubleshooting-unstable-cluster-disconnected).
-
-
-#### Diagnosing `lagging` nodes [_diagnosing_lagging_nodes]
-
-See [Diagnosing `lagging` nodes](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md#troubleshooting-unstable-cluster-lagging).
-
-
-#### Diagnosing `follower check retry count exceeded` nodes [_diagnosing_follower_check_retry_count_exceeded_nodes]
-
-See [Diagnosing `follower check retry count exceeded` nodes](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md#troubleshooting-unstable-cluster-follower-check).
-
-
-#### Diagnosing `ShardLockObtainFailedException` failures [_diagnosing_shardlockobtainfailedexception_failures]
-
-See [Diagnosing `ShardLockObtainFailedException` failures](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md#troubleshooting-unstable-cluster-shardlockobtainfailedexception).
-
-
-#### Diagnosing other network disconnections [_diagnosing_other_network_disconnections]
-
-See [Diagnosing other network disconnections](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md#troubleshooting-unstable-cluster-network).
-
-
+For more information, refer to [Troubleshooting an unstable cluster](/troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md).

--- a/deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md
+++ b/deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md
@@ -21,4 +21,4 @@ Additionally, each node periodically verifies that its data path is healthy by w
 $$$cluster-fault-detection-cluster-state-publishing$$$
 The elected master node will also remove nodes from the cluster if nodes are unable to apply an updated cluster state within a reasonable time. The timeout defaults to 2 minutes starting from the beginning of the cluster state update. Refer to [Publishing the cluster state](cluster-state-overview.md#cluster-state-publishing) for a more detailed description.
 
-For more information, refer to [Troubleshooting an unstable cluster](/troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md).
+For more information, refer to [Troubleshooting an unstable cluster](../../../troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md).

--- a/troubleshoot/elasticsearch/discovery-troubleshooting.md
+++ b/troubleshoot/elasticsearch/discovery-troubleshooting.md
@@ -66,7 +66,7 @@ If the logs suggest that the node cannot discover or join the cluster due to tim
 
 ## Node joins cluster and leaves again [discovery-node-leaves]
 
-If a node joins the cluster but {{es}} determines it to be faulty, it is removed from the cluster again. Refer to [Troubleshooting an unstable cluster](../../deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md#cluster-fault-detection-troubleshooting) for more information.
+If a node joins the cluster but {{es}} determines it to be faulty, it is removed from the cluster again. Refer to [Troubleshooting an unstable cluster](/troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md) for more information.
 
 
 ## Investigate timeout and network issues [investigate-timeout-and-network-issues]

--- a/troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md
+++ b/troubleshoot/elasticsearch/troubleshooting-unstable-cluster.md
@@ -174,7 +174,7 @@ cat shardlock.log | sed -e 's/.*://' | base64 --decode | gzip --decompress
 
 {{es}} is designed to run on a fairly reliable network. It opens a number of TCP connections between nodes and expects these transport connections to remain open [forever](elasticsearch://reference/elasticsearch/configuration-reference/networking-settings.md#long-lived-connections). If a transport connection is closed then {{es}} tries to reopen the connection, failing any in-flight operations that were using the connection at the time. Occasional closures of transport connections might be acceptable because they have a small impact on the cluster, but repeatedly-dropped transport connections severely affect its operations.
 
-{{es}} nodes only actively close an outbound transport connection to another node if the other node leaves the cluster. Refer to [Troubleshooting an unstable cluster](../../deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection.md#cluster-fault-detection-troubleshooting) for further information about identifying and troubleshooting this situation. If an outbound transport connection closes for some other reason, {{es}} logs messages such as the following:
+{{es}} nodes only actively close an outbound transport connection to another node if the other node leaves the cluster. If an outbound transport connection closes for some other reason, {{es}} logs messages such as the following:
 
 ```text
 [INFO ][o.e.t.ClusterConnectionManager] [node-1] transport connection to [{node-2}{g3cCUaMDQJmQ2ZLtjr-3dg}{10.0.0.1:9300}] closed by remote


### PR DESCRIPTION

## Summary
👋 Mini PR. 

[Cluster Fault Detection](https://www.elastic.co/docs/deploy-manage/distributed-architecture/discovery-cluster-formation/cluster-fault-detection) used to house the [Troubleshoot an Unstable Cluster](https://www.elastic.co/docs/troubleshoot/elasticsearch/troubleshooting-unstable-cluster#troubleshooting-unstable-cluster-network) sub content. 

I can't determine reason why we left one-for-one cross-sub-links under `docs-content` nor `elasticsearch` repos, so am looking to remove for more generic "for more info, refer ...".

<img width="744" height="585" alt="image" src="https://github.com/user-attachments/assets/5ee76e90-df4b-4de6-b023-052cd247296f" />

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [X] No  
