### PR TITLE
[agent builder] Simplify built-in agents reference page

### DIFF
--- a/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
@@ -14,34 +14,26 @@ products:
 
 # {{agent-builder}} built-in agents reference
 
-Built-in agents are pre-configured by Elastic with specific instructions and tools to handle common use cases.
-
-## Availability
-
-The [Elastic AI Agent](#elastic-ai-agent) is created automatically in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed, and is only available in the space where it was created.
+Built-in agents are pre-configured by Elastic with instructions and tools to handle common use cases.
 
 ## Elastic AI Agent
 
-The **Elastic AI Agent** is the default general-purpose agent for {{es}}. It is designed to help with a wide range of tasks, from writing {{esql}} queries to exploring your data indices.
+The **Elastic AI Agent** is the default general-purpose agent. It is designed to help with a wide range of tasks, from writing {{esql}} queries to exploring your data indices.
 
-It is a standard persisted agent that is space-aware, so you can customize it independently for each space: change its instructions, adjust which tools it has access to, or clone it as a starting point for a new agent.
-
-:::{note}
-:applies_to: { "stack": "preview =9.2, ga =9.3" }
-In {{stack}} 9.2 (preview) and 9.3 (GA), the Elastic AI Agent cannot be modified or deleted. To customize it, clone it and [create a custom agent](custom-agents.md#create-a-new-agent).
-:::
-
-**Default assigned tools:**
-* All [**Platform core tools**](./tools/builtin-tools-reference.md#platform-core-tools)
-
-::::{dropdown} Previous versions
+The Elastic AI Agent is a standard persisted agent that is space-aware. A separate instance is created automatically in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed, and each instance can be customized independently: change its instructions, adjust which tools it has access to, or clone it as a starting point for a new agent.
 
 :::{note}
-:applies_to: { "stack": "preview =9.2, ga =9.3" }
-{{product.observability}} and {{product.security}} users must opt-in to use {{agent-builder}}. To learn more, refer to [](/explore-analyze/ai-features/ai-chat-experiences/ai-agent-or-ai-assistant.md#switch-between-chat-experiences).
+In 9.2  and 9.3, the Elastic AI Agent cannot be modified or deleted. To customize it, clone it and [create a custom agent](custom-agents.md#create-a-new-agent).
 :::
 
-## Observability Agent
+
+## Built-in agents in previous versions
+
+:::{important}
+In {{stack}} 9.3, {{agent-builder}} included two specialized built-in agents for observability and security use cases. Both were removed in 9.4 in favor of equivalent capabilities exposed as skills on the [Elastic AI Agent](#elastic-ai-agent).
+:::
+
+### Observability Agent
 ```{applies_to}
 stack: preview =9.3, removed 9.4+
 serverless:
@@ -55,7 +47,7 @@ A specialized agent for logs, metrics, and traces. It is designed to assist with
 * All [**{{observability}} tools**](./tools/builtin-tools-reference.md#observability-tools)
 * A subset of [**Platform core tools**](./tools/builtin-tools-reference.md#platform-core-tools)
 
-## Threat Hunting Agent
+### Threat Hunting Agent
 ```{applies_to}
 stack: preview =9.3, removed 9.4+
 serverless:
@@ -71,8 +63,6 @@ A specialized agent for security alert analysis tasks, including alert investiga
 The standalone **Threat Hunting Agent** is removed in 9.4. Threat hunting workflows now use the [Elastic AI Agent](#elastic-ai-agent) with the [`threat-hunting`](builtin-skills-reference.md#agent-builder-threat-hunting-skill) skill enabled, which provides the same capabilities without switching between separate built-in agents. For Security-specific context, refer to [](/solutions/security/ai/agent-builder/skills-model.md).
 
 **Migration path:** Enable the [`threat-hunting`](builtin-skills-reference.md#agent-builder-threat-hunting-skill) skill on the Elastic AI Agent in place of that standalone agent. The skill ships with the same tool set and query templates previously bundled into the agent, plus platform core tools for generating and running {{esql}} queries. For use cases and example prompts, refer to [Security use cases for {{agent-builder}}](/solutions/security/ai/agent-builder/skills-use-cases.md#threat-hunting).
-
-::::
 
 ## Related pages
 

--- a/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
@@ -16,78 +16,30 @@ products:
 
 Built-in agents are pre-configured by Elastic with specific instructions and tools to handle common use cases.
 
-::::{applies-switch}
-
-:::{applies-item} { stack: ga 9.4+, serverless: ga }
-
-The **Elastic AI Agent** is now a standard persisted default agent that is space-aware and modifiable. Refer to [Elastic AI Agent](#elastic-ai-agent) for details.
-
-:::
-
-:::{applies-item} { stack: preview =9.2, ga 9.3 }
-
-You cannot modify or delete built-in agents. To customize one, you can clone it and [create a custom agent](custom-agents.md#create-a-new-agent).
-
-:::
-
-::::
-
 ## Availability
 
-The availability of specific agents depends on your solution view or serverless project type.
+The [Elastic AI Agent](#elastic-ai-agent) is created automatically in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed, and is only available in the space where it was created.
 
-::::{applies-switch}
+## Elastic AI Agent
 
-:::{applies-item} { stack: ga 9.4+, serverless: ga }
+The **Elastic AI Agent** is the default general-purpose agent for {{es}}. It is designed to help with a wide range of tasks, from writing {{esql}} queries to exploring your data indices.
 
-Built-in agents are space-agnostic: they are available across all [{{kib}} spaces](/deploy-manage/manage-spaces.md). The default [Elastic AI Agent](#elastic-ai-agent) is an exception: it is created automatically per space and is only available in the space where it was created.
+It is a standard persisted agent that is space-aware, so you can customize it independently for each space: change its instructions, adjust which tools it has access to, or clone it as a starting point for a new agent.
 
+:::{note}
+:applies_to: { "stack": "preview =9.2, ga =9.3" }
+In {{stack}} 9.2 (preview) and 9.3 (GA), the Elastic AI Agent cannot be modified or deleted. To customize it, clone it and [create a custom agent](custom-agents.md#create-a-new-agent).
 :::
 
-:::{applies-item} { stack: preview =9.2, ga 9.3 }
+**Default assigned tools:**
+* All [**Platform core tools**](./tools/builtin-tools-reference.md#platform-core-tools)
 
-Built-in agents are space-agnostic: they are available across all [{{kib}} spaces](/deploy-manage/manage-spaces.md).
-
-:::
-
-::::
+::::{dropdown} Previous versions
 
 :::{note}
 :applies_to: { "stack": "preview =9.2, ga =9.3" }
 {{product.observability}} and {{product.security}} users must opt-in to use {{agent-builder}}. To learn more, refer to [](/explore-analyze/ai-features/ai-chat-experiences/ai-agent-or-ai-assistant.md#switch-between-chat-experiences).
 :::
-
-## Elastic AI Agent
-```{applies_to}
-stack: preview =9.2, ga 9.3+
-serverless: ga
-```
-
-::::{applies-switch}
-
-:::{applies-item} { stack: ga 9.4+, serverless: ga }
-
-The **Elastic AI Agent** is the default general-purpose agent for {{es}}. Unlike the other built-in agents, it is a standard persisted agent that is automatically created in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed.
-
-Because the default agent is space-aware, you can customize it independently for each space. You can change its instructions, adjust which tools it has access to, or clone it as a starting point for a new agent.
-
-**Default assigned tools:**
-* All [**Platform core tools**](./tools/builtin-tools-reference.md#platform-core-tools)
-
-:::
-
-:::{applies-item} { stack: preview =9.2, ga 9.3 }
-
-The **Elastic AI Agent** is the default general-purpose agent for {{es}}. It is designed to help with a wide range of tasks, from writing {{esql}} queries to exploring your data indices.
-
-**Assigned tools:**
-* All [**Platform core tools**](./tools/builtin-tools-reference.md#platform-core-tools)
-
-:::
-
-::::
-
-:::{dropdown} Previous versions
 
 ## Observability Agent
 ```{applies_to}
@@ -120,7 +72,7 @@ The standalone **Threat Hunting Agent** is removed in 9.4. Threat hunting workfl
 
 **Migration path:** Enable the [`threat-hunting`](builtin-skills-reference.md#agent-builder-threat-hunting-skill) skill on the Elastic AI Agent in place of that standalone agent. The skill ships with the same tool set and query templates previously bundled into the agent, plus platform core tools for generating and running {{esql}} queries. For use cases and example prompts, refer to [Security use cases for {{agent-builder}}](/solutions/security/ai/agent-builder/skills-use-cases.md#threat-hunting).
 
-:::
+::::
 
 ## Related pages
 

--- a/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
@@ -20,7 +20,7 @@ Built-in agents are pre-configured by Elastic with instructions and tools to han
 
 The **Elastic AI Agent** is the default general-purpose agent. It is designed to help with a wide range of tasks, from writing {{esql}} queries to exploring your data indices.
 
-The Elastic AI Agent is a standard persisted agent that is space-aware. A separate instance is created automatically in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed, and each instance can be customized independently: change its instructions, adjust which tools it has access to, or clone it as a starting point for a new agent.
+The Elastic AI Agent is a standard persisted agent that is space-aware. A separate instance is created automatically in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed, and each instance can be customized independently: change its instructions, assign [skills](builtin-skills-reference.md) and [tools](./tools/builtin-tools-reference.md), or clone it as a starting point for a new agent.
 
 :::{note}
 In 9.2  and 9.3, the Elastic AI Agent cannot be modified or deleted. To customize it, clone it and [create a custom agent](custom-agents.md#create-a-new-agent).


### PR DESCRIPTION
## Summary

The built-in agents reference page had grown hyper-complex through a stack of `applies-switch` tabs covering 9.2 preview, 9.3 GA, and 9.4+/serverless GA. With the Observability and Threat Hunting agents removed in 9.4, only the Elastic AI Agent remains as a built-in agent, so the page can be much simpler.

- Lead with 9.4+/serverless GA as the canonical state for the Elastic AI Agent; gate older-version differences (cannot modify or delete) with a single inline note.
- Drop the redundant `## Availability` section: the per-space behavior now lives in the Elastic AI Agent description, which also clarifies that each space gets its own customizable instance.
- Mention that skills and tools can be assigned to the agent, with links to both reference pages.
- Remove the duplicate Serverless/Stack version tags from the `## Elastic AI Agent` heading (already present on the page header).
- Replace the "Previous versions" dropdown with a flat `## Built-in agents in previous versions` section, introduced by an Important admonition explaining that the 9.3 specialized agents (Observability Agent, Threat Hunting Agent) were removed in 9.4 in favor of skills on the Elastic AI Agent.


🤖 Generated with [Claude Code](https://claude.com/claude-code)