### PR TITLE
docs-quality-sweep master: pass `--repo` to `gh workflow run`

### DIFF
--- a/.github/workflows/docs-quality-sweep.yml
+++ b/.github/workflows/docs-quality-sweep.yml
@@ -72,7 +72,7 @@ jobs:
             local name="$1"
             want "$name" || { echo "  skip $name (not in sweeps='$SWEEPS')"; return; }
             echo "→ dispatching docs-${name}-sweep.yml"
-            gh workflow run "docs-${name}-sweep.yml" \
+            gh workflow run "docs-${name}-sweep.yml" --repo "${{ github.repository }}" \
               -f source-repo="$SRC" \
               -f docs-root="$ROOT" \
               -f target-batch-size="$BATCH" \
@@ -87,7 +87,7 @@ jobs:
           # typos has its own input shape (no rotation, plus codespell-args)
           if want typos; then
             echo "→ dispatching docs-typos-sweep.yml"
-            gh workflow run docs-typos-sweep.yml \
+            gh workflow run docs-typos-sweep.yml --repo "${{ github.repository }}" \
               -f source-repo="$SRC" \
               -f docs-root="$ROOT" \
               -f max-per-fix-issue="$MAX" \
@@ -99,7 +99,7 @@ jobs:
           # staleness has its own thresholds
           if want staleness; then
             echo "→ dispatching docs-staleness-sweep.yml"
-            gh workflow run docs-staleness-sweep.yml \
+            gh workflow run docs-staleness-sweep.yml --repo "${{ github.repository }}" \
               -f source-repo="$SRC" \
               -f docs-root="$ROOT" \
               -f target-batch-size="$BATCH" \
@@ -112,7 +112,7 @@ jobs:
           # coherence overrides target-batch-size
           if want coherence; then
             echo "→ dispatching docs-coherence-sweep.yml"
-            gh workflow run docs-coherence-sweep.yml \
+            gh workflow run docs-coherence-sweep.yml --repo "${{ github.repository }}" \
               -f source-repo="$SRC" \
               -f docs-root="$ROOT" \
               -f target-batch-size="$COHER_BATCH" \


### PR DESCRIPTION
## Summary

The master dispatcher introduced in #6271 fails on the first `gh workflow run` invocation:

\`\`\`
→ dispatching docs-frontmatter-sweep.yml
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
\`\`\`

Failing run: https://github.com/elastic/docs-content/actions/runs/25373495676/job/74402614432

## Cause

`gh workflow run` resolves the target repository from the local git remote when no `--repo` flag is given. The master skips `actions/checkout` deliberately — it's a thin dispatcher that doesn't need the source tree — so there's no `.git` directory and the command exits 1 before doing anything.

## Fix

Add `--repo "${{ github.repository }}"` to all four `gh workflow run` invocations (the `fire_with_default_inputs` helper plus the typos / staleness / coherence blocks). The runtime expression `${{ github.repository }}` resolves to `elastic/docs-content`, so gh CLI skips the local-remote inference entirely.

Same effect as adding `actions/checkout@v6` to the step but cheaper — no clone, no filesystem I/O for what's a sub-second dispatch script.

## Test plan

- [ ] Merge.
- [ ] Dispatch `docs-quality-sweep.yml` with `sweeps=typos`. Expect:
  - master finishes in seconds with `→ dispatching docs-typos-sweep.yml` printed (no "fatal: not a git repository");
  - a separate `Docs typos sweep` run appears in the Actions tab.
- [ ] Dispatch with `sweeps=all`. Expect seven sub-runs in the Actions tab, each independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)