### PR TITLE
[agent builder] Recommend frontier models for ESQL-heavy dashboard generation

### DIFF
--- a/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md
+++ b/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md
@@ -18,6 +18,10 @@ Agents can create and manage [dashboards](/explore-analyze/dashboards.md) and [v
 
 This functionality is powered by the built-in [`dashboard-management`](builtin-skills-reference.md#agent-builder-dashboard-management-skill) and [`visualization-creation`](builtin-skills-reference.md#agent-builder-visualization-creation-skill) skills, along with the [dashboard tools](tools/builtin-tools-reference.md#dashboard-tools) and [visualization platform tools](tools/builtin-tools-reference.md#platform-core-tools).
 
+:::{tip}
+For best results with {{esql}}-heavy dashboard generation, use a higher-tier model such as Claude 4.6 Opus. Current testing shows that Claude 4.6 Sonnet may require more corrections for generated dashboard queries.
+:::
+
 ## When to use agent-generated dashboards
 
 Building dashboards manually requires knowing which indices to query, how to write the right visualizations, and how to arrange panels. Agent-generated dashboards let you skip that process and go from a question to a working dashboard in seconds. This is particularly useful when you need to:

--- a/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
+++ b/explore-analyze/ai-features/agent-builder/limitations-known-issues.md
@@ -64,6 +64,12 @@ Error executing agent: No tool calls found in the response.
 
 To learn more, refer to [](models.md).
 
+### Claude 4.6 Sonnet may generate invalid ES|QL for dashboards
+
+Current testing shows that Claude 4.6 Sonnet may generate invalid {{esql}} for dashboard and visualization workflows, particularly with reserved keywords, dotted field names such as `system.load.1`, and incorrectly formatted aliases.
+
+**Workaround:** Use a higher-tier model, such as Claude 4.6 Opus, for {{esql}}-heavy dashboard generation. To learn more, refer to [Recommended models](models.md#recommended-models).
+
 ### Context length exceeded error [conversation-length-exceeded]
 
 This error occurs when a conversation exceeds the maximum context length supported by the LLM. This typically happens when tools return large responses that consume the available token budget.
@@ -106,4 +112,3 @@ For more information about {{agent-builder}} and Spaces, refer to [Permissions a
 
 - [Get started](get-started.md)
 - [Troubleshooting](troubleshooting.md)
-

--- a/explore-analyze/ai-features/agent-builder/models.md
+++ b/explore-analyze/ai-features/agent-builder/models.md
@@ -138,12 +138,16 @@ The following models are known to work well with {{agent-builder}}. These catego
 
 | Category | Model examples | Use cases | Trade-offs |
 |---|---|---|---|
-| Extended reasoning | - Gemini 3.1 Pro <br>- Claude 4.6 Opus | Open-ended exploration, multi-step planning, and complex analysis | Higher latency and cost. Best for latency-insensitive, batch, or async workflows. |
-| Balanced performance | - GPT-5.2 <br>- Claude 4.6 Sonnet | General-purpose agents requiring reliable tool orchestration and data retrieval and synthesis | Moderate cost. Suitable for real-time and interactive use. |
+| Extended reasoning | - Gemini 3.1 Pro <br>- Claude 4.6 Opus | Open-ended exploration, multi-step planning, complex analysis, and {{esql}}-heavy dashboard generation | Higher latency and cost. Best for latency-insensitive, batch, async, or dashboard workflows that need fewer corrections. |
+| Balanced performance | - GPT-5.2 <br>- Claude 4.6 Sonnet | General-purpose agents requiring reliable tool orchestration and data retrieval and synthesis | Moderate cost. Suitable for real-time and interactive use. For {{esql}}-heavy dashboard generation, use an extended reasoning model. |
 | High throughput | Gemini 3.0 Flash | Latency-sensitive pipelines and high-concurrency scenarios with well-scoped tasks | Lower reasoning depth. Ideal for high-volume workloads with well-defined tasks. |
 
 :::{tip}
 For agents working with large documents or conversation histories, consider models with extended context windows. For example, Claude 4.6 Sonnet and Gemini 3.1 Pro support up to 1M tokens. Check your model provider's documentation for specific context limits.
+:::
+
+:::{note}
+For [dashboards and visualizations](agent-builder-dashboards-and-visualizations.md), choose a higher-tier model when the workflow depends on complex {{esql}} generation. Current testing shows Claude 4.6 Opus generates more reliable dashboard {{esql}} than Claude 4.6 Sonnet.
 :::
 
 ### Incompatible models


### PR DESCRIPTION
## Summary

- Adds a known issue documenting that Claude 4.6 Sonnet may generate invalid {{esql}} for dashboard and visualization workflows (reserved keywords, dotted field names, malformed aliases).
- Updates the recommended models table and adds a tip pointing users toward Claude 4.6 Opus (or another extended-reasoning model) for {{esql}}-heavy dashboard generation.
- Adds a tip in the dashboards and visualizations page surfacing the same guidance at the point of use.
 