### PR TITLE
Add ES|QL note to runtime fields docs

### DIFF
--- a/manage-data/data-store/mapping/runtime-fields.md
+++ b/manage-data/data-store/mapping/runtime-fields.md
@@ -61,7 +61,7 @@ Queries against runtime fields are considered expensive. If [`search.allow_expen
 
 ## Runtime fields in {{esql}} [runtime-esql]
 
-{{esql}} treats runtime fields defined in the index mapping like regular mapped fields. However, {{esql}} does not support defining new runtime fields at search time. To create computed columns at query time, use the [`EVAL`](elasticsearch://reference/query-languages/esql/commands/eval.md) command instead.
+In {{esql}}, runtime fields defined in the index mapping function as regular mapped fields. However, {{esql}} does not support defining new runtime fields at search time. To create computed columns at query time, use the [`EVAL`](elasticsearch://reference/query-languages/esql/commands/eval.md) command instead.
 
 Runtime fields are also different from unmapped fields. For information on how {{esql}} handles fields that don't exist in the mapping, refer to [`SET unmapped_fields`](elasticsearch://reference/query-languages/esql/commands/set.md#esql-unmapped_fields).
 

--- a/manage-data/data-store/mapping/runtime-fields.md
+++ b/manage-data/data-store/mapping/runtime-fields.md
@@ -59,6 +59,13 @@ Queries against runtime fields are considered expensive. If [`search.allow_expen
 ::::
 
 
+## Runtime fields in {{esql}} [runtime-esql]
+
+{{esql}} treats runtime fields defined in the index mapping like regular mapped fields. However, {{esql}} does not support defining new runtime fields at search time. To create computed columns at query time, use the [`EVAL`](elasticsearch://reference/query-languages/esql/commands/eval.md) command instead.
+
+Runtime fields are also different from unmapped fields. For information on how {{esql}} handles fields that don't exist in the mapping, refer to [`SET unmapped_fields`](elasticsearch://reference/query-languages/esql/commands/set.md#esql-unmapped_fields).
+
+
 
 
 


### PR DESCRIPTION
## Summary
- Adds a "Runtime fields in ES|QL" section to the runtime fields page
- Clarifies that ES|QL respects mapping-defined runtime fields but does not support defining new runtime fields at search time, pointing to `EVAL` as an alternative
- Distinguishes runtime fields from unmapped fields, linking to `SET unmapped_fields`

Companion to an upcoming elasticsearch repo PR that updates the ES|QL docs (EVAL, limitations, and the generated `unmapped_fields` setting description).