### PR TITLE
docs: document the dashboard 48-column grid (#5449)

### DIFF
--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -17,7 +17,7 @@ Customize your dashboard layout by arranging panels into logical groups and adju
 
 To organize dashboard panels, you need the **All** privilege for the **Dashboard** feature in {{product.kibana}}.
 
-## Dashboard grid layout [dashboard-grid-layout]
+## Dashboard grid layout and best practices [dashboard-grid-layout]
 
 Dashboards use a 48-column grid with rows of fixed height. When you move or resize a panel, it snaps to column and row boundaries on this grid. New panels are created at half width (24 columns) by default.
 
@@ -31,9 +31,8 @@ Use these reference widths to keep panels aligned across a row:
 | Quarter     | 12      |
 | Sixth       | 8       |
 
-### Best practices [arrange-panels-best-practices]
 
-A few habits keep dashboards scannable and consistent as you add panels:
+Consider the following best practices to keep dashboards scannable as you add panels:
 
 * **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
 * **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -40,8 +40,6 @@ A few habits keep dashboards scannable and consistent as you add panels:
 * **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row. Use the column reference widths above to keep panels aligned.
 * **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
 
-For best practices on overall dashboard layout and information hierarchy, refer to [Best practices for dashboard design](create-dashboard.md#create-dashboard-best-practices).
-
 ## Arrange panels in collapsible sections [collapsible-sections]
 ```{applies_to}
 stack: ga 9.1

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -31,6 +31,17 @@ Use these reference widths to keep panels aligned across a row:
 | Quarter     | 12      |
 | Sixth       | 8       |
 
+### Best practices [arrange-panels-best-practices]
+
+A few habits keep dashboards scannable and consistent as you add panels:
+
+* **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
+* **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
+* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row. Use the column reference widths above to keep panels aligned.
+* **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
+
+For best practices on overall dashboard layout and information hierarchy, refer to [Best practices for dashboard design](create-dashboard.md#create-dashboard-best-practices).
+
 ## Arrange panels in collapsible sections [collapsible-sections]
 ```{applies_to}
 stack: ga 9.1

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -34,7 +34,7 @@ Use these reference widths to keep panels aligned across a row:
 
 Consider the following best practices to keep dashboards scannable as you add panels:
 
-* **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
+* **Match panel shape to the chart.** Single-value metrics and KPIs work in compact panels of any shape. Time series, bar charts with many categories, and tables need horizontal room so axes and columns are not cramped. Pie and donut charts read best in roughly square panels.
 * **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
 * **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row. Use the column reference widths above to keep panels aligned.
 * **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -54,12 +54,26 @@ Compare the data in your panels side-by-side, organize panels by priority, resiz
 In the application menu, click **Edit**, then use the following options:
 
 * To move, hover over the panel, click and hold ![The move control icon](/explore-analyze/images/kibana-move-control.png "The move control icon =4%x4%") and drag to the new location. Your screen scrolls automatically when you drag above or below the visible parts of the dashboard.
-* To resize, click and hold the bottom right corner of the panel and drag to the new dimensions.
+* To resize, click and hold the bottom right corner of the panel and drag to the new dimensions. Panels snap to a [48-column grid](#dashboard-grid-layout).
 * To maximize to full screen, open the panel menu and click **Maximize**.
 
   ::::{tip}
   If you [share](sharing.md) a dashboard while viewing a full screen panel, the generated link will directly open the same panel in full screen mode.
   ::::
+
+### Dashboard grid layout [dashboard-grid-layout]
+
+Dashboards use a 48-column grid with rows of fixed height. When you move or resize a panel, it snaps to column and row boundaries on this grid. New panels are created at half width (24 columns) by default.
+
+Use these reference widths to keep panels aligned across a row:
+
+| Panel width | Columns |
+| ----------- | ------- |
+| Full        | 48      |
+| Half        | 24      |
+| Third       | 16      |
+| Quarter     | 12      |
+| Sixth       | 8       |
 
 ### Move and resize panels using a keyboard
 ```{applies_to}

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -17,6 +17,20 @@ Customize your dashboard layout by arranging panels into logical groups and adju
 
 To organize dashboard panels, you need the **All** privilege for the **Dashboard** feature in {{product.kibana}}.
 
+## Dashboard grid layout [dashboard-grid-layout]
+
+Dashboards use a 48-column grid with rows of fixed height. When you move or resize a panel, it snaps to column and row boundaries on this grid. New panels are created at half width (24 columns) by default.
+
+Use these reference widths to keep panels aligned across a row:
+
+| Panel width | Columns |
+| ----------- | ------- |
+| Full        | 48      |
+| Half        | 24      |
+| Third       | 16      |
+| Quarter     | 12      |
+| Sixth       | 8       |
+
 ## Arrange panels in collapsible sections [collapsible-sections]
 ```{applies_to}
 stack: ga 9.1
@@ -60,20 +74,6 @@ In the application menu, click **Edit**, then use the following options:
   ::::{tip}
   If you [share](sharing.md) a dashboard while viewing a full screen panel, the generated link will directly open the same panel in full screen mode.
   ::::
-
-### Dashboard grid layout [dashboard-grid-layout]
-
-Dashboards use a 48-column grid with rows of fixed height. When you move or resize a panel, it snaps to column and row boundaries on this grid. New panels are created at half width (24 columns) by default.
-
-Use these reference widths to keep panels aligned across a row:
-
-| Panel width | Columns |
-| ----------- | ------- |
-| Full        | 48      |
-| Half        | 24      |
-| Third       | 16      |
-| Quarter     | 12      |
-| Sixth       | 8       |
 
 ### Move and resize panels using a keyboard
 ```{applies_to}


### PR DESCRIPTION
## Summary

This PR addresses #5449 in full and contributes the panel-sizing/arranging portion of #5445.

Changes to `explore-analyze/dashboards/arrange-panels.md`:

- New top-level **Dashboard grid layout and best practices** section, placed right after **Requirements** so readers see it before any of the arrange/move/resize sections. It documents:
  - The 48-column grid and snap behavior, plus the default new-panel width (half / 24 columns).
  - A reference table of common widths (Full / Half / Third / Quarter / Sixth).
  - A short set of best practices for sizing and arranging panels: matching panel height to content type, keeping heights consistent within a row, using width to signal importance, and separating primary from secondary content with collapsible sections.
- Updates the resize bullet under **Move and resize panels** to point readers to the new section, so the snap behavior is discoverable from the procedure.

The best practices bullets were originally drafted in #6330 and moved here so all panel-sizing and arranging guidance lives next to the grid mechanics it depends on.

Verified against `elastic/kibana` source:
- `DASHBOARD_GRID_COLUMN_COUNT = 48` (`src/platform/plugins/shared/dashboard/common/page_bundle_constants.ts`)
- `DEFAULT_PANEL_WIDTH = DASHBOARD_GRID_COLUMN_COUNT / 2` = 24 (`src/platform/plugins/shared/dashboard/common/constants.ts`)

The 48-column grid is long-standing and not version-scoped, so no `applies_to` is added.

## Resolves

- Closes #5449
- Partially addresses #5445 (the panel-sizing/arranging guidance for **Organize dashboard panels**). The remaining design guidance for `create-dashboard.md`, `lens.md`, and `text-panels.md` is in #6330.

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.