### PR TITLE
docs: add Best practices for creating dashboards page (#5449, #5445)

### DIFF
--- a/explore-analyze/dashboards.md
+++ b/explore-analyze/dashboards.md
@@ -39,6 +39,7 @@ Once you understand the basics, explore these common tasks:
 - [Add filter controls](dashboards/add-controls.md): Enable interactive filtering with options lists, range sliders, and time sliders.
 - [Add drilldowns](dashboards/drilldowns.md): Create interactive navigation between dashboards or to external URLs.
 - [Organize dashboard panels](dashboards/arrange-panels.md): Arrange panels using collapsible sections, resizing, and positioning.
+- [Best practices for creating dashboards](dashboards/dashboards-best-practices.md): Plan layout, size panels, build a clear information hierarchy, and tune dashboard performance.
 
 **Manage and share**
 - [Manage dashboards](dashboards/managing.md): Browse, search, organize, and track usage of your dashboards.

--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -11,7 +11,7 @@ products:
 
 # Organize dashboard panels [arrange-panels]
 
-Customize your dashboard layout by arranging panels into logical groups and adjusting their size and position. When panels are well organized, your dashboard becomes easier to read, loads faster, and helps viewers locate important information more quickly.
+Customize your dashboard layout by arranging panels into logical groups and adjusting their size and position. When panels are well organized, your dashboard becomes easier to read, loads faster, and helps viewers locate important information more quickly. For panel sizing recommendations and layout patterns, refer to [Best practices for creating dashboards](dashboards-best-practices.md).
 
 ## Requirements [arrange-panels-requirements]
 
@@ -54,7 +54,7 @@ Compare the data in your panels side-by-side, organize panels by priority, resiz
 In the application menu, click **Edit**, then use the following options:
 
 * To move, hover over the panel, click and hold ![The move control icon](/explore-analyze/images/kibana-move-control.png "The move control icon =4%x4%") and drag to the new location. Your screen scrolls automatically when you drag above or below the visible parts of the dashboard.
-* To resize, click and hold the bottom right corner of the panel and drag to the new dimensions.
+* To resize, click and hold the bottom right corner of the panel and drag to the new dimensions. Panels snap to a 48-column grid; for reference widths and sizing recommendations, refer to [Best practices for creating dashboards](dashboards-best-practices.md#dashboard-grid).
 * To maximize to full screen, open the panel menu and click **Maximize**.
 
   ::::{tip}

--- a/explore-analyze/dashboards/building.md
+++ b/explore-analyze/dashboards/building.md
@@ -30,6 +30,8 @@ Once you have a dashboard, you can also:
 * [Duplicate a dashboard](duplicate-dashboards.md) as a starting point for a new one
 * [Import a dashboard](import-dashboards.md) exported from another {{product.kibana}} instance
 
+For opinionated guidance on layout, panel sizing, information hierarchy, and titling, refer to [Best practices for creating dashboards](dashboards-best-practices.md).
+
 ## Requirements [dashboard-minimum-requirements]
 
 To create or edit dashboards, you need:

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -13,7 +13,7 @@ type: how-to
 
 # Create a dashboard from the UI [create-dashboard]
 
-Create a new dashboard in {{product.kibana}} to start visualizing and monitoring your data. Once created, you can add visualizations, configure interactive controls, and organize panels to build a comprehensive view of your data.
+Create a new dashboard in {{product.kibana}} to start visualizing and monitoring your data. Once created, you can add visualizations, configure interactive controls, and organize panels to build a comprehensive view of your data. For guidance on layout, panel sizing, and information hierarchy, refer to [Best practices for creating dashboards](dashboards-best-practices.md).
 
 :::{tip} - New ways to create dashboards
 :applies_to: {"stack": "preview 9.4+", "serverless": "preview"}

--- a/explore-analyze/dashboards/create-dashboards-programmatically.md
+++ b/explore-analyze/dashboards/create-dashboards-programmatically.md
@@ -41,6 +41,8 @@ The API supports all panel types that have a defined schema, including visualiza
 
 Refer to the [Dashboards API reference](https://elastic.github.io/dashboards-api-spec/dashboards#tag/Dashboards) for the full request schema, panel types, and authentication requirements.
 
+When you set panel coordinates by hand, the dashboard editor's automatic packing no longer applies. For guidance on panel sizing, grid packing, and information hierarchy, refer to [Best practices for creating dashboards](dashboards-best-practices.md).
+
 ## Visualizations API [lens-visualizations-api]
 ```{applies_to}
 stack: preview 9.4+

--- a/explore-analyze/dashboards/dashboards-best-practices.md
+++ b/explore-analyze/dashboards/dashboards-best-practices.md
@@ -6,6 +6,7 @@ applies_to:
   serverless: ga
 products:
   - id: kibana
+type: overview
 ---
 
 # Best practices for creating dashboards [dashboards-best-practices]
@@ -69,7 +70,7 @@ Use these reference widths to keep panels aligned across a row:
 
 Dashboards read better when there are no empty pockets between panels:
 
-* **Eliminate dead vertical space.** Make each panel's top edge meet the bottom edge of the panel that sits directly over it. Gaps push supporting content further down the dashboard.
+* **Remove dead vertical space.** Make each panel's top edge meet the bottom edge of the panel that sits directly over it. Gaps push supporting content further down the dashboard.
 * **Align heights within a row.** When several panels sit side by side, give them the same height. Mismatched heights leave awkward gaps and make the row harder to scan. If panel heights must differ, fill the empty space with another panel before starting a new full-width row.
 
 The {{product.kibana}} dashboard editor packs the grid for you when you drag and resize panels in the UI. When you author dashboards through the [Dashboards API](create-dashboards-programmatically.md), you set `x`, `y`, `w`, and `h` numerically, so apply the same packing rules in your JSON definitions.
@@ -154,7 +155,7 @@ Best for: data analysis, comparisons, deep dives.
 └───────────────────────────────────────────┘
 ```
 
-A large primary chart anchors the analysis on the left, with focused summaries and a top-N list on the right. The comparison chart and per-dimension breakdowns let analysts pivot without leaving the dashboard.
+A large primary chart anchors the analysis, with focused summaries and a top-N list grouped alongside. The comparison chart and per-dimension breakdowns let analysts pivot without leaving the dashboard.
 
 ### Executive dashboard [executive-dashboard]
 

--- a/explore-analyze/dashboards/dashboards-best-practices.md
+++ b/explore-analyze/dashboards/dashboards-best-practices.md
@@ -34,8 +34,10 @@ Place the most important information at the top of the dashboard, where viewers 
 * **Primary KPIs and key metrics** at the top.
 * **Primary charts and trends** in the middle.
 * **Detail tables and supporting panels** at the bottom for users who want to dig deeper.
+* **Make the primary insight visually dominant.** A large, central panel anchors the dashboard and tells viewers where to look first. Wide rectangles like full-width timelines work especially well as focal points.
+* **Place related panels next to each other.** When two related charts sit far apart, readers pay a cognitive tax to connect them. Group panels that share a data source or that explain the same trend.
 
-Group related panels so each row tells a coherent story. The following sketch shows a standard hierarchy:
+The following sketch shows a standard hierarchy:
 
 ```text
 ┌─────────────────────────────────────────────────────┐
@@ -103,7 +105,29 @@ A descriptive panel title is the most important label in the visualization. It e
 
 * **Write titles that explain the insight, not the field.** "Requests by response code" reads better than "count by status".
 * **Hide redundant axis titles.** Once the panel title makes the X and Y axes obvious, the axis titles repeat what the reader already knows. In the [Lens](../visualize/lens.md) editor, set **Axis title** to **None** for both axes when the panel title is self-explanatory.
+* **Don't repeat the same word in every title.** When most panels start with the same prefix (such as "Usage" across eight panels), drop it from each title and put it in the dashboard title or a section header instead.
+* **Trim numbers to what readers need.** A KPI tile reads better as `$3.4M` than `$3,364,726`. Round to the magnitude that conveys the change you're tracking, and reserve full precision for tables.
 * **Don't use [text panels](../visualize/text-panels.md) as section headers.** They take vertical space without showing data. For section breaks, use [collapsible sections](arrange-panels.md#collapsible-sections) and descriptive panel titles.
+
+## Use color deliberately [use-color]
+
+Color is a strong signal. Use it to encode meaning, not for decoration.
+
+* **Stick to {{product.kibana}}'s built-in palettes.** They're tuned for accessibility, including color-blind safety, and produce a consistent look across dashboards.
+* **Reuse the same color for the same dimension across panels.** When a value (a service, a region, a status) appears in multiple panels, give it the same color in each so readers track it without re-orienting. Turn on the dashboard **Sync color palettes across panels** setting to enforce this automatically.
+* **Match the palette to the data.** For sequential data (low to high, like usage or counts), use a single-hue gradient that gets darker as values grow. For divergent data (around a meaningful midpoint, like deviation from a target), use a two-color palette with the darkest tones at the extremes.
+* **Don't use too many colors in a single panel.** Many distinct colors create noise and make patterns harder to spot. Group categories or use shape and weight to differentiate where you can.
+* **For brand-customized dashboards, keep the palette small.** A few brand colors mixed with neutral grays read better, and more accessibly, than a full custom rainbow.
+
+## Apply consistent dashboard settings [dashboard-settings]
+
+A handful of dashboard-wide settings control how the whole dashboard reads. Set them deliberately when you create the dashboard so panels look like they belong together. Find them in the **Settings** menu in the application menu.
+
+* **Use margins between panels.** Margins create visual breathing room and signal which panels belong to the same group. Keep them on for most dashboards.
+* **Sync color palettes across panels.** Applies the same color to the same value across every panel. Refer to [](#use-color) for why this matters.
+* **Sync cursor across panels** and **Sync tooltips across panels.** When a viewer hovers a time series chart or heatmap, the same point highlights and the same tooltip appears on every related chart. Useful when panels share the same time axis.
+
+For the full list of dashboard settings and where to find them, refer to [Create a dashboard](create-dashboard.md).
 
 ## Choose the right panel for the job [choose-panel-type]
 

--- a/explore-analyze/dashboards/dashboards-best-practices.md
+++ b/explore-analyze/dashboards/dashboards-best-practices.md
@@ -66,8 +66,6 @@ Use these reference widths to keep panels aligned across a row:
 | Quarter     | 12      |
 | Sixth       | 8       |
 
-### Pack the grid cleanly [pack-grid]
-
 Dashboards read better when there are no empty pockets between panels:
 
 * **Remove dead vertical space.** Make each panel's top edge meet the bottom edge of the panel that sits directly over it. Gaps push supporting content further down the dashboard.

--- a/explore-analyze/dashboards/dashboards-best-practices.md
+++ b/explore-analyze/dashboards/dashboards-best-practices.md
@@ -1,0 +1,191 @@
+---
+navigation_title: Best practices
+description: Opinionated guidance for building scannable, performant Kibana dashboards, covering grid layout, panel sizing, information hierarchy, titling, and layout patterns.
+applies_to:
+  stack: ga
+  serverless: ga
+products:
+  - id: kibana
+---
+
+# Best practices for creating dashboards [dashboards-best-practices]
+
+A well-designed dashboard answers a question at a glance and lets the reader drill in for detail. Use the recommendations on this page as defaults when building dashboards in {{product.kibana}}, whether through the UI, the [Dashboards API](create-dashboards-programmatically.md), or [{{agent-builder}}](create-dashboards-using-ai.md). Adapt them to your data and audience.
+
+For the steps to build a dashboard, refer to [Create a dashboard](create-dashboard.md). For panel-arrangement mechanics, refer to [Organize dashboard panels](arrange-panels.md).
+
+## Plan before you place panels [plan-before-place]
+
+Before adding panels, decide who the dashboard is for and what it must answer. A few minutes of planning saves significant time later, when reorganizing a populated dashboard is harder than starting from a sketch.
+
+Answer three questions:
+
+* **Who is the audience?** Operators monitor for status changes, analysts explore comparisons, executives want summaries. Each scans the dashboard differently.
+* **What is the primary question?** A current state, a trend over time, a comparison between groups, or a mix.
+* **What decisions or actions does the dashboard support?** Alerting, investigation, reporting, or planning.
+
+Then sketch the layout, on paper, a whiteboard, or a wireframe tool. Identify chart types for each data point, prioritize what goes where, and group related charts side by side. Leave room for the dashboard to grow as you add supporting panels.
+
+## Build a clear information hierarchy [information-hierarchy]
+
+Place the most important information at the top of the dashboard, where viewers look first.
+
+* **Primary KPIs and key metrics** at the top.
+* **Primary charts and trends** in the middle.
+* **Detail tables and supporting panels** at the bottom for users who want to dig deeper.
+
+Group related panels so each row tells a coherent story. The following sketch shows a standard hierarchy:
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  KPIs / Summary metrics (top row)                   │
+├────────────────────────┬────────────────────────────┤
+│  Primary chart         │  Secondary chart           │
+│  (main insight)        │  (supporting data)         │
+├────────────────────────┴────────────────────────────┤
+│  Timeline / Trend chart (full width)                │
+├────────────────────────┬────────────────────────────┤
+│  Detail chart 1        │  Detail chart 2            │
+└────────────────────────┴────────────────────────────┘
+```
+
+Aim to keep the most important content visible without scrolling. On a 1080p (16:9) screen, that's roughly the first 24 rows of the dashboard grid. On a 1440p screen, it's roughly 38 to 40 rows. Operational dashboards in particular benefit from showing 8 to 12 panels above the fold.
+
+## Use the dashboard grid [dashboard-grid]
+
+{{product.kibana}} dashboards use a 48-column grid with rows of fixed height. When you move or resize a panel, it snaps to column and row boundaries on this grid. New panels are created at half width (24 columns) by default.
+
+Use these reference widths to keep panels aligned across a row:
+
+| Panel width | Columns |
+| ----------- | ------- |
+| Full        | 48      |
+| Half        | 24      |
+| Third       | 16      |
+| Quarter     | 12      |
+| Sixth       | 8       |
+
+### Pack the grid cleanly [pack-grid]
+
+Dashboards read better when there are no empty pockets between panels:
+
+* **Eliminate dead vertical space.** Make each panel's top edge meet the bottom edge of the panel that sits directly over it. Gaps push supporting content further down the dashboard.
+* **Align heights within a row.** When several panels sit side by side, give them the same height. Mismatched heights leave awkward gaps and make the row harder to scan. If panel heights must differ, fill the empty space with another panel before starting a new full-width row.
+
+The {{product.kibana}} dashboard editor packs the grid for you when you drag and resize panels in the UI. When you author dashboards through the [Dashboards API](create-dashboards-programmatically.md), you set `x`, `y`, `w`, and `h` numerically, so apply the same packing rules in your JSON definitions.
+
+## Size panels for what they show [size-panels]
+
+Match panel size and shape to the chart type. Use the following heights and widths as a starting point and adjust based on the density of your data and the dashboard's overall layout. Heights are expressed in dashboard grid rows.
+
+| Chart type                          | Width                         | Height (rows) | Placement                |
+| ----------------------------------- | ----------------------------- | ------------- | ------------------------ |
+| KPI metric                          | Quarter (12)                  | 4 to 6        | Top row                  |
+| Compact bar chart (≤ 7 items)       | Half (24)                     | 8 to 10       | Above the fold           |
+| Standard bar chart (8 to 12 items)  | Half (24)                     | 12 to 13      | Mid-dashboard            |
+| Tall bar chart (13+ items)          | Half (24) to full (48)        | 15 or more    | Mid-dashboard            |
+| Time series (line, area, time bar)  | Full (48)                     | 12 to 15      | Own row                  |
+| Pie or donut                        | Quarter (12) to half (24)     | 12 to 18      | Grouped with related     |
+| Heat map                            | Full (48)                     | 15 to 25      | Own row                  |
+| Table                               | Half (24) to full (48)        | 15 or more    | Bottom of the dashboard  |
+
+A few principles behind these numbers:
+
+* **Single-value metrics and KPIs** work in compact panels of any shape, since the rendered content is one number.
+* **Time series, bar charts, and tables** need horizontal room so the time axis, bar labels, and column headers don't get cramped.
+* **Pie and donut charts** read best in roughly square panels. Stretching either axis wastes space without showing more data.
+* **Use width to signal importance.** Give primary charts more horizontal room, and group dense KPI metrics into narrower panels along a single row.
+
+For per-chart configuration options, refer to the dedicated page for each chart type, listed under [Lens](../visualize/lens.md).
+
+## Title and label panels [title-label-panels]
+
+A descriptive panel title is the most important label in the visualization. It explains what the chart shows in one phrase, so the data underneath has a clear answer to point to.
+
+* **Write titles that explain the insight, not the field.** "Requests by response code" reads better than "count by status".
+* **Hide redundant axis titles.** Once the panel title makes the X and Y axes obvious, the axis titles repeat what the reader already knows. In the [Lens](../visualize/lens.md) editor, set **Axis title** to **None** for both axes when the panel title is self-explanatory.
+* **Don't use [text panels](../visualize/text-panels.md) as section headers.** They take vertical space without showing data. For section breaks, use [collapsible sections](arrange-panels.md#collapsible-sections) and descriptive panel titles.
+
+## Choose the right panel for the job [choose-panel-type]
+
+A dashboard isn't only charts. {{product.kibana}} offers several panel types. Use them deliberately:
+
+* **Charts** ([Lens](../visualize/lens.md)) form the bulk of most dashboards.
+* **[Tables](../visualize/charts/tables.md)** show row-level detail when comparison and lookup matter more than at-a-glance trends.
+* **[Filter controls](add-controls.md)** let viewers narrow the dashboard to a subset of the data without editing.
+* **[Collapsible sections](arrange-panels.md#collapsible-sections)** group supporting panels and detail tables under a header, so the primary view stays focused. Content inside a collapsed section is loaded on demand, which speeds up the dashboard.
+* **[Text panels](../visualize/text-panels.md)** add context, instructions, links, or images. Use them for short paragraphs that explain the dashboard, not as visual section dividers.
+
+## Layout patterns to start from [layout-patterns]
+
+These templates are starting points. Adapt them to your data and your readers.
+
+### Operational dashboard [operational-dashboard]
+
+Best for: system health, real-time monitoring, alerts.
+
+```text
+┌──────────┬──────────┬──────────┬──────────┐
+│  KPI 1   │  KPI 2   │  KPI 3   │  KPI 4   │  Status at a glance
+├──────────┴──────────┴──────────┴──────────┤
+│         Main timeline (trends)            │  Primary metric over time
+├───────────────────────┬───────────────────┤
+│   Breakdown chart 1   │  Breakdown chart 2│  Drill down by dimension
+├───────────────────────┴───────────────────┤
+│         Secondary timeline                │  Supporting trends
+└───────────────────────────────────────────┘
+```
+
+A row of compact KPIs at the top tells viewers whether anything needs attention. The main timeline gives shape to the trend, breakdowns explain it, and a secondary timeline anchors longer-running context.
+
+### Analytical dashboard [analytical-dashboard]
+
+Best for: data analysis, comparisons, deep dives.
+
+```text
+┌───────────────────────┬───────────────────┐
+│                       │   Filter / summary│
+│   Primary analysis    ├───────────────────┤
+│   (large chart)       │   Top-N list      │
+├───────────────────────┴───────────────────┤
+│            Comparison chart               │
+├───────────────────────┬───────────────────┤
+│   Dimension A         │   Dimension B     │
+└───────────────────────────────────────────┘
+```
+
+A large primary chart anchors the analysis on the left, with focused summaries and a top-N list on the right. The comparison chart and per-dimension breakdowns let analysts pivot without leaving the dashboard.
+
+### Executive dashboard [executive-dashboard]
+
+Best for: high-level summaries, stakeholder reports.
+
+```text
+┌──────────┬──────────┬──────────┬──────────┐
+│  KPI 1   │  KPI 2   │  KPI 3   │  KPI 4   │
+├──────────┴──────────┼──────────┴──────────┤
+│   Trend chart 1     │    Trend chart 2    │
+├─────────────────────┴─────────────────────┤
+│           Distribution / breakdown        │
+└───────────────────────────────────────────┘
+```
+
+KPIs anchor the headline. Two trend charts show direction, and a single distribution panel summarizes the population. Detail belongs in a separate dashboard, accessed through a [drilldown](drilldowns.md).
+
+## Tune dashboard performance [dashboard-performance]
+
+A well-designed dashboard also loads quickly:
+
+* **Restrict the time range.** Time series and aggregations scan more data over longer ranges. Set a default time range that matches the dashboard's primary question.
+* **Defer the supporting view.** Place secondary panels and detail tables inside [collapsible sections](arrange-panels.md#collapsible-sections). Content inside a collapsed section is loaded on demand.
+* **Split very large dashboards.** Many tens of panels on a single dashboard hurt both performance and scannability. Build focused dashboards and link them with [drilldowns](drilldowns.md).
+* **Prefer summaries over raw row scans.** For high-cardinality data, build panels on aggregations or summarized [ES|QL](../query-filter/languages/esql-kibana.md) queries rather than scanning raw documents.
+
+## Related [related]
+
+* [Create a dashboard](create-dashboard.md)
+* [Organize dashboard panels](arrange-panels.md)
+* [Add filter controls](add-controls.md)
+* [Drilldowns](drilldowns.md)
+* [Create dashboards programmatically](create-dashboards-programmatically.md)
+* [Create dashboards using AI](create-dashboards-using-ai.md)

--- a/explore-analyze/dashboards/dashboards-best-practices.md
+++ b/explore-analyze/dashboards/dashboards-best-practices.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Best practices
-description: Opinionated guidance for building scannable, performant Kibana dashboards, covering grid layout, panel sizing, information hierarchy, titling, and layout patterns.
+description: Design scannable, performant Kibana dashboards with opinionated guidance on layout, panel sizing, information hierarchy, color, titling, and reusable patterns.
 applies_to:
   stack: ga
   serverless: ga

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -282,6 +282,7 @@ toc:
           - file: dashboards/add-controls.md
           - file: dashboards/drilldowns.md
           - file: dashboards/arrange-panels.md
+          - file: dashboards/dashboards-best-practices.md
           - file: dashboards/duplicate-dashboards.md
           - file: dashboards/import-dashboards.md
       - file: dashboards/managing.md

--- a/explore-analyze/visualize/charts/area-charts.md
+++ b/explore-analyze/visualize/charts/area-charts.md
@@ -68,7 +68,9 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 **Label clearly**
 :   Provide a descriptive title and axis labels that clearly communicate what the chart shows. For example, mention the metric being visualized ("Average Response Time") and reference the time period when relevant ("Dec 8-16, 2025").
 
-Refer to [Area chart settings](#area-chart-settings) to find all configuration options for your area chart.  
+Refer to [Area chart settings](#area-chart-settings) to find all configuration options for your area chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/bar-charts.md
+++ b/explore-analyze/visualize/charts/bar-charts.md
@@ -77,6 +77,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Sort bars by value (ascending or descending) to make comparisons easier, or keep them in alphabetical/chronological order when the sequence matters.
 
 Refer to [](#settings) for a complete list of options.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 ::::
 
 ::::{step} Save the chart

--- a/explore-analyze/visualize/charts/gauge-charts.md
+++ b/explore-analyze/visualize/charts/gauge-charts.md
@@ -67,6 +67,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Provide clear titles that explain what the gauge measures and what the target value represents.
 
 Refer to [Gauge chart settings](#gauge-chart-settings) to find all configuration options for your gauge chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -64,6 +64,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   For categorical axes, order values logically (alphabetically, by frequency, or by a natural ordering like days of the week). Use the **Sort order** [style setting](#appearance-options) to control how axis values are sorted.
 
 Refer to [Heat map chart settings](#heat-map-chart-settings) to find all configuration options for your heat map chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/line-charts.md
+++ b/explore-analyze/visualize/charts/line-charts.md
@@ -64,8 +64,9 @@ You can tweak the appearance of your chart by adjusting axes, legends, and serie
 **Provide context**
 :   Add a legend and descriptive axis titles, or remove them for obvious axes.
 
-For layout, hierarchy, and color guidance on dashboards, check EUI’s [Dashboard good practices](https://eui.elastic.co/docs/dataviz/dashboard-good-practices/). 
 For more chart configuration options, go to the [Line chart settings](#settings) section.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/metric-charts.md
+++ b/explore-analyze/visualize/charts/metric-charts.md
@@ -72,6 +72,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Use titles and subtitles to explain what the metric shows. "45,234" is a number, but "Active Users" as a title gives it meaning, and "Last 24 hours" as a subtitle makes it unambiguous.
 
 Refer to [](#settings) for a complete list of options.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 ::::
 
 ::::{step} Save the chart

--- a/explore-analyze/visualize/charts/mosaic-charts.md
+++ b/explore-analyze/visualize/charts/mosaic-charts.md
@@ -62,6 +62,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Colors typically represent the vertical axis categories, making it easier to track how each category appears across columns.
 
 Refer to [Mosaic chart settings](#mosaic-chart-settings) to find all configuration options for your mosaic chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/pie-charts.md
+++ b/explore-analyze/visualize/charts/pie-charts.md
@@ -66,6 +66,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Keep labels inside or close to slices when possible. For charts with many small slices or long labels, use the legend instead.
 
 Refer to [Pie chart settings](#pie-chart-settings) to find all configuration options for your pie chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/region-map-charts.md
+++ b/explore-analyze/visualize/charts/region-map-charts.md
@@ -61,6 +61,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Region maps are choropleth maps, where color represents data values. Be aware that larger regions can visually dominate, even if their values are smaller.
 
 Refer to [Region map chart settings](#region-map-chart-settings) to find all configuration options for your region map chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/tables.md
+++ b/explore-analyze/visualize/charts/tables.md
@@ -77,6 +77,8 @@ Tweak the appearance of the table to your needs. Consider the following best pra
 :   Adjust table density based on your use case. Use **Compact** for fitting more rows, **Expanded** for better readability.
 
 Refer to [](#settings) for a complete list of options.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 ::::
 
 ::::{step} Save the table

--- a/explore-analyze/visualize/charts/tag-cloud-charts.md
+++ b/explore-analyze/visualize/charts/tag-cloud-charts.md
@@ -61,6 +61,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Use colors to add meaning (categories) or keep them neutral to focus attention on size differences.
 
 Refer to [Tag cloud chart settings](#tag-cloud-chart-settings) to find all configuration options for your tag cloud chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/treemap-charts.md
+++ b/explore-analyze/visualize/charts/treemap-charts.md
@@ -61,6 +61,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Labels are automatically hidden on rectangles that are too small to fit them. If too many labels are missing, reduce the number of categories or increase the panel size.
 
 Refer to [Treemap chart settings](#treemap-chart-settings) to find all configuration options for your treemap chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/charts/waffle-charts.md
+++ b/explore-analyze/visualize/charts/waffle-charts.md
@@ -63,6 +63,8 @@ Tweak the appearance of the chart to your needs. Consider the following best pra
 :   Arrange categories from largest to smallest or in a natural order (such as satisfaction ratings from low to high).
 
 Refer to [Waffle chart settings](#waffle-chart-settings) to find all configuration options for your waffle chart.
+
+For dashboard-wide guidance on panel sizing, layout, and titling, refer to [Best practices for creating dashboards](../../dashboards/dashboards-best-practices.md).
 :::::
 
 :::::{step} Save the chart

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -19,6 +19,8 @@ Data views are created automatically if you [upload a file](/manage-data/ingest/
 
 Once you select a {{data-source}}, you can build many types of visualizations by choosing aggregations, splitting dimensions, and configuring chart styles, legends, and layers.
 
+For panel titles, axis labels, and dashboard sizing recommendations, refer to [Best practices for creating dashboards](/explore-analyze/dashboards/dashboards-best-practices.md).
+
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-dashboards
 :::

--- a/explore-analyze/visualize/text-panels.md
+++ b/explore-analyze/visualize/text-panels.md
@@ -12,6 +12,8 @@ products:
 
 To provide context to your dashboard panels, add **Text** panels that display important information, instructions, images, and more. You can create **Text** panels using GitHub-flavored Markdown text.
 
+For guidance on when to use a text panel and when to reach for [collapsible sections](/explore-analyze/dashboards/arrange-panels.md#collapsible-sections) or descriptive panel titles instead, refer to [Best practices for creating dashboards](/explore-analyze/dashboards/dashboards-best-practices.md#choose-panel-type).
+
 {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` You can also save a Markdown panel to the **Visualize Library** to reuse it across multiple dashboards. For details, refer to [Save and reuse Markdown panels across dashboards](#markdown-library-reuse).
 
 ## Create a Markdown panel [create-markdown-panel]


### PR DESCRIPTION
## Summary

Adds a single, opinionated guidance page for designing effective {{kib}} dashboards, and routes existing pages to it instead of fragmenting the same advice across many places.

This PR closes both #5449 (grid documentation) and #5445 (dashboard design best practices). It replaces the earlier #6329 and #6330, which split the guidance across multiple pages. Both have been closed in favor of this consolidated approach.

## What's new

**`explore-analyze/dashboards/dashboards-best-practices.md`** (new). Sections:

1. **Plan before you place panels** — audience, primary question, decisions to support; sketch first.
2. **Build a clear information hierarchy** — KPIs at the top, charts in the middle, detail tables at the bottom; above-the-fold (~24 rows on 1080p, ~38–40 rows on 1440p); 8–12 panels above the fold for operational dashboards. Includes an ASCII layout sketch.
3. **Use the dashboard grid** — 48-column grid, snap behavior, default new-panel width (24 columns / half).
   - **Pack the grid cleanly** — eliminate dead vertical space, align heights within a row.
4. **Size panels for what they show** — per-chart sizing reference table with concrete row counts (KPI 4–6, compact bar 8–10, time series 12–15, table 15+, heat map 15–25, etc.) plus the principles behind the numbers.
5. **Title and label panels** — descriptive titles, hide redundant axis titles, don't use text panels as section headers.
6. **Choose the right panel for the job** — Lens charts, tables, filter controls, collapsible sections, text panels.
7. **Layout patterns to start from** — Operational, Analytical, Executive templates with ASCII sketches and prose.
8. **Tune dashboard performance** — time range, deferred views via collapsible sections, splitting large dashboards, summaries over raw scans.

## Discoverability pointers added

- `explore-analyze/dashboards.md` — adds the page to the **Build and customize dashboards** list.
- `explore-analyze/dashboards/building.md` — closing pointer after the related-tasks list.
- `explore-analyze/dashboards/create-dashboard.md` — pointer in the page intro.
- `explore-analyze/dashboards/arrange-panels.md` — pointer in the intro and from the resize bullet, linking to `#dashboard-grid`.
- `explore-analyze/dashboards/create-dashboards-programmatically.md` — pointer at the end of the **Dashboards API** section, framed for API authors who set panel coordinates by hand.
- `explore-analyze/visualize/lens.md` — pointer near the intro for panel titles, axis labels, and dashboard sizing.
- `explore-analyze/visualize/text-panels.md` — pointer near the intro, anchored to `#choose-panel-type`.
- All 13 individual Lens chart pages (`area`, `bar`, `gauge`, `heat-map`, `line`, `metric`, `mosaic`, `pie`, `region-map`, `tables`, `tag-cloud`, `treemap`, `waffle`) — pointer added to the existing **Customize the chart to follow best practices** build step.
- `explore-analyze/visualize/charts/line-charts.md` — replaces the existing external EUI **Dashboard good practices** link with the new internal page.
- `explore-analyze/toc.yml` — adds the page under **Building dashboards**, after **Organize dashboard panels** and before **Duplicate a dashboard**.

## Sourcing of opinionated guidance

The numbers and patterns come from the `kibana-dashboards` and `kibana-vega` agent skills in [elastic/agent-skills-sandbox](https://github.com/elastic/agent-skills-sandbox), reframed for a docs audience and verified against the {{kib}} source where applicable:

- **48-column grid:** `DASHBOARD_GRID_COLUMN_COUNT = 48` in `src/platform/plugins/shared/dashboard/common/page_bundle_constants.ts`.
- **Default panel width 24 (half):** `DEFAULT_PANEL_WIDTH = DASHBOARD_GRID_COLUMN_COUNT / 2` in `src/platform/plugins/shared/dashboard/common/constants.ts`.
- **Per-chart row counts and layout patterns:** authored opinion from the skills, kept opinionated per the page's framing.

## Resolves

- Closes #5449
- Closes #5445

## Replaces

- Supersedes #6329 (now closed)
- Supersedes #6330 (now closed)

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.
