### PR TITLE
[Security] Update EA threat hunting leads docs to match current UI

### DIFF
--- a/solutions/security/advanced-entity-analytics/overview.md
+++ b/solutions/security/advanced-entity-analytics/overview.md
@@ -53,10 +53,10 @@ AI-generated leads appear at the top of the page, giving threat hunters a curate
 
 Interact with this section in the following ways:
 
-* Turn **Auto-refresh** on to automatically regenerate leads every 24 hours.
-* Click **Generate** to manually trigger a new set of leads without waiting for the next automatic refresh.
-* Click a lead or click **Hunt in Chat** to open an AI-assisted investigation session in Agent Builder.
-* Click **See all** to access and search the full list of current leads.
+* Click **Generate** or **Regenerate** to manually trigger a new set of leads without waiting for the next automatic refresh.
+* Click a lead or click **Hunt with AI** to open an AI-assisted investigation session in Agent Builder.
+* Click **See recent leads** to access and search the most recent leads.
+* Click the options menu {icon}`boxes_vertical` to select a connector and toggle **Auto-generate every 24 hours** on or off.
 
 
 ## Entity risk levels [entity-risk-levels]

--- a/solutions/security/advanced-entity-analytics/overview.md
+++ b/solutions/security/advanced-entity-analytics/overview.md
@@ -54,9 +54,10 @@ AI-generated leads appear at the top of the page, giving threat hunters a curate
 Interact with this section in the following ways:
 
 * Click **Generate** or **Regenerate** to manually trigger a new set of leads without waiting for the next automatic refresh.
-* Click a lead or click **Hunt with AI** to open an AI-assisted investigation session in Agent Builder.
 * Click **See recent leads** to access and search the most recent leads.
+* Click **Hunt with AI** to open an AI-assisted investigation session in Agent Builder without any pre-loaded lead context.
 * Click the options menu {icon}`boxes_vertical` to select a connector and toggle **Auto-generate every 24 hours** on or off.
+* Click a lead to open an AI-assisted investigation session in Agent Builder with that lead's context pre-loaded.
 
 
 ## Entity risk levels [entity-risk-levels]


### PR DESCRIPTION
## Summary
Resolves https://github.com/elastic/docs-content-internal/issues/1202. Updates the Threat hunting leads section on the Entity analytics overview page to reflect the UI changes introduced in https://github.com/elastic/kibana/pull/262457.
## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

