### PR TITLE
Typo error as instead of `Percentage`, the term `Parentage` is written on Session View page.

### DIFF
--- a/solutions/security/investigate/session-view.md
+++ b/solutions/security/investigate/session-view.md
@@ -13,7 +13,7 @@ products:
 
 # Session View [security-session-view]
 
-Session View is an investigation tool that allows you to examine Linux process data organized in a tree-like structure according to the Linux logical event model, with processes organized by parentage and time of execution. It displays events in a highly readable format that is inspired by the terminal. This makes it a powerful tool for monitoring and investigating session activity on your Linux infrastructure and understanding user and service behavior.
+Session View is an investigation tool that allows you to examine Linux process data organized in a tree-like structure according to the Linux logical event model, with processes organized by percentage and time of execution. It displays events in a highly readable format that is inspired by the terminal. This makes it a powerful tool for monitoring and investigating session activity on your Linux infrastructure and understanding user and service behavior.
 
 ::::{admonition} Requirements
 Ensure you have the appropriate [{{stack}} subscription](https://www.elastic.co/pricing) or [{{serverless-short}} project feature tier](../../../deploy-manage/deploy/elastic-cloud/project-settings.md).


### PR DESCRIPTION
**Documentation links**
Doc Link: https://www.elastic.co/docs/solutions/security/investigate/session-view

**Description**
Typo error as instead of `Percentage`, the term `Parentage` is written on Session View page.

**Screenshot:**

<img width="801" height="380" alt="rt18" src="https://github.com/user-attachments/assets/01a1111b-e38a-4494-882f-93cbe0086d99" />



**Which documentation set(s) does this bug apply to?**
ESS and serverless

**Release version**
9.4

**Testing environment**
Build deployed from the production cloud environment: https://cloud.elastic.co/