### PR TITLE
[agent builder] Resolve actionable TODOs in agent builder docs

### DIFF
--- a/explore-analyze/ai-features/agent-builder/kibana-api.md
+++ b/explore-analyze/ai-features/agent-builder/kibana-api.md
@@ -68,8 +68,6 @@ Dev Tools [Console](/explore-analyze/query-filter/tools/console.md) automaticall
 
 ## Available APIs
 
-% TODO: we may remove this list once the API reference is live, but probably helpful in the short term
-
 The following sections provide quick examples for each API endpoint grouped by resource type.
 
 ### Tools APIs

--- a/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
+++ b/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
@@ -71,8 +71,7 @@ $$$agent-builder-product-documentation-tool$$$ `platform.core.product_documentat
 :   Retrieves the status and, if available, the final output of an [Elastic Workflows](/explore-analyze/workflows.md) execution from its execution ID.
 
 `platform.core.resume_workflow_execution` {applies_to}`stack: ga 9.4+`
-:   Resumes an [Elastic Workflows](/explore-analyze/workflows.md) execution that is paused at a `waitForInput` step, providing the reviewer's input to the workflow so it can continue.
-% TODO: Restore the link on `waitForInput` to /explore-analyze/workflows/authoring-techniques/human-in-the-loop.md once https://github.com/elastic/docs-content/pull/6048 merges (the page is added in that PR).
+:   Resumes an [Elastic Workflows](/explore-analyze/workflows.md) execution that is paused at a [`waitForInput`](/explore-analyze/workflows/authoring-techniques/human-in-the-loop.md) step, providing the reviewer's input to the workflow so it can continue.
 
 <!--
 ### Attachment tools
@@ -150,11 +149,6 @@ Streams tools provide capabilities for exploring and managing [Streams](/solutio
 ## Observability tools
 
 Observability tools provide specialized capabilities for monitoring applications, infrastructure, and logs.
-
-% TODO (9.4): Document time range awareness behavior change in agent-builder-observability.md.
-% As of 9.4, the agent uses the current page's time picker by default when invoking tools,
-% unless the user specifies a different time range.
-% Source: https://github.com/elastic/kibana/pull/256343
 
 `observability.get_alerts` {applies_to}`stack: ga 9.3+`
 :   Retrieves Observability [alerts](/solutions/observability/incident-management/alerting.md) within a specified time range, supporting filtering by status (active/recovered) and KQL queries.

--- a/solutions/observability/ai/agent-builder-observability.md
+++ b/solutions/observability/ai/agent-builder-observability.md
@@ -34,6 +34,15 @@ The Elastic AI Agent includes built-in [{{observability}} skills](/explore-analy
 
 By default it includes the [`observability.investigation`](/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md#agent-builder-observability-investigation-skill) skill. You can [create a custom skill](/explore-analyze/ai-features/agent-builder/custom-skills.md) to extend the agent's capabilities for your specific use case. To learn more about the available skills, refer to [](/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md).
 
+### Time range awareness
+
+```{applies_to}
+stack: ga 9.4+
+serverless: ga
+```
+
+When you chat with the agent from an {{observability}} UI, it uses the current page's time picker as the default time range when invoking tools, unless you specify a different range in your prompt. Outside of a UI context, tools fall back to their built-in defaults.
+
 :::
 
 :::{applies-item} stack: preview =9.3, removed =9.4


### PR DESCRIPTION
## Summary

Cleans up the actionable TODO comments left in the agent builder docs:

- **Restore `waitForInput` link** in [`builtin-tools-reference.md`](explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md) — the human-in-the-loop workflows page (added in #6048) is now live, so the link can be wired up and the TODO removed.
- **Document time range awareness** in [`agent-builder-observability.md`](solutions/observability/ai/agent-builder-observability.md) — adds a short 9.4 section explaining that, when chatting from an Observability UI, the agent uses the current time picker as the default time range unless the user specifies otherwise (source: `elastic/kibana#256343`). Removes the matching TODO from `builtin-tools-reference.md`.
- **Drop a stale meta TODO** in [`kibana-api.md`](explore-analyze/ai-features/agent-builder/kibana-api.md) about whether to keep the API example list — keeping it.

Two TODOs are intentionally left in place:
- The `% TODO are these available in 9.3?` line lives inside a commented-out `### Attachment tools` block and depends on an availability decision that isn't mine to make.
- `% TODO (9.4): Publish once https://github.com/elastic/kibana/pull/255717 merges.` — that Kibana PR is still open.

Closes elastic/docs-content-internal#1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)