### PR TITLE
remove inline applies_to on lightweight xrefs

### DIFF
--- a/deploy-manage/monitor/query-activity.md
+++ b/deploy-manage/monitor/query-activity.md
@@ -15,7 +15,7 @@ products:
 The **Query activity** page in {{kib}} gives you a real-time view of all search work running in your {{es}} cluster. Use it to find long-running or resource-intensive queries, trace them back to their source, and cancel them when needed.
 
 Query activity surfaces all in-flight search requests in your cluster, including ES|QL, DSL, EQL, and SQL queries, multi-search requests, and background searches.
-It shows only what is currently running. For historical query data, use {applies_to}`stack: preview 9.4` {applies_to}`serverless: unavailable` [query logs](/deploy-manage/monitor/logging-configuration/query-logs.md) or [AutoOps](/deploy-manage/monitor/autoops.md).
+It shows only what is currently running. For historical query data, use [query logs](/deploy-manage/monitor/logging-configuration/query-logs.md) or [AutoOps](/deploy-manage/monitor/autoops.md).
 
 :::{image} /deploy-manage/images/query-activity.png
 :alt: The Query activity page showing a list of running queries with their task ID, query type, source, start time, and run time
@@ -128,6 +128,6 @@ To change this threshold:
 
 ## Related pages
 
-- {applies_to}`stack: preview 9.4` {applies_to}`serverless: unavailable` [Query logging](/deploy-manage/monitor/logging-configuration/query-logs.md)
-- [Slow query and index logging](/deploy-manage/monitor/logging-configuration/slow-logs.md)
-- [Tune for search speed](/deploy-manage/production-guidance/optimize-performance/search-speed.md)
+- [](/deploy-manage/monitor/logging-configuration/query-logs.md)
+- [](/deploy-manage/monitor/logging-configuration/slow-logs.md)
+- [](/deploy-manage/production-guidance/optimize-performance/search-speed.md)


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Pulling back on some overly excited applies_to tagging inline. these types of tags should be used at the bullet level, and avoided mid-sentence. also should avoid when the applicability info is less important (e.g. lightweight xrefs between pages - target page can communicate applicability)

also removed some manual titles on page xrefs to let the autotitle do its job

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

