### PR TITLE
Fix root-cause-analysis.md workflow example

### DIFF
--- a/explore-analyze/workflows/use-cases/observability/root-cause-analysis.md
+++ b/explore-analyze/workflows/use-cases/observability/root-cause-analysis.md
@@ -25,7 +25,7 @@ If you're new to workflows, complete [Build your first workflow](/explore-analyz
 
 - **Permissions.** `All` on **Analytics > Workflows**, **Observability > Cases**, and whatever Agent Builder privilege is required to invoke agents in your space. Refer to [{{kib}} privileges](/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md).
 - **Alerting rule.** A configured [observability alerting rule](/solutions/observability/incident-management/alerting.md) that fires on the conditions you want to auto-investigate (metric thresholds, SLO burn rate, anomaly detection, or custom query).
-- **SRE agent.** An {{agent-builder}} agent configured to investigate observability signals. The source workflow uses an agent named `sre-agent`. Substitute your agent ID.
+- **SRE agent.** An {{agent-builder}} agent configured to investigate observability signals. The examples use `elastic-ai-agent` as a generic default; substitute the ID of the agent you've configured.
 - **Attach the workflow to the rule.** After saving the workflow, attach it as an action on the alerting rule. Refer to [Alert triggers](/explore-analyze/workflows/triggers/alert-triggers.md).
 
 ## How it works [workflows-rca-how-it-works]
@@ -62,11 +62,10 @@ Call the agent with the alert payload. Keep `create-conversation: true` so follo
 steps:
   - name: rca_analysis
     type: ai.agent
-    agent-id: "{{ consts.agent_id }}"
-    connector-id: "{{ consts.connector_id }}"
+    agent-id: elastic-ai-agent
     create-conversation: true
     with:
-      prompt: |
+      message: |
         Investigate the following alert and propose root causes.
         Keep your analysis and data exploration brief to preserve context.
 
@@ -85,19 +84,17 @@ Reuse the conversation (so the agent remembers its analysis) and ask it for a ti
 ```yaml
   - name: case_title
     type: ai.agent
-    agent-id: "{{ consts.agent_id }}"
-    connector-id: "{{ consts.connector_id }}"
-    conversation-id: "{{ steps.rca_analysis.output.conversation_id }}"
+    agent-id: elastic-ai-agent
     with:
-      prompt: "Based on your analysis, produce a clear case title. Output only the title."
+      conversation_id: "{{ steps.rca_analysis.output.conversation_id }}"
+      message: "Based on your analysis, produce a clear case title. Output only the title."
 
   - name: case_description
     type: ai.agent
-    agent-id: "{{ consts.agent_id }}"
-    connector-id: "{{ consts.connector_id }}"
-    conversation-id: "{{ steps.rca_analysis.output.conversation_id }}"
+    agent-id: elastic-ai-agent
     with:
-      prompt: "Based on your analysis, produce a clear case description. Output only the description."
+      conversation_id: "{{ steps.rca_analysis.output.conversation_id }}"
+      message: "Based on your analysis, produce a clear case description. Output only the description."
 ```
 
 Using a conversation ID keeps tokens cheap and ensures the title and description match the earlier analysis.
@@ -192,20 +189,15 @@ tags: ["rca", "ai", "observability"]
 triggers:
   - type: alert
 
-consts:
-  agent_id: "sre-agent"
-  connector_id: "your-connector-id"
-
 steps:
   - name: rca_analysis
     type: ai.agent
-    agent-id: "{{ consts.agent_id }}"
-    connector-id: "{{ consts.connector_id }}"
+    agent-id: elastic-ai-agent
     create-conversation: true
     with:
-      prompt: |
+      message: |
         Investigate the following alert and propose root causes.
-        Keep your analysis and data exploration brief.
+        Keep your analysis and data exploration brief to preserve context.
 
         <alert>
         {{ event | json }}
@@ -213,19 +205,17 @@ steps:
 
   - name: case_title
     type: ai.agent
-    agent-id: "{{ consts.agent_id }}"
-    connector-id: "{{ consts.connector_id }}"
-    conversation-id: "{{ steps.rca_analysis.output.conversation_id }}"
+    agent-id: elastic-ai-agent
     with:
-      prompt: "Based on your analysis, produce a clear case title. Output only the title."
+      conversation_id: "{{ steps.rca_analysis.output.conversation_id }}"
+      message: "Based on your analysis, produce a clear case title. Output only the title."
 
   - name: case_description
     type: ai.agent
-    agent-id: "{{ consts.agent_id }}"
-    connector-id: "{{ consts.connector_id }}"
-    conversation-id: "{{ steps.rca_analysis.output.conversation_id }}"
+    agent-id: elastic-ai-agent
     with:
-      prompt: "Based on your analysis, produce a clear case description. Output only the description."
+      conversation_id: "{{ steps.rca_analysis.output.conversation_id }}"
+      message: "Based on your analysis, produce a clear case description. Output only the description."
 
   - name: create_case
     type: cases.createCase

--- a/explore-analyze/workflows/use-cases/observability/root-cause-analysis.md
+++ b/explore-analyze/workflows/use-cases/observability/root-cause-analysis.md
@@ -25,7 +25,7 @@ If you're new to workflows, complete [Build your first workflow](/explore-analyz
 
 - **Permissions.** `All` on **Analytics > Workflows**, **Observability > Cases**, and whatever Agent Builder privilege is required to invoke agents in your space. Refer to [{{kib}} privileges](/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-privileges.md).
 - **Alerting rule.** A configured [observability alerting rule](/solutions/observability/incident-management/alerting.md) that fires on the conditions you want to auto-investigate (metric thresholds, SLO burn rate, anomaly detection, or custom query).
-- **SRE agent.** An {{agent-builder}} agent configured to investigate observability signals. The examples use `elastic-ai-agent` as a generic default; substitute the ID of the agent you've configured.
+- **SRE agent.** An {{agent-builder}} agent configured to investigate observability signals. The examples use `elastic-ai-agent` as a default. Substitute your agent ID.
 - **Attach the workflow to the rule.** After saving the workflow, attach it as an action on the alerting rule. Refer to [Alert triggers](/explore-analyze/workflows/triggers/alert-triggers.md).
 
 ## How it works [workflows-rca-how-it-works]


### PR DESCRIPTION
Closes #6392

External customer Mirko Bez reported that the published RCA workflow doesn't run when copy-pasted in 9.4. Two underlying bugs, confirmed by engineering (Marco Liberati, Sergi Massaneda):

1. ai.agent takes 'message:' inside 'with:', not 'prompt:'.
2. Liquid templating only resolves inside 'with:' for custom steps. Top-level fields (agent-id, connector-id, conversation-id) are passed through literally, so '{{ consts.agent_id }}' was never evaluated.

Applies Tinsae's recommended fix from the Slack thread:

- Replace 'prompt:' with 'message:' for the three ai.agent invocations (six occurrences across the stepper and full-workflow YAML).
- Default to a literal 'agent-id: elastic-ai-agent' across the page; drop the 'consts:' block that previously held agent_id and connector_id.
- Drop 'connector-id:' from the ai.agent examples (the agent already encodes its connector).
- Move top-level 'conversation-id:' (kebab-case) into 'with:' as 'conversation_id:' (snake_case), matching the ai.agent reference page.
- Update the SRE agent prerequisite to point at 'elastic-ai-agent' as the generic default.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ x] Yes  Cursor / Claude 4.7
- [ ] No  