### PR TITLE
Fix FedRAMP TLS limitations to reflect TLS 1.2 edge

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/fedramp.md
+++ b/deploy-manage/deploy/elastic-cloud/fedramp.md
@@ -63,14 +63,13 @@ There are some limitations to note for using the FedRAMP authorized Cloud offeri
 
 **Applies to:** {{fedramp-mod}}, {{fedramp-high}}
 
-% Copied from https://www.elastic.co/docs/deploy-manage/security/fips-ingest#ingest-limitations-tls
-% I'll single-source this if the finalized content is identical to what we have in the security section.
+% Based on https://www.elastic.co/docs/deploy-manage/security/fips-ingest#ingest-limitations-tls
+% FedRAMP cloud edge TLS differs: client connections terminate at TLS v1.2 only in FIPS mode.
 
 Only FIPS 140-2 compliant TLS protocols, ciphers, and curve types are allowed to be used as listed below.
-* The supported TLS versions are `TLS v1.2` and `TLS v1.3`.
+* The supported TLS version for client connections is `TLS v1.2`.
 * The supported cipher suites are:
   * `TLS v1.2`: `ECDHE-RSA-AES-128-GCM-SHA256`, `ECDHE-RSA-AES-256-GCM-SHA384`, `ECDHE-ECDSA-AES-128-GCM-SHA256`, `ECDHE-ECDSA-AES-256-GCM-SHA384`
-  * `TLS v1.3`: `TLS-AES-128-GCM-SHA256`, `TLS-AES-256-GCM-SHA384`
 * The supported curve types are `P-256`, `P-384` and `P-521`.
 
 Support for encrypted private keys is not available, as the cryptographic modules used for decrypting password protected keys are not FIPS validated. If an output or any other component with an SSL key that is password protected is configured, the components will fail to load the key. When running in FIPS mode, you must provide non-encrypted keys.


### PR DESCRIPTION
## Summary

- Corrects the TLS limitations section in `fedramp.md` to state that client connections to FedRAMP deployments use **TLS v1.2 only**, matching the FIPS-mode route-server configuration in GovCloud (`max_tls_version: TLSv1.2`).
- Removes the incorrect TLS v1.3 version and cipher suite bullets for the cloud edge path.
- Adds a brief source comment noting this section intentionally differs from the ingest FIPS TLS limitations page.

## Test plan

- [ ] Docs build / preview (if required by docs-content CI)
- [ ] Verify rendered page reads correctly for FedRAMP Moderate and High

Made with [Cursor](https://cursor.com)