### PR TITLE
[agent builder] Move Elastic capabilities docs to agents overview

### DIFF
--- a/explore-analyze/ai-features/agent-builder/agent-builder-agents.md
+++ b/explore-analyze/ai-features/agent-builder/agent-builder-agents.md
@@ -87,6 +87,28 @@ The **Agents** page provides a centralized view of all your agents. From this pa
       :::
 
 
+## Elastic capabilities [elastic-capabilities]
+
+```{applies_to}
+stack: ga 9.4+
+```
+
+The **Enable Elastic capabilities** toggle controls whether an agent is automatically assigned all current and future Elastic-built [tools](tools/builtin-tools-reference.md), [skills](builtin-skills-reference.md), and plugins. The set of assigned capabilities is dynamic and grows as Elastic adds new built-in content. Disable this toggle to manage tool, skill, and plugin assignments manually.
+
+:::{image} images/elastic-capabilities.png
+:alt: Enable Elastic Capabilities toggle ON
+:width: 500px
+:::
+
+This toggle is available for all agents, both built-in and custom.
+
+### Default settings
+
+- **Built-in agents**: Elastic capabilities are **enabled** by default. Disable if you want to limit the agent to a specific set of tools and skills.
+- **Custom agents**: Elastic capabilities are **disabled** by default. Enable if you want the agent to have access to all current and future Elastic-built tools, skills, and plugins.
+
+To review which tools and skills are active, open the agent's **Tools** or **Skills** tab after enabling the toggle. Elastic-provided items are marked with a lock icon.
+
 ## Agents API
 
 The Agents API enables programmatic management of both built-in and custom agents.

--- a/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-agents-reference.md
@@ -22,6 +22,8 @@ The **Elastic AI Agent** is the default general-purpose agent. It is designed to
 
 The Elastic AI Agent is a standard persisted agent that is space-aware. A separate instance is created automatically in each [{{kib}} space](/deploy-manage/manage-spaces.md) when first accessed, and each instance can be customized independently: change its instructions, assign [skills](builtin-skills-reference.md) and [tools](./tools/builtin-tools-reference.md), or clone it as a starting point for a new agent.
 
