### PR TITLE
fix(security): split-workflow pattern + same-repo guard for docs PR AI menu (SEC-043)

### DIFF
--- a/.github/workflows/docs-pr-ai-menu-collect.yml
+++ b/.github/workflows/docs-pr-ai-menu-collect.yml
@@ -1,0 +1,33 @@
+name: Docs PR AI menu (collect)
+
+# Canonical home: elastic/oblt-aw/.github/remote-workflow-template/docs/.github/workflows/docs-pr-ai-menu-collect.yml
+# Distributed automatically to repos listed in elastic/oblt-aw/config/docs/active-repositories.json.
+# Part of the split-workflow pattern: saves the PR number as an artifact so that
+# docs-pr-ai-menu.yml can post the AI PR menu comment from a trusted workflow_run context,
+# avoiding the need for pull_request_target.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  collect:
+    name: Save PR number
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr_number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -1,8 +1,9 @@
 name: Docs PR AI menu
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: ["Docs PR AI menu (collect)"]
+    types: [completed]
   issue_comment:
     types: [edited]
   workflow_dispatch:
@@ -23,7 +24,9 @@ permissions:
 jobs:
   post-menu:
     name: Post or refresh AI PR menu
-    if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
+    if: >-
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -31,10 +34,27 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: docs-pr-ai-menu-${{ github.event.pull_request.number || github.event.inputs.pull_request_number }}
+      group: docs-pr-ai-menu-${{ github.event.workflow_run.id || github.event.inputs.pull_request_number }}
       cancel-in-progress: false
 
     steps:
+      - name: Download PR number artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve pull request number
+        id: resolve-pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.inputs.pull_request_number }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
         with:
@@ -42,17 +62,16 @@ jobs:
 
       - name: Create or update AI PR menu comment
         uses: actions/github-script@v9.0.0
+        env:
+          PULL_REQUEST_NUMBER: ${{ steps.resolve-pr.outputs.number }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
-            const workflowDispatchPrNumber = context.payload.inputs?.pull_request_number;
-            const pullRequestNumber = context.eventName === 'workflow_dispatch'
-              ? Number(workflowDispatchPrNumber)
-              : context.payload.pull_request.number;
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
 
             if (!pullRequestNumber) {
-              core.setFailed('Pull request number is required for workflow_dispatch runs.');
+              core.setFailed('Pull request number is required.');
               return;
             }
 
@@ -70,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       docs_review_triggered: ${{ steps.evaluate.outputs.docs_review_triggered }}
 
@@ -86,6 +106,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_pr_ai_menu.cjs`);
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            if (pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setOutput('docs_review_triggered', 'false');
+              return;
+            }
+
             const body = context.payload.comment.body || '';
             const previousBody = context.payload.changes?.body?.from || '';
 


### PR DESCRIPTION
## Summary

- Replaces `pull_request_target` with the **split-workflow pattern** to fix the SEC-043 dangerous-trigger finding while preserving the AI PR menu for fork PRs.
- Adds a **same-repo guard** to `evaluate-trigger` so fork contributors cannot toggle the checkbox to reach the `COPILOT_GITHUB_TOKEN` path.

**How it works:**
1. **New `docs-pr-ai-menu-collect.yml`** — triggered by `pull_request` (read-only, no secrets). Saves the PR number as an artifact.
2. **`docs-pr-ai-menu.yml`** — now triggered by `workflow_run` on the collect workflow. Downloads the PR number artifact and passes it to the existing script via `process.env.PULL_REQUEST_NUMBER`. Runs in the trusted base-repo context.
3. **`evaluate-trigger`** — fetches the PR on `issue_comment` events and short-circuits with `docs_review_triggered=false` if `head.repo.full_name` doesn't match the base repo.

This mirrors the fix applied to the canonical template in elastic/oblt-aw#896.

## Test plan

- [ ] Open a same-repo PR → collect workflow runs, then main workflow posts the AI PR menu comment.
- [ ] Open a fork PR → collect workflow runs (read-only), then main workflow posts the menu on the fork PR too.
- [ ] `workflow_dispatch` with a PR number → still works.
- [ ] Fork contributor toggling the checkbox → `evaluate-trigger` short-circuits, no docs review triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)