### PR TITLE
Add docs-quality-sweep workflow

### DIFF
--- a/.github/workflows/docs-quality-sweep.yml
+++ b/.github/workflows/docs-quality-sweep.yml
@@ -1,0 +1,122 @@
+name: Docs quality sweep
+on:
+  workflow_dispatch:
+    inputs:
+      sweeps:
+        description: "Sweeps to run (comma-separated): frontmatter,applies-to,openings,style,typos,staleness,coherence — or 'all'"
+        required: false
+        default: "all"
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory in the source repo (set to '.' for repos where docs live at the root)"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Approximate pages per rotating slice (Tier 2 sweeps)"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+      typos-codespell-args:
+        description: "Extra codespell flags for the typos sweep"
+        required: false
+        default: ""
+      staleness-content-months:
+        description: "Stale-content threshold (months) for the staleness sweep"
+        required: false
+        default: "24"
+      coherence-batch-size:
+        description: "Override target-batch-size for the coherence sweep (smaller because comparisons are expensive)"
+        required: false
+        default: "50"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  frontmatter:
+    if: contains(inputs.sweeps, 'frontmatter') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-frontmatter-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  applies-to:
+    if: contains(inputs.sweeps, 'applies-to') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-applies-to-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  openings:
+    if: contains(inputs.sweeps, 'openings') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-openings-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  style:
+    if: contains(inputs.sweeps, 'style') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-style-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  typos:
+    if: contains(inputs.sweeps, 'typos') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-typos-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+      codespell-args: ${{ inputs.typos-codespell-args }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  staleness:
+    if: contains(inputs.sweeps, 'staleness') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-staleness-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+      stale-content-months: ${{ inputs.staleness-content-months }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+
+  coherence:
+    if: contains(inputs.sweeps, 'coherence') || inputs.sweeps == 'all'
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-coherence-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.coherence-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Installs the seven-sweep orchestrator from [elastic/docs-actions@v1](https://github.com/elastic/docs-actions) (release [1.15.2](https://github.com/elastic/docs-actions/releases/tag/1.15.2)). Triggered manually via `workflow_dispatch`. Runs all seven sweeps in parallel by default, or any subset via the `sweeps` input.

```bash
gh workflow run docs-quality-sweep.yml -f sweeps=all
gh workflow run docs-quality-sweep.yml -f sweeps=frontmatter,typos
```

Seven jobs run in parallel; each opens its own labeled fix-issue in this repo (or `noop` if the slice is clean):

| Sweep | Label | Default behavior |
|-------|-------|------------------|
| `frontmatter` | `docs-fix:frontmatter` | Audits frontmatter completeness + description quality on a rotating slice |
| `applies-to` | `docs-fix:applies-to` | Validates `applies_to` correctness |
| `openings` | `docs-fix:openings` | Vague H1 / weak opening / missing prerequisites |
| `style` | `docs-fix:style` | Vale + Elastic style guide; includes tortured-sentence detection |
| `typos` | `docs-fix:typos` | codespell scan over the whole repo |
| `staleness` | `docs-fix:staleness` | Stale content / screenshots / broken external links / EOL versions |
| `coherence` | `docs-fix:coherence` | Duplicate / contradictory content vs. published docs |

All issues also carry the parent label `docs-quality-sweep`. Each sweep auto-closes its prior fix-issue (`close-older-issues: true`).

## Where the issues land

Issues from this install are filed **in this repo** (public). A companion install in [elastic/docs-content-internal#1136](https://github.com/elastic/docs-content-internal/pull/1136) runs the same sweeps against this repo's content but files its findings privately.

You'd typically use one or the other, not both — running both means each scan generates two parallel issues per finding. Possible setups:

- **Public-only** — keep this PR, drop the internal install. Easier for contributors to see + act on findings; nothing about the audit is hidden.
- **Internal-only** — close this PR, keep the internal install. Triage stays in the docs-content team's private repo.
- **Both, scoped differently** — public install runs only the safe-to-publish sweeps (`typos`, `staleness`); internal install runs the rest. Subset selectable via `sweeps` input on each side.

Worth deciding before merging.

## Pre-flight (already done)

- [x] All eight labels created in this repo (`docs-quality-sweep`, `docs-fix:frontmatter`, `docs-fix:applies-to`, `docs-fix:openings`, `docs-fix:style`, `docs-fix:typos`, `docs-fix:staleness`, `docs-fix:coherence`).
- [x] `COPILOT_GITHUB_TOKEN` already configured for existing agentic workflows (docs-issue-scope, docs-triage, docs-ai-menu).

## Known upstream blocker

The four sweeps that import skills from `elastic/elastic-docs-skills` (`frontmatter`, `applies-to`, `openings`, `style`) currently fail at the agent step's APM bundle unpack — see [github/gh-aw#30252](https://github.com/github/gh-aw/issues/30252) (open, no fix yet). Affects gh-aw's own CI as well; we've added our repro [in a comment there](https://github.com/github/gh-aw/issues/30252#issuecomment-4378100781).

The three deterministic / MCP-only sweeps (`typos`, `staleness`, `coherence`) work today. So this PR is mergeable now and immediately useful for those three; the four APM ones will start working once #30252 is fixed upstream and a new gh-aw release lands.

## Test plan

- [ ] Merge this PR.
- [ ] Dispatch with `sweeps=typos` first — full-repo codespell scan, fast feedback. Confirm a `docs-fix:typos` issue lands here (or `noop` if no findings).
- [ ] Dispatch with `sweeps=typos,staleness,coherence` — confirms the three working sweeps in parallel.
- [ ] Dispatch with `sweeps=all` after #30252 is fixed and a new gh-aw release advances `v1`. Confirm all seven sweeps land their fix-issues here.
- [ ] Once stable, decide whether to add a `schedule:` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)