### PR TITLE
[IAM][BYOIdP] Remove note about empty groups preserving roles

### DIFF
--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -218,8 +218,8 @@ To ensure continuous access and control over your organization settings, the fir
 To allow for role mapping verification, SSO must be configured and enabled for you to create role mappings.
 
 ::::{note}
-* If [SSO enforcement](#enforce-sso) is not enabled, user roles might not be consistent with your role mapping and additional manual role assignment might be needed. Roles manually assigned using the {{ecloud}} Console are overwritten by the role mapping when the user logs in using SSO.
-* If the `groups` attribute is not included in the SAML response, the user will keep whatever groups they were last assigned by the IdP. If you want to remove all groups for a user as part of an offboarding process, instead unassign the user from the {{ecloud}} application.
+* If [SSO enforcement](#enforce-sso) is not enabled, organization member roles might not be consistent with your role mapping and additional manual role assignment might be needed.
+* Roles manually assigned to a member using the {{ecloud}} Console are overwritten by the role mapping every time the member logs in using SSO.
 ::::
 
 ### Create a role mapping


### PR DESCRIPTION
Move overwriting of manually assigned roles to own bullet for emphasis

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Removes the note about member roles being preserved if the SAML `groups` attribute is empty or missing. That's a limitation we addressed in https://github.com/elastic/cp-iam-team/issues/1631

Moves the sentence about the overwriting of manually assigned roles when users sign in via SSO with role mappings to its own bullet point for emphasis since questions about it come up fairly frequently.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

