### PR TITLE
Improve shards/indices/nodes defintions with snippets

### DIFF
--- a/deploy-manage/distributed-architecture/_snippets/shard-lucene-and-distribution.md
+++ b/deploy-manage/distributed-architecture/_snippets/shard-lucene-and-distribution.md
@@ -1,0 +1,5 @@
+<!-- Snippet used by:
+     /manage-data/data-store/index-basics.md
+     /deploy-manage/distributed-architecture/clusters-nodes-shards.md -->
+Each shard is a self-contained [Apache Lucene](https://lucene.apache.org/) index with practical limits on how much data it can efficiently manage, so splitting data across multiple shards keeps individual shards performant. Distributing those shards across cluster nodes adds horizontal scaling and redundancy.
+The right number of shards depends on your data volume, query patterns, and cluster topology — there is no single correct answer. Refer to [shard sizing and distribution recommendations](/deploy-manage/production-guidance/optimize-performance/size-shards.md#sizing-shard-guidelines) for more information and best practices.

--- a/deploy-manage/distributed-architecture/_snippets/shard-primary-replica.md
+++ b/deploy-manage/distributed-architecture/_snippets/shard-primary-replica.md
@@ -1,0 +1,7 @@
+<!-- Snippet used by:
+     /manage-data/data-store/index-basics.md
+     /deploy-manage/distributed-architecture/clusters-nodes-shards.md -->
+There are two types of shards:
+
+* **Primary shards**: Every document belongs to exactly one primary shard. The number of primary shards is fixed at index creation, either through an [index template](/manage-data/data-store/templates.md) or the [`index.number_of_shards`](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#index-number-of-shards) setting in the create index request.
+* **Replica shards**: These are copies of primary shards that provide redundancy and serve read requests. You can adjust the number of replicas at any time using the [`index.number_of_replicas`](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#dynamic-index-number-of-replicas) setting. Changing the replica count does not interrupt indexing or query operations.

--- a/deploy-manage/distributed-architecture/clusters-nodes-shards.md
+++ b/deploy-manage/distributed-architecture/clusters-nodes-shards.md
@@ -17,7 +17,7 @@ Nodes and shards are what make {{es}} distributed and scalable. These concepts a
 * **{{serverless-full}}**: You don’t need to worry about nodes, shards, or replicas. These resources are 100% automated on the serverless platform, which is designed to scale with your workload.
 ::::
 
-You can add servers (*nodes*) to a cluster to increase capacity, and {{es}} automatically distributes your data and query load across all of the available nodes.
+You can add servers (*nodes*) to a cluster to increase capacity, and {{es}} automatically distributes your data and query load across all available nodes.
 {{es}} does that in part by subdividing each index into one or more *shards*.
 
 ::::{include} _snippets/shard-lucene-and-distribution.md

--- a/deploy-manage/distributed-architecture/clusters-nodes-shards.md
+++ b/deploy-manage/distributed-architecture/clusters-nodes-shards.md
@@ -18,13 +18,12 @@ Nodes and shards are what make {{es}} distributed and scalable. These concepts a
 ::::
 
 You can add servers (*nodes*) to a cluster to increase capacity, and {{es}} automatically distributes your data and query load across all of the available nodes.
+{{es}} does that in part by subdividing each index into one or more *shards*.
 
-Elastic is able to distribute your data across nodes by subdividing an index into *shards*. Each index in {{es}} is a grouping of one or more physical shards, where each shard is a self-contained Lucene index containing a subset of the documents in the index. By distributing the documents in an index across multiple shards, and distributing those shards across multiple nodes, {{es}} increases indexing and query capacity.
+::::{include} _snippets/shard-lucene-and-distribution.md
+::::
 
-There are two types of shards: *primaries* and *replicas*. Each document in an index belongs to one primary shard. A replica shard is a copy of a primary shard. Replicas maintain redundant copies of your data across the nodes in your cluster. This protects against hardware failure and increases capacity to serve read requests like searching or retrieving a document.
-
-::::{tip}
-The number of primary shards in an index is fixed at the time that an index is created, but the number of replica shards can be changed at any time, without interrupting indexing or query operations.
+::::{include} _snippets/shard-primary-replica.md
 ::::
 
 Shard copies in your cluster are automatically balanced across nodes to provide scale and high availability. All nodes are aware of all the other nodes in the cluster and can forward client requests to the appropriate node. This allows {{es}} to distribute indexing and query load across the cluster.

--- a/manage-data/data-store/index-basics.md
+++ b/manage-data/data-store/index-basics.md
@@ -99,16 +99,17 @@ For the full list of available settings, refer to [Index settings](elasticsearch
 
 ## How an index stores data
 
-When you create an index, {{es}} doesn't store all its documents in a single location. Instead, it divides the index into one or more _shards_ and distributes those shards across the nodes in your cluster. Each shard is a self-contained [Apache Lucene](https://lucene.apache.org/) index with practical limits on how much data it can efficiently manage, so splitting data across multiple shards keeps individual shards performant. Distributing those shards across cluster nodes adds horizontal scaling and redundancy. The right number of shards depends on your data volume, query patterns, and cluster topology — there is no single correct answer. Refer to [shard sizing and distribution recommendations](/deploy-manage/production-guidance/optimize-performance/size-shards.md#sizing-shard-guidelines) for more information and best practices.
+When you create an index, {{es}} doesn't store all its documents in a single location. Instead, it divides the index into one or more _shards_ and distributes those shards across the nodes in your cluster.
+
+::::{include} /deploy-manage/distributed-architecture/_snippets/shard-lucene-and-distribution.md
+::::
 
 You don't interact with shards directly when indexing or searching. Instead, you target the index by name and {{es}} routes the operation to the appropriate shards. However, the number and size of shards you configure affects performance and stability. Refer to [Common index design decisions](#common-index-design-decisions) for more information.
 
 A shard holds a subset of the index's documents and can independently handle indexing and search operations. Inside each shard, data is organized into immutable _segments_ that are written as documents are indexed. To learn how segments affect search availability, refer to [Near real-time search](/manage-data/data-store/near-real-time-search.md).
 
-There are two types of shards:
-
-* **Primary shards**: Every document belongs to exactly one primary shard. The number of primary shards is fixed at index creation, either through an [index template](/manage-data/data-store/templates.md) or the [`index.number_of_shards`](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#index-number-of-shards) setting in the create index request.
-* **Replica shards**: Copies of primary shards that provide redundancy and serve read requests. You can adjust the number of replicas at any time using the [`index.number_of_replicas`](elasticsearch://reference/elasticsearch/index-settings/index-modules.md#dynamic-index-number-of-replicas) setting.
+::::{include} /deploy-manage/distributed-architecture/_snippets/shard-primary-replica.md
+::::
 
 By distributing shards across multiple nodes, {{es}} can scale horizontally and continue operating even when individual nodes fail. For a detailed explanation of this distributed model, refer to [](/deploy-manage/distributed-architecture.md).
 To learn how {{es}} coordinates reads and writes across primary and replica shards, refer to [Reading and writing documents](/deploy-manage/distributed-architecture/reading-and-writing-documents.md).


### PR DESCRIPTION
## Summary

Fixes #5691 The [Clusters, nodes, and shards](https://www.elastic.co/docs/deploy-manage/distributed-architecture/clusters-nodes-shards) page, the [Index fundamentals](https://www.elastic.co/docs/manage-data/data-store/index-basics) page, and probably a few other spots (that I investigated but didn't end up updating) describe these key concepts. I'm adding snippets for consistency on how we think and describe these concepts.


## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->
I used the Auto Agent mode in Cursor to inquire about potential other pages where these snippets could live, such as [Shard allocation, relocation, and recovery](https://www.elastic.co/docs/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery) or [Size your shards](https://www.elastic.co/docs/deploy-manage/production-guidance/optimize-performance/size-shards), but came to the conclusion it would be disruptive to those pages to force snippets in. In conclusion, everything else either already links to the right home or has a different job than these snippets. 
