### PR TITLE
[agent builder] refresh get started

### DIFF
--- a/explore-analyze/ai-features/agent-builder/get-started.md
+++ b/explore-analyze/ai-features/agent-builder/get-started.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Get started"
-description: "Learn how to access Elastic Agent Builder, ingest data, and start chatting with AI agents."
+description: "Learn how to access Elastic Agent Builder, ingest data, and build skills for AI agents."
 applies_to:
   stack: preview =9.2, ga 9.3+
   serverless: ga
@@ -21,10 +21,6 @@ If you don't already have an Elastic deployment, you can start a [free trial](ht
 ::::{admonition}
 This feature requires the appropriate {{stack}} [subscription](https://www.elastic.co/pricing) or {{serverless-short}} [project feature tier](/deploy-manage/deploy/elastic-cloud/project-settings.md).
 ::::
-
-:::{note}
-For model choice, refer to [Model configuration](models.md) and [Configure access to LLMs](/explore-analyze/ai-features/llm-guides/llm-connectors.md).
-:::
 
 :::::::{stepper}
 ::::::{step} Access {{agent-builder}}
@@ -140,33 +136,30 @@ If you already have data, you can:
 
 The **Agent Chat** UI provides a conversational interface where you can interact with agents and explore your data using natural language. The default `Elastic AI Agent` is ready to use immediately.
 
+Use chat to ask questions, request data analysis, try [built-in skills](builtin-skills-reference.md), or [create dashboards and visualizations](agent-builder-dashboards-and-visualizations.md). You can also invoke a specific skill with a slash command, inspect the agent's reasoning and tool calls, and confirm any proposed write actions before changes are applied.
+
 Learn more in [Agent Chat](chat.md).
 
 ::::
 
 ::::{step} Configure model (optional)
 
-On {{ech}} and {{serverless-full}}, {{agent-builder}} comes with preconfigured models ready to use. To switch models or add your own, refer to [model selection and configuration](models.md).
+On {{ech}} and {{serverless-full}}, {{agent-builder}} comes with preconfigured models ready to use. To review recommended models, switch models, or add your own, refer to [model selection and configuration](models.md).
 
 ::::
 
-::::{step} Enable Elastic capabilities (optional)
-```{applies_to}
-stack: ga 9.4+
-```
+::::{step} Build skills, tools, and agents
 
-When you [create a custom agent](custom-agents.md#create-a-new-agent), use the **Enable Elastic Capabilities** toggle on the **Settings** tab to opt in to Elastic-built tools, skills, and plugins. The toggle is off by default, so the agent only uses capabilities you assign unless you turn it on.
+After you test the default `Elastic AI Agent`, create a [custom skill](custom-skills.md) for a specific workflow. Skills package task-specific instructions, context, and the tools needed to complete the workflow.
 
-For details, refer to [Enable Elastic Capabilities](custom-agents.md#enable-elastic-capabilities).
+Add [tools](tools.md) when the skill needs to retrieve data, run queries, call APIs, or take action. Create a [custom agent](custom-agents.md#create-a-new-agent) when you need a distinct persona, system prompt, model configuration, or set of enabled skills. You don't need a separate agent for every workflow: a single agent can use skill descriptions to choose the right skills and tools for the user's request.
 
-::::
-
-::::{step} Begin building agents and tools
-
-Once you've tested [built-in agents](builtin-agents-reference.md) with [built-in Elastic tools](tools.md), you can begin [building your own agents](custom-agents.md#create-a-new-agent) with custom instructions and [creating your own tools](tools/custom-tools.md#create-custom-tools-in-the-ui) to assign them. You can also clone the default `Elastic AI Agent` as a starting point for a custom agent.
-
-To build agents and tools programmatically, try the [{{agent-builder}} API tutorial](agent-builder-api-tutorial.md) or explore the [Kibana APIs](programmatic-access.md).
+To build programmatically, try the [{{agent-builder}} API tutorial](agent-builder-api-tutorial.md) or explore the [Kibana APIs](programmatic-access.md).
 
 ::::
 
 :::::::
+
+:::{tip}
+For solution-specific guidance, refer to [Agent Builder for {{observability}}](/solutions/observability/ai/agent-builder-observability.md) and [Agent Builder for {{elastic-sec}}](/solutions/security/ai/agent-builder/agent-builder.md).
+:::


### PR DESCRIPTION
Refresh the Agent Builder get-started flow so it better matches the current skills-oriented experience. The page now gives readers a clearer path from first chat to building reusable skills, while preserving links to deeper model, chat, and solution-specific guidance.

- remove elastic capabilities step
- clarify chat and model setup
- reframe building around skills, tools, and agents
- link solution-specific guidance

## https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/6327/explore-analyze/ai-features/agent-builder/get-started