### PR TITLE
[Security] Add note about importing endpoint artifacts

### DIFF
--- a/solutions/security/manage-elastic-defend/blocklist.md
+++ b/solutions/security/manage-elastic-defend/blocklist.md
@@ -111,6 +111,10 @@ You can import and export blocklist entries as NDJSON files:
 - **When the list is empty**: Click **Import blocklist entries**.
 - **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import blocklist entries** or **Export blocklist entries**.
 
+::::{note}
+The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.
+::::
+
 When you import an NDJSON file, the imported blocklist entries are appended to your existing entries — existing entries are not removed or overwritten.
 
 Items are processed individually on import — per-policy items that are not visible in the current space are skipped, while the remaining items are imported.

--- a/solutions/security/manage-elastic-defend/blocklist.md
+++ b/solutions/security/manage-elastic-defend/blocklist.md
@@ -109,7 +109,7 @@ serverless: ga
 You can import and export blocklist entries as NDJSON files:
 
 - **When the list is empty**: Click **Import blocklist entries**.
-- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import blocklist entries** or **Export blocklist entries**.
+- **When the list has entries**: Click the actions menu {icon}`boxes_vertical`, then select **Import blocklist entries** or **Export blocklist entries**.
 
 ::::{note}
 The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.

--- a/solutions/security/manage-elastic-defend/elastic-endpoint-exceptions.md
+++ b/solutions/security/manage-elastic-defend/elastic-endpoint-exceptions.md
@@ -138,8 +138,12 @@ The **Endpoint exceptions** tab on the **Artifacts** page displays all {{elastic
 
 You can import and export {{elastic-endpoint}} exceptions as NDJSON files:
 
-- **When the list is empty**: click **Import {{elastic-endpoint}}**.
-- **When the list has entries**: click the actions menu ({icon}`boxes_vertical`), then select **Import {{elastic-endpoint}}** or **Export {{elastic-endpoint}}**.
+- **When the list is empty**: Click **Import Endpoint exceptions**.
+- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import Endpoint exceptions** or **Export Endpoint exceptions**.
+
+::::{note}
+The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.
+::::
 
 When you import an NDJSON file, the imported exceptions are appended to your existing exceptions — existing entries are not removed or overwritten.
 

--- a/solutions/security/manage-elastic-defend/elastic-endpoint-exceptions.md
+++ b/solutions/security/manage-elastic-defend/elastic-endpoint-exceptions.md
@@ -139,7 +139,7 @@ The **Endpoint exceptions** tab on the **Artifacts** page displays all {{elastic
 You can import and export {{elastic-endpoint}} exceptions as NDJSON files:
 
 - **When the list is empty**: Click **Import Endpoint exceptions**.
-- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import Endpoint exceptions** or **Export Endpoint exceptions**.
+- **When the list has entries**: Click the actions menu {icon}`boxes_vertical`, then select **Import Endpoint exceptions** or **Export Endpoint exceptions**.
 
 ::::{note}
 The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.

--- a/solutions/security/manage-elastic-defend/event-filters.md
+++ b/solutions/security/manage-elastic-defend/event-filters.md
@@ -130,7 +130,7 @@ serverless: ga
 You can import and export event filters as NDJSON files:
 
 - **When the list is empty**: Click **Import event filters**.
-- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import event filters** or **Export event filters**.
+- **When the list has entries**: Click the actions menu {icon}`boxes_vertical`, then select **Import event filters** or **Export event filters**.
 
 ::::{note}
 The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.

--- a/solutions/security/manage-elastic-defend/event-filters.md
+++ b/solutions/security/manage-elastic-defend/event-filters.md
@@ -129,8 +129,12 @@ serverless: ga
 
 You can import and export event filters as NDJSON files:
 
-- **When the list is empty**: click **Import event filters**.
-- **When the list has entries**: click the actions menu ({icon}`boxes_vertical`), then select **Import event filters** or **Export event filters**.
+- **When the list is empty**: Click **Import event filters**.
+- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import event filters** or **Export event filters**.
+
+::::{note}
+The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.
+::::
 
 When you import an NDJSON file, the imported event filters are appended to your existing entries — existing entries are not removed or overwritten.
 

--- a/solutions/security/manage-elastic-defend/host-isolation-exceptions.md
+++ b/solutions/security/manage-elastic-defend/host-isolation-exceptions.md
@@ -91,8 +91,12 @@ serverless: ga
 
 You can import and export host isolation exceptions as NDJSON files:
 
-- **When the list is empty**: click **Import host isolation exceptions**.
-- **When the list has entries**: click the actions menu ({icon}`boxes_vertical`), then select **Import host isolation exceptions** or **Export host isolation exceptions**.
+- **When the list is empty**: Click **Import host isolation exceptions**.
+- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import host isolation exceptions** or **Export host isolation exceptions**.
+
+::::{note}
+The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.
+::::
 
 When you import an NDJSON file, the imported host isolation exceptions are appended to your existing entries — existing entries are not removed or overwritten.
 

--- a/solutions/security/manage-elastic-defend/host-isolation-exceptions.md
+++ b/solutions/security/manage-elastic-defend/host-isolation-exceptions.md
@@ -92,7 +92,7 @@ serverless: ga
 You can import and export host isolation exceptions as NDJSON files:
 
 - **When the list is empty**: Click **Import host isolation exceptions**.
-- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import host isolation exceptions** or **Export host isolation exceptions**.
+- **When the list has entries**: Click the actions menu {icon}`boxes_vertical`, then select **Import host isolation exceptions** or **Export host isolation exceptions**.
 
 ::::{note}
 The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.

--- a/solutions/security/manage-elastic-defend/trusted-applications.md
+++ b/solutions/security/manage-elastic-defend/trusted-applications.md
@@ -174,8 +174,12 @@ serverless: ga
 
 You can import and export trusted applications as NDJSON files:
 
-- **When the list is empty**: click **Import trusted applications**.
-- **When the list has entries**: click the actions menu ({icon}`boxes_vertical`), then select **Import trusted applications** or **Export trusted applications**.
+- **When the list is empty**: Click **Import trusted applications**.
+- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import trusted applications** or **Export trusted applications**.
+
+::::{note}
+The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.
+::::
 
 When you import an NDJSON file, the imported trusted applications are appended to your existing entries — existing entries are not removed or overwritten.
 

--- a/solutions/security/manage-elastic-defend/trusted-applications.md
+++ b/solutions/security/manage-elastic-defend/trusted-applications.md
@@ -175,7 +175,7 @@ serverless: ga
 You can import and export trusted applications as NDJSON files:
 
 - **When the list is empty**: Click **Import trusted applications**.
-- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import trusted applications** or **Export trusted applications**.
+- **When the list has entries**: Click the actions menu {icon}`boxes_vertical`, then select **Import trusted applications** or **Export trusted applications**.
 
 ::::{note}
 The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.

--- a/solutions/security/manage-elastic-defend/trusted-devices.md
+++ b/solutions/security/manage-elastic-defend/trusted-devices.md
@@ -69,8 +69,12 @@ serverless: ga
 
 You can import and export trusted devices as NDJSON files:
 
-- **When the list is empty**: click **Import trusted devices**.
-- **When the list has entries**: click the actions menu ({icon}`boxes_vertical`), then select **Import trusted devices** or **Export trusted devices**.
+- **When the list is empty**: Click **Import trusted devices**.
+- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import trusted devices** or **Export trusted devices**.
+
+::::{note}
+The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.
+::::
 
 When you import an NDJSON file, the imported trusted devices are appended to your existing entries — existing entries are not removed or overwritten.
 

--- a/solutions/security/manage-elastic-defend/trusted-devices.md
+++ b/solutions/security/manage-elastic-defend/trusted-devices.md
@@ -70,7 +70,7 @@ serverless: ga
 You can import and export trusted devices as NDJSON files:
 
 - **When the list is empty**: Click **Import trusted devices**.
-- **When the list has entries**: Click the actions menu ({icon}`boxes_vertical`), then select **Import trusted devices** or **Export trusted devices**.
+- **When the list has entries**: Click the actions menu {icon}`boxes_vertical`, then select **Import trusted devices** or **Export trusted devices**.
 
 ::::{note}
 The imported file must be an NDJSON file exported from {{kib}}. Files exported from third-party software are not supported.


### PR DESCRIPTION
## Summary
Adds a note to endpoint artifact pages to clarify that only files exported from Kibana can be imported.

Related to https://github.com/elastic/docs-content/pull/6378.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

