### PR TITLE
Add .claude/worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ AGENTS.md
 CLAUDE.md
 GEMINI.md
 .cursor
+.claude/worktrees
 
 # VS code settings
 .vscode


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees` to `.gitignore` so Claude agent worktree directories don't show up as untracked files in `git status` of the main repo.

Worktrees themselves continue to function normally — git tracks them via `.git/worktrees/`, not through file tracking.

Made with [Cursor](https://cursor.com)