### PR TITLE
docs(style-guide): italicize for in conjunction list

### DIFF
--- a/contribute-docs/style-guide/grammar-spelling.md
+++ b/contribute-docs/style-guide/grammar-spelling.md
@@ -225,7 +225,7 @@ Use commas:
 * For additional context, alert events are stored in hidden Elasticsearch indices.
 :::
 
-* To join independent clauses with a coordinating conjunction (*and*, *but*, *or*, *nor*, *fo*r, *so*, or *yet*).
+* To join independent clauses with a coordinating conjunction (*and*, *but*, *or*, *nor*, *for*, *so*, or *yet*).
 
 :::{dropdown} Examples
 * A case can have multiple connectors, but only one connector can be selected at a time.
@@ -248,7 +248,7 @@ Use commas:
 
 ❌ Don't use commas:
 
-* When an independent clause and a dependent clause are separated by a coordinating conjunction (*and*, *but*, *or*, *nor*, *fo*r, *so*, or *yet*).
+* When an independent clause and a dependent clause are separated by a coordinating conjunction (*and*, *but*, *or*, *nor*, *for*, *so*, or *yet*).
 
 :::{dropdown} Examples
 ❌ **Don't**: The rule runs every 5 minutes, but analyzes the documents added to indices during the last 6 minutes.


### PR DESCRIPTION
## Summary

Closes #6650. The two grammar-spelling style guide lines that list coordinating conjunctions (`contribute-docs/style-guide/grammar-spelling.md:228` and `:251`) wrapped each conjunction in italics: `*and*, *but*, *or*, *nor*, *fo*r, *so*, or *yet*`. The "for" entry put the closing asterisk inside the word instead of after it, so the rendered output italicized just "fo" and left "r" plain. Move the closing asterisk to after `r` so the rendered word matches the other six italicized conjunctions in the same sentence.

## Why this matters

The codespell sweep (#6650, generated by Elastic's docs typos sweep agent) flagged "fo" on those two lines as a misspelling, suggesting "for". The codespell-suggested rewrite (`*fo*r` -> `for`) would correct the spelling but drop the italic formatting that's intentional for the other conjunctions in the list. The correct fix is in the formatting, not the spelling: `*fo*r` -> `*for*`. Both lines render identical English text afterward, and codespell no longer sees a bare "fo" token.

## Changes

- `contribute-docs/style-guide/grammar-spelling.md:228` - `*fo*r` -> `*for*`.
- `contribute-docs/style-guide/grammar-spelling.md:251` - same.

No other content touched.

## How to test

```
$ grep -n "\*fo\*r" contribute-docs/style-guide/grammar-spelling.md
(empty)
$ grep -n "\*for\*, \*so\*" contribute-docs/style-guide/grammar-spelling.md
228:* To join independent clauses with a coordinating conjunction (*and*, *but*, *or*, *nor*, *for*, *so*, or *yet*).
251:* When an independent clause and a dependent clause are separated by a coordinating conjunction (*and*, *but*, *or*, *nor*, *for*, *so*, or *yet*).
```

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool(s) and model(s) used: Claude (Anthropic).

Fixes #6650
