### PR TITLE
Mark Prometheus remote write docs as preview for serverless

### DIFF
--- a/manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md
+++ b/manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md
@@ -2,6 +2,7 @@
 navigation_title: "Prometheus remote write endpoint"
 applies_to:
   stack: preview
+  serverless: preview
 products:
   - id: elasticsearch
 ---


### PR DESCRIPTION
The Prometheus remote write endpoint page already carried a preview designation for the stack, but the front matter did not include serverless. That meant readers on Elastic Serverless would not see the same preview labeling as on self-managed or Elastic Cloud Hosted. This change adds `serverless: preview` alongside `stack: preview` in `tsds-ingest-prometheus-remote-write.md` so the feature tier is shown consistently across deployment types.