### PR TITLE
Add beat-receivers anchor to redirects.yml

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -853,6 +853,7 @@ redirects:
   'reference/fleet/elastic-agent-as-otel-collector.md':
     anchors:
       'hybrid-elastic-agent': 'elastic-agent-multiple-collection-methods'
+      'beat-receivers': 'beat-receivers'
   'reference/fleet/otel-integrations.md':
     anchors:
       'otel-integrations-hybrid-policies': 'agent-policies-multiple-integrations'


### PR DESCRIPTION
## Summary

Adds an anchor to the `redirects.yml` file to allow linking to the _Beat receivers_ heading (`#beat-receivers`).

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  