+[Elastic capabilities](agent-builder-agents.md#elastic-capabilities) are **enabled** by default for the Elastic AI Agent, which means it is automatically assigned all Elastic-built [tools](./tools/builtin-tools-reference.md), [skills](builtin-skills-reference.md), and plugins.
+
 :::{note}
 In 9.2  and 9.3, the Elastic AI Agent cannot be modified or deleted. To customize it, clone it and [create a custom agent](custom-agents.md#create-a-new-agent).
 :::

--- a/explore-analyze/ai-features/agent-builder/custom-agents.md
+++ b/explore-analyze/ai-features/agent-builder/custom-agents.md
@@ -83,15 +83,14 @@ Configure the essential agent settings in the **Settings** tab:
 
 :::::
 
-:::::{step} Enable Elastic capabilities
-:anchor: create-custom-agent-enable-elastic-capabilities
+:::::{step} Enable Elastic capabilities (optional)
 ```{applies_to}
 stack: ga 9.4+
 ```
 
-Use the **Enable Elastic Capabilities** toggle to activate built-in Elastic tools and skills for your agent. This toggle is disabled by default.
+Optionally enable the **Enable Elastic capabilities** toggle to automatically assign all Elastic-built [tools](tools/builtin-tools-reference.md), [skills](builtin-skills-reference.md), and plugins to your agent. This toggle is disabled by default for custom agents.
 
-For more information, refer to [Enable Elastic Capabilities](#enable-elastic-capabilities).
+For more information, refer to [Elastic capabilities](agent-builder-agents.md#elastic-capabilities).
 
 :::::
 
@@ -201,23 +200,6 @@ Control who can view and edit your agent by configuring its visibility. To chang
 :::{image} images/agent-visibility-levels.png
 :alt: Agent visibility dropdown showing Public, Shared, and Private.
 :width: 700px
-:::
-
-## Enable Elastic Capabilities [enable-elastic-capabilities]
-
-```{applies_to}
-stack: ga 9.4+
-```
-
-When the **Enable Elastic Capabilities** toggle is enabled, it automatically assigns all current and future Elastic-built skills, plugins, and tools to the agent. The set of assigned capabilities is dynamic and grows as Elastic adds new built-in content.
-
-To review which skills and tools are active, open the agent's **Skills** or **Tools** tab after enabling the toggle. Elastic-provided items are marked with a lock icon.
-
-Disable this toggle to manage skill, plugin, and tool assignments manually.
-
-:::{image} images/elastic-capabilities.png
-:alt: Enable Elastic Capabilities toggle ON
-:width: 500px
 :::
 
 ## Best practices for custom agents

--- a/explore-analyze/ai-features/agent-builder/get-started.md
+++ b/explore-analyze/ai-features/agent-builder/get-started.md
@@ -152,7 +152,7 @@ On {{ech}} and {{serverless-full}}, {{agent-builder}} comes with preconfigured m
 
 After you test the default `Elastic AI Agent`, create a [custom skill](custom-skills.md) for a specific workflow. Skills package task-specific instructions, context, and the tools needed to complete the workflow.
 
-Add [tools](tools.md) when the skill needs to retrieve data, run queries, call APIs, or take action. Create a [custom agent](custom-agents.md#create-a-new-agent) when you need a distinct persona, system prompt, model configuration, or set of enabled skills. You don't need a separate agent for every workflow: a single agent can use skill descriptions to choose the right skills and tools for the user's request.
+Add [tools](tools.md) when the skill needs to retrieve data, run queries, call APIs, or take action. Create a [custom agent](custom-agents.md#create-a-new-agent) when you need a distinct persona, system prompt, model configuration, or set of enabled skills. You don't need a separate agent for every workflow: a single agent can use skill descriptions to choose the right skills and tools for the user's request. Note that custom agents don't include [Elastic capabilities](agent-builder-agents.md#elastic-capabilities) by default — enable the toggle to assign all Elastic-built tools, skills, and plugins automatically.
 
 To build programmatically, try the [{{agent-builder}} API tutorial](agent-builder-api-tutorial.md) or explore the [Kibana APIs](programmatic-access.md).
 

--- a/explore-analyze/ai-features/agent-builder/glossary.md
+++ b/explore-analyze/ai-features/agent-builder/glossary.md
@@ -162,7 +162,7 @@ Elastic Managed LLM
 
 $$$enable-elastic-capabilities$$$
 Elastic capabilities {applies_to}`stack: ga 9.4+`
-:   The toggle on an agent's **Settings** tab that opts the agent in to all current and future Elastic-built [tools](tools/builtin-tools-reference.md), [skills](builtin-skills-reference.md), and plugins. Enabled by default for built-in agents; disabled by default for custom agents. See [](agent-builder-agents.md#elastic-capabilities).
+:   The toggle on an agent's **Settings** tab that opts the agent in to all current and future Elastic-built [tools](tools/builtin-tools-reference.md), [skills](builtin-skills-reference.md), and plugins. Enabled by default for built-in agents, disabled by default for custom agents. See [](agent-builder-agents.md#elastic-capabilities).
 
 $$$entity-store$$$
 Entity store

--- a/explore-analyze/ai-features/agent-builder/glossary.md
+++ b/explore-analyze/ai-features/agent-builder/glossary.md
@@ -161,8 +161,8 @@ Elastic Managed LLM
 :   A pre-configured LLM provided by Elastic and powered by the Elastic Inference Service. On {{ech}} and {{serverless-full}}, an Elastic Managed LLM is available out of the box, so {{agent-builder}} works with no additional setup. See [](models.md#default-model-configuration).
 
 $$$enable-elastic-capabilities$$$
-Enable Elastic Capabilities {applies_to}`stack: ga 9.4+`
-:   The toggle on a custom agent's **Settings** tab that opts the agent in to all current and future Elastic-built skills, plugins, and tools. The toggle is off by default. See [](custom-agents.md#enable-elastic-capabilities).
+Elastic capabilities {applies_to}`stack: ga 9.4+`
+:   The toggle on an agent's **Settings** tab that opts the agent in to all current and future Elastic-built [tools](tools/builtin-tools-reference.md), [skills](builtin-skills-reference.md), and plugins. Enabled by default for built-in agents; disabled by default for custom agents. See [](agent-builder-agents.md#elastic-capabilities).
 
 $$$entity-store$$$
 Entity store

--- a/redirects.yml
+++ b/redirects.yml
@@ -887,3 +887,11 @@ redirects:
           'add-inference-endpoints': 'add-endpoint'
           'inference-endpoints': 'manage-models'
           'create-custom-eis': 'add-endpoint'
+
+  # Elastic capabilities section moved from custom-agents to agents overview
+  'explore-analyze/ai-features/agent-builder/custom-agents.md':
+    to: 'explore-analyze/ai-features/agent-builder/custom-agents.md'
+    many:
+      - to: 'explore-analyze/ai-features/agent-builder/agent-builder-agents.md'
+        anchors:
+          'enable-elastic-capabilities': 'elastic-capabilities'

--- a/redirects.yml
+++ b/redirects.yml
@@ -888,7 +888,7 @@ redirects:
           'inference-endpoints': 'manage-models'
           'create-custom-eis': 'add-endpoint'
 
-  # Elastic capabilities section moved from custom-agents to agents overview
+  # https://github.com/elastic/docs-content/pull/6582
   'explore-analyze/ai-features/agent-builder/custom-agents.md':
     to: 'explore-analyze/ai-features/agent-builder/custom-agents.md'
     many:


### PR DESCRIPTION
## Summary

The Elastic capabilities toggle docs were misplaced buried under custom agents and incomplete. This PR fixes that by:

- Moving the **Elastic capabilities** section from the custom agents page to the **agents overview** page, since the toggle applies to all agents (built-in and custom) with different defaults
- Clarifying that built-in agents have it **enabled** by default, custom agents have it **disabled** by default
- Adding links to the [built-in tools reference](https://docs.elastic.co/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference) and [built-in skills reference](https://docs.elastic.co/explore-analyze/ai-features/agent-builder/builtin-skills-reference) pages
- Adding mentions and cross-links from the built-in agents, custom agents, get-started, and glossary pages

### Follow-up

A follow-up PR in `elastic/kibana` will add a doc link from the product UI and update the toggle's UI copy to reduce confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

h/t @wandergeek @Mpdreamz 