### PR TITLE
Clarify URL used to test Elastic Cloud SSO 

### DIFF
--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -137,6 +137,7 @@ Add the information that you collected to {{ecloud}}.
 The **Enforce SAML SSO** option is disabled by default. You must verify your SSO configuration by logging in using SSO to enable this option.
 ::::
 
+$$$sp-details$$$
 If your configuration is valid, the following details of the service provider (SP) will be displayed:
 
 * **SSO Login URL**: The URL that your organization members can use to log in to your organization using your IdP.
@@ -160,7 +161,7 @@ Additional details that you might want to use in your IdP configuration, such as
 
 ### Step 3: Test SSO [ec_test_sso]
 
-After you register the IdP in {{ecloud}} and configure your IdP, you can test authentication. To begin SSO, open the [SSO Login URL provided by {{ecloud}}](#ec_register_the_idp_with_ecloud) in an incognito browsing session. If everything is configured correctly, you should be redirected to your IdP for authentication and then redirected back to {{ecloud}} signed in.
+After you register the IdP in {{ecloud}} and configure your IdP, you can test authentication. To begin SSO, open the [SSO Login URL provided by {{ecloud}}](#sp-details) in an incognito browsing session. If everything is configured correctly, you should be redirected to your IdP for authentication and then redirected back to {{ecloud}} signed in.
 
 Users who are not a member of the {{ecloud}} organization can authenticate with your IdP to automatically create an {{ecloud}} account provided that their email matches the claimed domain.
 

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -137,7 +137,6 @@ Add the information that you collected to {{ecloud}}.
 The **Enforce SAML SSO** option is disabled by default. You must verify your SSO configuration by logging in using SSO to enable this option.
 ::::
 
-
 If your configuration is valid, the following details of the service provider (SP) will be displayed:
 
 * **SSO Login URL**: The URL that your organization members can use to log in to your organization using your IdP.
@@ -161,7 +160,7 @@ Additional details that you might want to use in your IdP configuration, such as
 
 ### Step 3: Test SSO [ec_test_sso]
 
-After you register the IdP in {{ecloud}} and configure your IdP, you can test authentication. To begin SSO, open the identity provider SSO URL in an incognito browsing session. If everything is configured correctly, you should be redirected to your IdP for authentication and then redirected back to {{ecloud}} signed in.
+After you register the IdP in {{ecloud}} and configure your IdP, you can test authentication. To begin SSO, open the [SSO Login URL provided by {{ecloud}}](#ec_register_the_idp_with_ecloud) in an incognito browsing session. If everything is configured correctly, you should be redirected to your IdP for authentication and then redirected back to {{ecloud}} signed in.
 
 Users who are not a member of the {{ecloud}} organization can authenticate with your IdP to automatically create an {{ecloud}} account provided that their email matches the claimed domain.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary

Clarifies the correct URL to use when testing your SSO config. Links up to the section where you retrieve your SP details

Info from [slack](https://elastic.slack.com/archives/C063NHTKUFP/p1779257697557019) (internal)

<img width="622" height="138" alt="image" src="https://github.com/user-attachments/assets/15154762-50d5-4f47-b9dc-6ee35694ca70" />

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

