### PR TITLE
Fixes incorrect `typeKey` values in cases.addObservables workflow docs

### DIFF
--- a/explore-analyze/workflows/steps/cases.md
+++ b/explore-analyze/workflows/steps/cases.md
@@ -510,11 +510,11 @@ Add observables (indicators of compromise such as IPs, file hashes, domains, or 
       - typeKey: "observable-type-ipv4"
         value: "{{ event.alerts[0].source.ip }}"
         description: "Source of malicious activity"
-      - typeKey: "observable-type-hash-sha256"
+      - typeKey: "observable-type-file-hash"
         value: "{{ event.alerts[0].file.hash.sha256 }}"
 ```
 
-The `typeKey` must match one of the built-in observable type keys (for example, `observable-type-ipv4`, `observable-type-ipv6`, `observable-type-url`, `observable-type-domain`, `observable-type-hash-sha256`, `observable-type-hash-md5`).
+The `typeKey` must match one of the built-in observable type keys (for example, `observable-type-ipv4`, `observable-type-ipv6`, `observable-type-url`, `observable-type-domain`, `observable-type-file-hash`). Use `observable-type-file-hash` for all hash types (MD5, SHA-1, SHA-256, and so on); the algorithm (for example, `sha256`) describes the hash subtype, not the top-level type key.
 
 ### `cases.getAllAttachments` [cases-getallattachments]
 

--- a/explore-analyze/workflows/steps/cases.md
+++ b/explore-analyze/workflows/steps/cases.md
@@ -514,7 +514,7 @@ Add observables (indicators of compromise such as IPs, file hashes, domains, or 
         value: "{{ event.alerts[0].file.hash.sha256 }}"
 ```
 
-The `typeKey` must match one of the built-in observable type keys (for example, `observable-type-ipv4`, `observable-type-ipv6`, `observable-type-url`, `observable-type-domain`, `observable-type-file-hash`). Use `observable-type-file-hash` for all hash types (MD5, SHA-1, SHA-256, and so on); the algorithm (for example, `sha256`) describes the hash subtype, not the top-level type key.
+The `typeKey` must match one of the built-in observable type keys: `observable-type-ipv4`, `observable-type-ipv6`, `observable-type-url`, `observable-type-domain`, or `observable-type-file-hash`. Use `observable-type-file-hash` for all hash algorithms (MD5, SHA-1, SHA-256, and so on).
 
 ### `cases.getAllAttachments` [cases-getallattachments]
 

--- a/explore-analyze/workflows/use-cases/security/automate-security-operations/alert-triage-with-case.md
+++ b/explore-analyze/workflows/use-cases/security/automate-security-operations/alert-triage-with-case.md
@@ -140,7 +140,7 @@ Link the alert that triggered the workflow with `cases.addAlerts`, then attach t
   with:
     case_id: "{{ steps.create_case.output.case.id }}"
     observables:
-      - typeKey: "observable-type-hash-sha256"
+      - typeKey: "observable-type-file-hash"
         value: "{{ event.alerts[0].file.hash.sha256 }}"
       - typeKey: "observable-type-ipv4"
         value: "{{ event.alerts[0].source.ip }}"
@@ -265,7 +265,7 @@ steps:
         with:
           case_id: "{{ steps.create_case.output.case.id }}"
           observables:
-            - typeKey: "observable-type-hash-sha256"
+            - typeKey: "observable-type-file-hash"
               value: "{{ event.alerts[0].file.hash.sha256 }}"
             - typeKey: "observable-type-ipv4"
               value: "{{ event.alerts[0].source.ip }}"


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Fixes https://github.com/elastic/docs-content/issues/65.

The docs listed the wrong type keys for file hashes. To fix this, I replaced the incorrect hash-specific keys (`observable-type-hash-sha256`, `observable-type-hash-md5`) with the correct one (`observable-type-file-hash`) in all code examples and the accepted-values list.

**Updated pages**

- `explore-analyze/workflows/steps/cases.md`
- `explore-analyze/workflows/use-cases/security/automate-security-operations/alert-triage-with-case.md`

### Previews

https://github.com/elastic/docs-content/pull/6596#issuecomment-4502877311


## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes - Cursor + Auto
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

