### PR TITLE
Adds note about Jina model deployment limitations

### DIFF
--- a/explore-analyze/machine-learning/nlp/ml-nlp-jina.md
+++ b/explore-analyze/machine-learning/nlp/ml-nlp-jina.md
@@ -12,7 +12,7 @@ products:
 This page collects all Jina models you can use as part of the {{stack}}.
 
 :::{note}
-Jina models are currently available only through [Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) and are not supported for deployment on [{{ml}} nodes](/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#ml-node-role). Using these models requires connectivity to EIS and is therefore not compatible with fully air-gapped environments.
+Jina models are currently available only through [Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) and are not supported for deployment on [{{ml}} nodes](/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#ml-node-role). Using these models requires connectivity to EIS and is therefore not currently compatible with fully air-gapped environments.
 :::
 
 Currently, the following models are available as built-in models:

--- a/explore-analyze/machine-learning/nlp/ml-nlp-jina.md
+++ b/explore-analyze/machine-learning/nlp/ml-nlp-jina.md
@@ -10,6 +10,11 @@ products:
 # Jina models [ml-nlp-jina]
 
 This page collects all Jina models you can use as part of the {{stack}}.
+
+:::{note}
+Jina models are currently available only through [Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) and are not supported for deployment on [{{ml}} nodes](/deploy-manage/distributed-architecture/clusters-nodes-shards/node-roles.md#ml-node-role). Using these models requires connectivity to EIS and is therefore not compatible with fully air-gapped environments.
+:::
+
 Currently, the following models are available as built-in models:
 
 **Embedding models**


### PR DESCRIPTION
This PR adds a note clarifying that Jina models are currently available only through Elastic Inference Service (EIS) and are not supported for deployment on Elasticsearch ML nodes.

Related issue: https://github.com/elastic/docs-content/issues/6312
Related PR: https://github.com/elastic/elasticsearch/pull/148395