### PR TITLE
docs(discover): document lookup index editor row display limit

### DIFF
--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -320,7 +320,7 @@ In this version, you cannot fully reset the index configuration. For example, yo
 
 ### Limitations [discover-esql-lookup-editor-limitations]
 
-The following limitations apply to the lookup index editor in Kibana. For general limitations of the `LOOKUP JOIN` command, refer to [Join data from multiple indices with LOOKUP JOIN](elasticsearch://reference/query-languages/esql/esql-lookup-join.md#_limitations).
+The following limitations apply to the lookup index editor in Kibana. For general limitations of the `LOOKUP JOIN` command, refer to [Join data from multiple indices with LOOKUP JOIN](elasticsearch://reference/query-languages/esql/esql-lookup-join.md#limitations).
 
 Row display limit
 :   The lookup index editor displays up to 1,000 rows. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index. The `LIMIT` command in your ES|QL query has no effect on the data shown here.

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -320,7 +320,7 @@ In this version, you cannot fully reset the index configuration. For example, yo
 
 ### Limitations [discover-esql-lookup-editor-limitations]
 
-The following limitations apply to the lookup index editor in Kibana. For general limitations of the `LOOKUP JOIN` command, refer to [Join data from multiple indices with LOOKUP JOIN](elasticsearch://reference/query-languages/esql/esql-lookup-join.md#limitations).
+The following limitations apply to the lookup index editor in {{kib}}. For general limitations of the `LOOKUP JOIN` command, refer to [Join data from multiple indices with LOOKUP JOIN](elasticsearch://reference/query-languages/esql/esql-lookup-join.md#limitations).
 
 Row display limit
 :   The lookup index editor displays up to 1,000 rows. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index. The `LIMIT` command in your ES|QL query has no effect on the data shown here.

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -320,8 +320,8 @@ In this version, you cannot fully reset the index configuration. For example, yo
 
 ### Limitations [discover-esql-lookup-editor-limitations]
 
-- **Row display limit:** The lookup index editor displays up to 1,000 rows. Use the search field to find specific rows when the index contains more entries: it searches the full index, not just the visible rows.
-- **`LIMIT` command:** The `LIMIT` command in your ES|QL query has no effect on the data displayed in the lookup index editor.
+Row display limit
+:   The lookup index editor displays up to 1,000 rows. The `LIMIT` command in your ES|QL query has no effect on the data shown here. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index.
 
 ## Add variable controls to your Discover queries [add-variable-control]
 ```{applies_to}

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -321,7 +321,7 @@ In this version, you cannot fully reset the index configuration. For example, yo
 ### Limitations [discover-esql-lookup-editor-limitations]
 
 Row display limit
-:   The lookup index editor displays up to 1,000 rows. The `LIMIT` command in your ES|QL query has no effect on the data shown here. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index.
+:   The lookup index editor displays up to 1,000 rows. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index. The `LIMIT` command in your ES|QL query has no effect on the data shown here.
 
 ## Add variable controls to your Discover queries [add-variable-control]
 ```{applies_to}

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -320,6 +320,8 @@ In this version, you cannot fully reset the index configuration. For example, yo
 
 ### Limitations [discover-esql-lookup-editor-limitations]
 
+The following limitations apply to the lookup index editor in Kibana. For general limitations of the `LOOKUP JOIN` command, refer to [Join data from multiple indices with LOOKUP JOIN](elasticsearch://reference/query-languages/esql/esql-lookup-join.md#_limitations).
+
 Row display limit
 :   The lookup index editor displays up to 1,000 rows. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index. The `LIMIT` command in your ES|QL query has no effect on the data shown here.
 

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -318,6 +318,11 @@ In this version, you cannot fully reset the index configuration. For example, yo
 
 :::::
 
+### Limitations [discover-esql-lookup-editor-limitations]
+
+- **Row display limit:** The lookup index editor displays up to 1,000 rows. Use the search field to find specific rows when the index contains more entries: it searches the full index, not just the visible rows.
+- **`LIMIT` command:** The `LIMIT` command in your ES|QL query has no effect on the data displayed in the lookup index editor.
+
 ## Add variable controls to your Discover queries [add-variable-control]
 ```{applies_to}
 stack: preview 9.2

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -193,7 +193,7 @@ stack: preview 9.2
 serverless: preview
 ```
 
-In **Discover**, LOOKUP JOIN commands include interactive options that let you create or edit lookup indices directly from the editor.
+In **Discover**, [`LOOKUP JOIN`](elasticsearch://reference/query-languages/esql/esql-lookup-join.md) commands include interactive options that let you create or edit lookup indices directly from the editor.
 
 :::{note}
 This section describes how to use the {{kib}} UI to create and edit lookup indices. You can also create and manage indices using the {{es}} APIs for [version 9]({{es-apis}}operation/operation-indices-create) and [Serverless]({{es-serverless-apis}}operation/operation-indices-create).

--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -323,7 +323,7 @@ In this version, you cannot fully reset the index configuration. For example, yo
 The following limitations apply to the lookup index editor in {{kib}}. For general limitations of the `LOOKUP JOIN` command, refer to [Join data from multiple indices with LOOKUP JOIN](elasticsearch://reference/query-languages/esql/esql-lookup-join.md#limitations).
 
 Row display limit
-:   The lookup index editor displays up to 1,000 rows. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index. The `LIMIT` command in your ES|QL query has no effect on the data shown here.
+:   The lookup index editor displays up to 1,000 rows. To find a specific row when the index contains more than 1,000 entries, use the search field: it searches the full index. The `LIMIT` command in your {{esql}} query has no effect on the data shown here.
 
 ## Add variable controls to your Discover queries [add-variable-control]
 ```{applies_to}


### PR DESCRIPTION
## Summary

- Adds a `### Limitations` subsection at the end of the "Create and edit lookup indices from queries" section in `try-esql.md`
- Documents the 1,000-row display cap in the lookup index editor and the search-field workaround
- Notes that the `LIMIT` command in an ES|QL query has no effect on the editor view

## Test plan

- [ ] Preview renders the new subsection correctly under the lookup section
- [ ] Anchor `[discover-esql-lookup-editor-limitations]` resolves

Made with [Cursor](https://cursor.com)