### PR TITLE
[agent builder] Document protected tool ID namespaces

### DIFF
--- a/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
+++ b/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
@@ -16,7 +16,7 @@ products:
 
 # {{agent-builder}} built-in tools reference
 
-This page lists all built-in tools available in {{agent-builder}}, grouped by namespace. Built-in tools are read-only: you can't modify or delete them.
+This page lists all built-in tools available in {{agent-builder}}, grouped by [namespace](custom-tools.md#protected-namespaces). Built-in tools are read-only: you can't modify or delete them.
 
 Platform tools are available across all deployments. Observability and security tools are scoped to their respective solutions. Tool prefixes (`platform.core`, `platform.streams`, `observability`, `security`) reflect this scoping.
 

--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -159,6 +159,8 @@ The Tool ID is a critical identifier. Use a namespace prefix to group tools logi
 - `support.get_ticket_details`
 - `ecommerce.cancel_order`
 
+Some prefixes are reserved by Elastic for built-in tools and cannot be used for custom tool IDs. Refer to [Protected namespaces](#protected-namespaces).
+
 ### Writing effective tool descriptions
 
 A strong description explains what the tool does, when to use it, and what limitations exist. Include these components:

--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -141,7 +141,7 @@ The set of protected prefixes has expanded across Elastic stack versions. The ve
 - `security.*` {applies_to}`stack: ga 9.3+`
 
 :::{important}
-Custom tools created in a namespace before it became protected remain in your environment but cannot be modified or deleted. Create a replacement under a non-protected namespace.
+The protected namespace list has grown across releases and may expand further. Before upgrading to a new version, check the list against your custom tool IDs and recreate any that might collide under a different namespace. Tools whose namespace becomes protected at upgrade time can no longer be modified or deleted.
 :::
 
 ## Best practices

--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -128,12 +128,12 @@ To start using a custom tool, you must assign it to a [custom agent](../custom-a
 
 Some tool ID prefixes are reserved by Elastic for built-in tools and cannot be used for custom tools. Saving a custom tool whose ID begins with a protected prefix fails with the error `Tool ID "<id>" uses a protected namespace.`
 
-The set of protected prefixes has expanded across Elastic stack versions. The version tag next to each prefix indicates the version in which it was added to the protected list:
+The set of protected prefixes has expanded across {{stack}} versions. The version tag next to each prefix indicates the version in which it was added to the protected list:
 
 - `attachments.*` {applies_to}`stack: ga 9.4+`
 - `filestore.*` {applies_to}`stack: ga 9.4+`
 - `observability.*` {applies_to}`stack: ga 9.3+`
-- `platform.core.*` {applies_to}`stack: ga =9.2`
+- `platform.core.*` {applies_to}`stack: ga 9.2+`
 - `platform.dashboard.*` {applies_to}`stack: ga 9.3+`
 - `platform.streams.*` {applies_to}`stack: ga 9.4+`
 - `platform.workflows.*` {applies_to}`stack: ga 9.4+`

--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -128,7 +128,7 @@ To start using a custom tool, you must assign it to a [custom agent](../custom-a
 
 Some tool ID prefixes are reserved by Elastic for built-in tools and cannot be used for custom tools. Saving a custom tool whose ID begins with a protected prefix fails with the error `Tool ID "<id>" uses a protected namespace.`
 
-The set of protected prefixes has expanded across Elastic stack versions:
+The set of protected prefixes has expanded across Elastic stack versions. The version tag next to each prefix indicates the version in which it was added to the protected list:
 
 - `attachments.*` {applies_to}`stack: ga 9.4+`
 - `filestore.*` {applies_to}`stack: ga 9.4+`

--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -124,6 +124,26 @@ To start using a custom tool, you must assign it to a [custom agent](../custom-a
 
 :::::
 
+## Protected namespaces
+
+Some tool ID prefixes are reserved by Elastic for built-in tools and cannot be used for custom tools. Saving a custom tool whose ID begins with a protected prefix fails with the error `Tool ID "<id>" uses a protected namespace.`
+
+The set of protected prefixes has expanded across Elastic stack versions:
+
+- `attachments.*` {applies_to}`stack: ga 9.4+`
+- `filestore.*` {applies_to}`stack: ga 9.4+`
+- `observability.*` {applies_to}`stack: ga 9.3+`
+- `platform.core.*` {applies_to}`stack: ga =9.2`
+- `platform.dashboard.*` {applies_to}`stack: ga 9.3+`
+- `platform.streams.*` {applies_to}`stack: ga 9.4+`
+- `platform.workflows.*` {applies_to}`stack: ga 9.4+`
+- `search.*` {applies_to}`stack: ga 9.4+`
+- `security.*` {applies_to}`stack: ga 9.3+`
+
+:::{important}
+Custom tools created in a namespace before it became protected remain in your environment but cannot be modified or deleted. Create a replacement under a non-protected namespace.
+:::
+
 ## Best practices
 
 Follow these guidelines to create tools that agents can use effectively.


### PR DESCRIPTION
## Summary

Adds a **Protected namespaces** section to the custom tools page documenting the tool ID prefixes that {{agent-builder}} reserves for built-in tools and the version each one became protected. This was prompted by a user report where a custom tool created in the `search.*` namespace prior to 9.4 could no longer be modified or deleted after upgrade, with no documentation to consult.




🤖 Generated with [Claude Code](https://claude.com/claude-code)