### PR TITLE
docs: add dashboard design best practices to existing pages (#5445)

### DIFF
--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -107,13 +107,13 @@ Copy panels from one dashboard to another dashboard.
 
     ![Copy a panel to another dashboard](https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt48304cb3cd1ee2e6/6753879eb7c4663812148d47/copy-to-dashboard-8.17.0.gif "")
 
-## Best practices for arranging panels [arrange-panels-best-practices]
+## Best practices [arrange-panels-best-practices]
 
 A few habits keep dashboards scannable and consistent as you add panels:
 
 * **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
 * **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
-* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row.
+* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row. For column reference widths, refer to [Dashboard grid layout](#dashboard-grid-layout).
 * **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
 
 For best practices on overall dashboard layout and information hierarchy, refer to [Best practices for dashboard design](create-dashboard.md#create-dashboard-best-practices).

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -61,15 +61,6 @@ In the application menu, click **Edit**, then use the following options:
   If you [share](sharing.md) a dashboard while viewing a full screen panel, the generated link will directly open the same panel in full screen mode.
   ::::
 
-### Tips for sizing panels [sizing-panels-tips]
-
-A few habits keep dashboards scannable and consistent as you add panels:
-
-* **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
-* **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
-* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row.
-* **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
-
 ### Move and resize panels using a keyboard
 ```{applies_to}
 stack: ga 9.1
@@ -115,6 +106,17 @@ Copy panels from one dashboard to another dashboard.
 2. On the **Copy to dashboard** window, select the dashboard, then click **Copy and go to dashboard**.
 
     ![Copy a panel to another dashboard](https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt48304cb3cd1ee2e6/6753879eb7c4663812148d47/copy-to-dashboard-8.17.0.gif "")
+
+## Best practices for arranging panels [arrange-panels-best-practices]
+
+A few habits keep dashboards scannable and consistent as you add panels:
+
+* **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
+* **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
+* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row.
+* **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
+
+For best practices on overall dashboard layout and information hierarchy, refer to [Best practices for dashboard design](create-dashboard.md#create-dashboard-best-practices).
 
 
 

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -107,16 +107,5 @@ Copy panels from one dashboard to another dashboard.
 
     ![Copy a panel to another dashboard](https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt48304cb3cd1ee2e6/6753879eb7c4663812148d47/copy-to-dashboard-8.17.0.gif "")
 
-## Best practices [arrange-panels-best-practices]
-
-A few habits keep dashboards scannable and consistent as you add panels:
-
-* **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
-* **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
-* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row. For column reference widths, refer to [Dashboard grid layout](#dashboard-grid-layout).
-* **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
-
-For best practices on overall dashboard layout and information hierarchy, refer to [Best practices for dashboard design](create-dashboard.md#create-dashboard-best-practices).
-
 
 

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -61,6 +61,15 @@ In the application menu, click **Edit**, then use the following options:
   If you [share](sharing.md) a dashboard while viewing a full screen panel, the generated link will directly open the same panel in full screen mode.
   ::::
 
+### Tips for sizing panels [sizing-panels-tips]
+
+A few habits keep dashboards scannable and consistent as you add panels:
+
+* **Match panel height to content type.** Single-value metrics and KPIs read well in short, compact panels. Time series, breakdowns, and tables benefit from more vertical space so trends and rows are not cramped.
+* **Keep heights consistent within a row.** When several panels sit side by side, use the same height for all of them. Mismatched heights leave awkward gaps and make the row harder to read.
+* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row.
+* **Separate primary from secondary content with collapsible sections.** When a dashboard accumulates supporting panels and detail tables, place them inside a [collapsible section](#collapsible-sections) so the primary view stays focused and the dashboard loads faster.
+
 ### Move and resize panels using a keyboard
 ```{applies_to}
 stack: ga 9.1

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -41,8 +41,16 @@ Before creating a dashboard, ensure you have:
     * [**Add annotations or navigation panels**](../visualize.md#panels-editors). Make your dashboard more informative and easier to read with sections, text, and images.
     * [**Add controls**](add-controls.md). Define a set of interactive filters (options lists, range or time sliders) that you and future users of this dashboard can use to explore its data.
 
-4. Organize your dashboard by [organizing the various panels](arrange-panels.md).
-5. Define the main settings of your dashboard from the **Settings** menu in the application menu.
+4. Plan your dashboard's information hierarchy. A scannable dashboard answers a question at a glance, then lets the reader drill in. As a starting point:
+
+    * Place primary KPIs and key metrics at the top, where viewers see them first.
+    * Put time series and breakdowns in the middle to show trends and distributions.
+    * Place detailed tables and supporting panels at the bottom for users who want to dig deeper.
+
+    Aim to keep the most important content visible without scrolling, and group related panels together so each row tells a coherent story.
+
+5. Organize your dashboard by [organizing the various panels](arrange-panels.md).
+6. Define the main settings of your dashboard from the **Settings** menu in the application menu.
 
     1. A meaningful title, description, and [tags](../find-and-organize/tags.md) allow you to find the dashboard quickly later when browsing your list of dashboards or using the {{kib}} search bar.
     2. Additional display options allow you unify the look and feel of the dashboard’s panels:
@@ -60,7 +68,7 @@ Before creating a dashboard, ensure you have:
        
 
 
-6. Save the dashboard. When saving, you can configure the following options:
+7. Save the dashboard. When saving, you can configure the following options:
 
     - **Title** and **Description**: Give the dashboard a meaningful name and description so you and others can find it later.
     - **Tags**: Add [tags](../find-and-organize/tags.md) to organize and categorize the dashboard.

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -37,7 +37,7 @@ Before you start adding panels, plan your dashboard's information hierarchy. A s
 
 Aim to keep the most important content visible without scrolling, and group related panels together so each row tells a coherent story.
 
-For best practices on sizing and arranging individual panels, refer to [Best practices for arranging panels](arrange-panels.md#arrange-panels-best-practices).
+For best practices on sizing and arranging individual panels, refer to [Dashboard grid layout and best practices](arrange-panels.md#dashboard-grid-layout).
 
 ## Create a new dashboard [create-dashboard-steps]
 

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -27,6 +27,18 @@ Before creating a dashboard, ensure you have:
 * [Data indexed into {{product.elasticsearch}}](/manage-data/ingest.md) and at least one [data view](../find-and-organize/data-views.md) configured
 * **All** privilege for the **Dashboard** feature in {{product.kibana}}
 
+## Best practices [create-dashboard-best-practices]
+
+Before you start adding panels, plan your dashboard's information hierarchy. A scannable dashboard answers a question at a glance, then lets the reader drill in. As a starting point:
+
+* Place primary KPIs and key metrics at the top, where viewers see them first.
+* Put time series and breakdowns in the middle to show trends and distributions.
+* Place detailed tables and supporting panels at the bottom for users who want to dig deeper.
+
+Aim to keep the most important content visible without scrolling, and group related panels together so each row tells a coherent story.
+
+For best practices on sizing and arranging individual panels, refer to [Best practices for arranging panels](arrange-panels.md#arrange-panels-best-practices).
+
 ## Create a new dashboard [create-dashboard-steps]
 
 1. Open the **Dashboards** page in {{product.kibana}}.
@@ -41,16 +53,8 @@ Before creating a dashboard, ensure you have:
     * [**Add annotations or navigation panels**](../visualize.md#panels-editors). Make your dashboard more informative and easier to read with sections, text, and images.
     * [**Add controls**](add-controls.md). Define a set of interactive filters (options lists, range or time sliders) that you and future users of this dashboard can use to explore its data.
 
-4. Plan your dashboard's information hierarchy. A scannable dashboard answers a question at a glance, then lets the reader drill in. As a starting point:
-
-    * Place primary KPIs and key metrics at the top, where viewers see them first.
-    * Put time series and breakdowns in the middle to show trends and distributions.
-    * Place detailed tables and supporting panels at the bottom for users who want to dig deeper.
-
-    Aim to keep the most important content visible without scrolling, and group related panels together so each row tells a coherent story.
-
-5. Organize your dashboard by [organizing the various panels](arrange-panels.md).
-6. Define the main settings of your dashboard from the **Settings** menu in the application menu.
+4. Organize your dashboard by [organizing the various panels](arrange-panels.md).
+5. Define the main settings of your dashboard from the **Settings** menu in the application menu.
 
     1. A meaningful title, description, and [tags](../find-and-organize/tags.md) allow you to find the dashboard quickly later when browsing your list of dashboards or using the {{kib}} search bar.
     2. Additional display options allow you unify the look and feel of the dashboard’s panels:
@@ -68,7 +72,7 @@ Before creating a dashboard, ensure you have:
        
 
 
-7. Save the dashboard. When saving, you can configure the following options:
+6. Save the dashboard. When saving, you can configure the following options:
 
     - **Title** and **Description**: Give the dashboard a meaningful name and description so you and others can find it later.
     - **Tags**: Add [tags](../find-and-organize/tags.md) to organize and categorize the dashboard.

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -45,6 +45,13 @@ With Lens, you can create the following visualization types:
 | [Tag cloud](/explore-analyze/visualize/charts/tag-cloud-charts.md) | Highlight the most frequent or important terms in a dataset. |
 | [Region map](/explore-analyze/visualize/charts/region-map-charts.md) | Show how values vary across geographic regions (choropleth). |
 
+### Tips for clear visualizations [lens-clarity-tips]
+
+A few small choices make Lens charts much easier to read on a dashboard:
+
+* **Write panel titles that describe the insight, not the field.** Prefer **Requests by response code** or **Slowest hosts (last 24h)** over **count of records** or **host.keyword**. The title should answer the question the chart is meant to answer.
+* **Hide axis titles when the panel title is self-explanatory.** A descriptive panel title makes axis titles redundant and reclaims vertical space for the data. To hide an axis title, open the corresponding **Left axis**, **Bottom axis**, or **Right axis** menu in the editor toolbar and set **Axis title** to **None**.
+
 ## Create visualizations [create-the-visualization-panel]
 
 If you’re unsure about the visualization type you want to use, or how you want to display the data, drag the fields you want to visualize onto the workspace, then let **Lens** choose for you.

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -45,7 +45,7 @@ With Lens, you can create the following visualization types:
 | [Tag cloud](/explore-analyze/visualize/charts/tag-cloud-charts.md) | Highlight the most frequent or important terms in a dataset. |
 | [Region map](/explore-analyze/visualize/charts/region-map-charts.md) | Show how values vary across geographic regions (choropleth). |
 
-### Tips for clear visualizations [lens-clarity-tips]
+## Best practices [lens-best-practices]
 
 A few small choices make Lens charts much easier to read on a dashboard:
 

--- a/explore-analyze/visualize/text-panels.md
+++ b/explore-analyze/visualize/text-panels.md
@@ -14,9 +14,16 @@ To provide context to your dashboard panels, add **Text** panels that display im
 
 {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` You can also save a Markdown panel to the **Visualize Library** to reuse it across multiple dashboards. For details, refer to [Save and reuse Markdown panels across dashboards](#markdown-library-reuse).
 
-:::{tip}
-**Text** panels work best for context, descriptions, instructions, links to related resources, or images. For section headers and dividers, prefer [collapsible sections](/explore-analyze/dashboards/arrange-panels.md#collapsible-sections) and descriptive chart titles, which give readers structure without taking up grid space the data could use.
-:::
+## Best practices [text-panels-best-practices]
+
+**Text** panels work best for content that helps readers interpret the rest of the dashboard, such as:
+
+* Short introductions or descriptions that explain what the dashboard shows and who it's for.
+* Instructions or notes that guide viewers through the data.
+* Links to related dashboards, runbooks, or documentation.
+* Images and logos.
+
+For section headers and dividers, prefer [collapsible sections](/explore-analyze/dashboards/arrange-panels.md#collapsible-sections) and descriptive chart titles, which give readers structure without taking up grid space the data could use.
 
 ## Create a Markdown panel [create-markdown-panel]
 

--- a/explore-analyze/visualize/text-panels.md
+++ b/explore-analyze/visualize/text-panels.md
@@ -14,6 +14,10 @@ To provide context to your dashboard panels, add **Text** panels that display im
 
 {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` You can also save a Markdown panel to the **Visualize Library** to reuse it across multiple dashboards. For details, refer to [Save and reuse Markdown panels across dashboards](#markdown-library-reuse).
 
+:::{tip}
+**Text** panels work best for context, descriptions, instructions, links to related resources, or images. For section headers and dividers, prefer [collapsible sections](/explore-analyze/dashboards/arrange-panels.md#collapsible-sections) and descriptive chart titles, which give readers structure without taking up grid space the data could use.
+:::
+
 ## Create a Markdown panel [create-markdown-panel]
 
 :::::{applies-switch}


### PR DESCRIPTION
## Summary

This PR addresses #5445 by adding explicit `## Best practices` H2 sections to three pages users naturally read while building dashboards, instead of scattering tip blocks. Each section is placed where the reader is already looking for that topic:

- **`explore-analyze/dashboards/create-dashboard.md`** — new `## Best practices` between **Requirements** and **Create a new dashboard**, covering information hierarchy (KPIs at top, charts in the middle, detail tables at the bottom). Sits before the steps so readers think about layout before clicking through them. Cross-references the panel-sizing best practices added in #6329.
- **`explore-analyze/visualize/lens.md`** — new `## Best practices` directly after the chart-type comparison table, covering descriptive panel titles and hiding redundant axis titles via the **Axis title** dropdown set to **None**.
- **`explore-analyze/visualize/text-panels.md`** — new `## Best practices` right after the page intro, listing what text panels are good for (descriptions, instructions, links, images) and pointing readers to [collapsible sections](https://www.elastic.co/docs/explore-analyze/dashboards/arrange-panels#collapsible-sections) and descriptive chart titles for section headers instead.

Guidance is sourced from the `kibana-dashboards` agent skill in [elastic/agent-skills-sandbox](https://github.com/elastic/agent-skills-sandbox/tree/main/skills/kibana/kibana-dashboards) and kept qualitative. The 48-column grid mechanics and exact panel widths from the skill are documented separately in #6329.

The **Axis title** dropdown label and its **None** option were verified against the current Lens source (`x-pack/platform/plugins/shared/lens/public/shared_components/vis_label.tsx` and `axis/title/toolbar_title_settings.tsx` on `main`).

## Resolves

Closes #5445

## Merge order

**Land #6329 first.** This PR contains a cross-link from `create-dashboard.md` to `arrange-panels.md#arrange-panels-best-practices`, an anchor created in #6329. Once #6329 is on `main`, this PR can merge with the link resolved.

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.