### PR TITLE
docs-quality-sweep: replace `uses:` orchestrator with `gh workflow run` master

### DIFF
--- a/.github/workflows/docs-applies-to-sweep.yml
+++ b/.github/workflows/docs-applies-to-sweep.yml
@@ -1,0 +1,38 @@
+name: Docs applies_to sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-applies-to-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-coherence-sweep.yml
+++ b/.github/workflows/docs-coherence-sweep.yml
@@ -1,0 +1,38 @@
+name: Docs coherence sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Pages per rotating slice (smaller — coherence is expensive)"
+        required: false
+        default: "50"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-coherence-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-frontmatter-sweep.yml
+++ b/.github/workflows/docs-frontmatter-sweep.yml
@@ -1,0 +1,38 @@
+name: Docs frontmatter sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-frontmatter-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-openings-sweep.yml
+++ b/.github/workflows/docs-openings-sweep.yml
@@ -1,0 +1,38 @@
+name: Docs page openings sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-openings-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-quality-sweep.yml
+++ b/.github/workflows/docs-quality-sweep.yml
@@ -1,9 +1,19 @@
 name: Docs quality sweep
+# Master dispatcher. Fans out to seven independent sub-workflows via
+# `gh workflow run`. We can't use `workflow_call` here because gh-aw
+# v0.71.x compiles a single artifact prefix per orchestrator run
+# (github.workflow + github.run_id), which collides across reusable
+# workflow_call invocations and silently feeds every agent the same
+# prompt. Tracked upstream as github/gh-aw#30338. By dispatching each
+# sweep separately, every sub-run gets its own github.run_id and
+# github.workflow, so artifact names are unique and prompts don't
+# cross-contaminate.
+
 on:
   workflow_dispatch:
     inputs:
       sweeps:
-        description: "Sweeps to run (comma-separated): frontmatter,applies-to,openings,style,typos,staleness,coherence — or 'all'"
+        description: "Sweeps to dispatch (comma-separated): frontmatter,applies-to,openings,style,typos,staleness,coherence — or 'all'"
         required: false
         default: "all"
       source-repo:
@@ -31,92 +41,85 @@ on:
         required: false
         default: "24"
       coherence-batch-size:
-        description: "Override target-batch-size for the coherence sweep (smaller because comparisons are expensive)"
+        description: "Override target-batch-size for the coherence sweep"
         required: false
         default: "50"
 
 permissions:
-  actions: read
+  actions: write   # required to dispatch sibling workflows via `gh workflow run`
   contents: read
-  discussions: write
-  issues: write
-  pull-requests: read
 
 jobs:
-  frontmatter:
-    if: contains(inputs.sweeps, 'frontmatter') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-frontmatter-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      target-batch-size: ${{ inputs.target-batch-size }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+  fan-out:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch selected sweeps
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SWEEPS: ${{ inputs.sweeps }}
+          SRC: ${{ inputs.source-repo }}
+          ROOT: ${{ inputs.docs-root }}
+          BATCH: ${{ inputs.target-batch-size }}
+          MAX: ${{ inputs.max-per-fix-issue }}
+          TYPOS_ARGS: ${{ inputs.typos-codespell-args }}
+          STALE_MONTHS: ${{ inputs.staleness-content-months }}
+          COHER_BATCH: ${{ inputs.coherence-batch-size }}
+        run: |
+          set -e
+          want() { [[ "$SWEEPS" == "all" || "$SWEEPS" == *"$1"* ]]; }
 
-  applies-to:
-    if: contains(inputs.sweeps, 'applies-to') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-applies-to-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      target-batch-size: ${{ inputs.target-batch-size }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          fire_with_default_inputs() {
+            local name="$1"
+            want "$name" || { echo "  skip $name (not in sweeps='$SWEEPS')"; return; }
+            echo "→ dispatching docs-${name}-sweep.yml"
+            gh workflow run "docs-${name}-sweep.yml" \
+              -f source-repo="$SRC" \
+              -f docs-root="$ROOT" \
+              -f target-batch-size="$BATCH" \
+              -f max-per-fix-issue="$MAX"
+          }
 
-  openings:
-    if: contains(inputs.sweeps, 'openings') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-openings-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      target-batch-size: ${{ inputs.target-batch-size }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # frontmatter, applies-to, openings, style — same input shape
+          for n in frontmatter applies-to openings style; do
+            fire_with_default_inputs "$n"
+          done
 
-  style:
-    if: contains(inputs.sweeps, 'style') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-style-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      target-batch-size: ${{ inputs.target-batch-size }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # typos has its own input shape (no rotation, plus codespell-args)
+          if want typos; then
+            echo "→ dispatching docs-typos-sweep.yml"
+            gh workflow run docs-typos-sweep.yml \
+              -f source-repo="$SRC" \
+              -f docs-root="$ROOT" \
+              -f max-per-fix-issue="$MAX" \
+              -f codespell-args="$TYPOS_ARGS"
+          else
+            echo "  skip typos (not in sweeps='$SWEEPS')"
+          fi
 
-  typos:
-    if: contains(inputs.sweeps, 'typos') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-typos-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-      codespell-args: ${{ inputs.typos-codespell-args }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # staleness has its own thresholds
+          if want staleness; then
+            echo "→ dispatching docs-staleness-sweep.yml"
+            gh workflow run docs-staleness-sweep.yml \
+              -f source-repo="$SRC" \
+              -f docs-root="$ROOT" \
+              -f target-batch-size="$BATCH" \
+              -f max-per-fix-issue="$MAX" \
+              -f stale-content-months="$STALE_MONTHS"
+          else
+            echo "  skip staleness (not in sweeps='$SWEEPS')"
+          fi
 
-  staleness:
-    if: contains(inputs.sweeps, 'staleness') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-staleness-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      target-batch-size: ${{ inputs.target-batch-size }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-      stale-content-months: ${{ inputs.staleness-content-months }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # coherence overrides target-batch-size
+          if want coherence; then
+            echo "→ dispatching docs-coherence-sweep.yml"
+            gh workflow run docs-coherence-sweep.yml \
+              -f source-repo="$SRC" \
+              -f docs-root="$ROOT" \
+              -f target-batch-size="$COHER_BATCH" \
+              -f max-per-fix-issue="$MAX"
+          else
+            echo "  skip coherence (not in sweeps='$SWEEPS')"
+          fi
 
-  coherence:
-    if: contains(inputs.sweeps, 'coherence') || inputs.sweeps == 'all'
-    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-coherence-sweep.lock.yml@v1
-    with:
-      source-repo: ${{ inputs.source-repo }}
-      docs-root: ${{ inputs.docs-root }}
-      target-batch-size: ${{ inputs.coherence-batch-size }}
-      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          echo ""
+          echo "Each dispatched sweep runs as its own workflow run — see the Actions tab."

--- a/.github/workflows/docs-staleness-sweep.yml
+++ b/.github/workflows/docs-staleness-sweep.yml
@@ -1,0 +1,43 @@
+name: Docs staleness sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "30"
+      stale-content-months:
+        description: "Flag pages whose latest commit is older than this many months"
+        required: false
+        default: "24"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-staleness-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+      stale-content-months: ${{ inputs.stale-content-months }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-style-sweep.yml
+++ b/.github/workflows/docs-style-sweep.yml
@@ -1,0 +1,38 @@
+name: Docs style sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to sweep"
+        required: false
+        default: "."
+      target-batch-size:
+        description: "Approximate pages per rotating slice"
+        required: false
+        default: "100"
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue"
+        required: false
+        default: "20"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-style-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      target-batch-size: ${{ inputs.target-batch-size }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-typos-sweep.yml
+++ b/.github/workflows/docs-typos-sweep.yml
@@ -1,0 +1,38 @@
+name: Docs typos sweep
+on:
+  workflow_dispatch:
+    inputs:
+      source-repo:
+        description: "Repository to scan (owner/repo). Leave empty to scan this repo."
+        required: false
+        default: ""
+      docs-root:
+        description: "Root directory to scan"
+        required: false
+        default: "."
+      max-per-fix-issue:
+        description: "Cap on findings per fix-issue (ignored — typos sweep emits all findings up to issue body limit)"
+        required: false
+        default: "20"
+      codespell-args:
+        description: "Extra codespell flags (e.g., --ignore-words=allowlist.txt --skip='*.svg')"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  run:
+    uses: elastic/docs-actions/.github/workflows/gh-aw-docs-typos-sweep.lock.yml@v1
+    with:
+      source-repo: ${{ inputs.source-repo }}
+      docs-root: ${{ inputs.docs-root }}
+      max-per-fix-issue: ${{ inputs.max-per-fix-issue }}
+      codespell-args: ${{ inputs.codespell-args }}
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Refactors the docs-quality-sweep installation to work around [github/gh-aw#30338](https://github.com/github/gh-aw/issues/30338).

The current orchestrator (merged via #6255) uses `workflow_call` to fan out to seven gh-aw reusable workflows in parallel. gh-aw v0.71.x derives a single artifact prefix per orchestrator run from `github.workflow + github.run_id`, both of which are identical for every reusable workflow_call invocation in one run. Result: all seven sub-workflows upload and download the **same** `<prefix>-activation.zip` and `<prefix>-agent.zip`. Last activation wins the race; every agent loads the same prompt. Three of the seven fix-issues from the first run came back with frontmatter-audit findings regardless of which sweep was supposed to run (#6266 / #6267 / #6268).

Until upstream lands a fix, this PR dispatches each sweep as its own independent workflow run.

## New layout

| File | Role |
|---|---|
| `docs-quality-sweep.yml` (modified) | Master dispatcher. Triggers on `workflow_dispatch`. One job that uses `gh workflow run` to fire each selected sub-workflow. Exits in seconds. |
| `docs-frontmatter-sweep.yml` (new) | Calls `elastic/docs-actions/.github/workflows/gh-aw-docs-frontmatter-sweep.lock.yml@v1`. |
| `docs-applies-to-sweep.yml` (new) | Calls the applies-to reusable. |
| `docs-openings-sweep.yml` (new) | Calls the openings reusable. |
| `docs-style-sweep.yml` (new) | Calls the style reusable. |
| `docs-typos-sweep.yml` (new) | Calls the typos reusable. |
| `docs-staleness-sweep.yml` (new) | Calls the staleness reusable. |
| `docs-coherence-sweep.yml` (new) | Calls the coherence reusable. |

Each sub-workflow has its own \`github.workflow\` and its own \`github.run_id\`, so the artifact prefix gh-aw computes is now distinct per sweep — no collision.

## UX

`gh workflow run docs-quality-sweep.yml -f sweeps=all` still works as the single dispatch point. The master prints \`→ dispatching docs-<name>-sweep.yml\` for each selected sweep and exits in a few seconds; the sub-runs appear separately in the Actions tab.

Selective dispatch still works via the \`sweeps\` input:

\`\`\`bash
gh workflow run docs-quality-sweep.yml -f sweeps=frontmatter,typos
\`\`\`

Sub-workflows can also be dispatched directly without going through the master, e.g. for retrying just one sweep:

\`\`\`bash
gh workflow run docs-style-sweep.yml
\`\`\`

That wasn't possible with the previous \`workflow_call\` orchestrator.

## Why \`GITHUB_TOKEN\` is enough

\`workflow_dispatch\` and \`repository_dispatch\` are explicit exceptions to the "GITHUB_TOKEN can't trigger workflows" rule (per the GitHub Actions docs). The master uses the auto-provided token; no PAT or App token needed. The master itself only needs \`actions: write\`; the sub-workflows retain \`actions: read\` + \`issues: write\` for fix-issue creation.

## Trade-offs vs. the old orchestrator

| | old (\`uses:\`) | new (\`gh workflow run\`) |
|---|---|---|
| Single dispatch point | ✓ | ✓ |
| Artifact-name isolation | ❌ collides (gh-aw#30338) | ✓ each sub-run independent |
| Visible as one workflow run | ✓ | master + 7 separate sub-runs |
| Per-sweep retry without re-running everything | ❌ | ✓ |
| \`sweeps=…\` filter | ✓ | ✓ |
| Number of files in this repo | 1 | 8 |

The 8-file footprint is the only real regression and it's bounded — they're trigger templates, not maintained logic.

## Test plan

- [ ] Merge this PR.
- [ ] Dispatch \`docs-quality-sweep.yml\` with \`sweeps=typos\` (cheapest, no APM). Confirm the master run finishes in under a minute and a separate \`Docs typos sweep\` run appears in the Actions tab.
- [ ] Confirm the new typos issue lands here (no longer capped at 20 — should reflect ~all codespell findings once docs-actions PR #132 ships).
- [ ] Dispatch with \`sweeps=frontmatter,style\`. Confirm two separate sub-runs appear, each with distinct artifact names (\`<unique-prefix-A>-activation.zip\` for frontmatter, \`<unique-prefix-B>-activation.zip\` for style — verify in the agent step logs).
- [ ] Confirm the resulting two fix-issues have **distinct** content — frontmatter findings in the frontmatter issue, style findings in the style issue. This is the regression we're trying to fix.
- [ ] Once happy, dispatch with \`sweeps=all\` and confirm seven sub-runs each produce a category-correct fix-issue.

## Related

- gh-aw issue: [github/gh-aw#30338](https://github.com/github/gh-aw/issues/30338)
- docs-actions PR adding the underlying sweep prompts: [elastic/docs-actions#132](https://github.com/elastic/docs-actions/pull/132) (open) — improves the per-sweep output once the agent prompts are no longer cross-contaminating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)