### PR TITLE
Redirect unlisted anchors back to old page

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/aws-marketplace.md
+++ b/deploy-manage/deploy/elastic-cloud/aws-marketplace.md
@@ -5,11 +5,12 @@ applies_to:
   deployment:
     ess: ga
   serverless: ga
+navigation_title: AWS Marketplace
 products:
   - id: cloud-hosted
 ---
 
-# AWS Marketplace [ec-billing-aws]
+# {{ecloud}} from AWS Marketplace [ec-billing-aws]
 
 7-Day Free Trial Sign-Up: On the [{{ecloud}} AWS marketplace page](https://aws.amazon.com/marketplace/pp/prodview-voru33wi6xs7k), click **View purchase options**, sign into your AWS account, then start using {{ecloud}}.
 

--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-logs-metrics.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-logs-metrics.md
@@ -14,7 +14,7 @@ navigation_title: Logs and metrics
 $$$ec-azure-logs-and-metrics$$$
 $$$azure-integration-monitor$$$
 
-The {{ecloud}} Azure Native Service simplifies logging for Azure services with the {{stack}}. This integration supports:
+The [{{ecloud}} Azure Native Service](/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md) simplifies logging for Azure services with the {{stack}}. This integration supports:
 
 * Azure subscription logs
 * Azure resources logs (check [Supported categories for Azure Resource Logs](https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-categories?WT.mc_id=Portal-Azure_Marketplace_Elastic) for examples)

--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-troubleshooting.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-troubleshooting.md
@@ -13,7 +13,7 @@ navigation_title: Troubleshooting
 
 $$$ec-azure-integration-troubleshooting$$$
 
-This page describes some scenarios that you might experience onboarding to {{ecloud}} through the Azure portal. If you're running into issues, you can always [get support](#azure-integration-support).
+This page describes some scenarios that you might experience [onboarding to {{ecloud}} through the Azure portal](/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md). If you're running into issues, you can always [get support](#azure-integration-support).
 
 
 ## Authorization errors

--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
@@ -5,12 +5,13 @@ applies_to:
   deployment:
     ess: ga
   serverless: ga
+navigation_title: Azure Native Service
 products:
   - id: cloud-hosted
   - id: cloud-serverless
 ---
 
-# Azure Native Service [ec-azure-marketplace-native]
+# {{ecloud}} Azure Native Service [ec-azure-marketplace-native]
 
 The {{ecloud}} Azure Native Service allows you to deploy managed instances of the {{stack}} directly in Azure, through the Microsoft Marketplace. The service brings the following benefits:
 

--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
@@ -270,3 +270,6 @@ Delete the deployment directly from the Azure portal. The delete operation perfo
 $$$azure-integration-delete-resource-group$$$
 If you delete an Azure Resource Group containing {{ecloud}} resources, the latter will be deleted automatically. However, you should not delete the Azure Resource Group containing the first deployment or project that you created. The usage associated with any other Elastic deployment created outside of the first resource group will continue to get reported and charged against this resource group. If you want to stop all charges to this Resource Group, you should delete the individual deployments.
 
+### Troubleshooting
+
+To troubleshoot issues with the Azure Native Service, refer to [](azure-native-isv-service-troubleshooting.md).

--- a/deploy-manage/deploy/elastic-cloud/google-cloud-platform-marketplace.md
+++ b/deploy-manage/deploy/elastic-cloud/google-cloud-platform-marketplace.md
@@ -5,12 +5,13 @@ applies_to:
   deployment:
     ess: ga
   serverless: ga
+navigation_title: Google Cloud Platform Marketplace
 products:
   - id: cloud-hosted
   - id: cloud-serverless
 ---
 
-# Google Cloud Platform Marketplace [ec-billing-gcp]
+# {{ecloud}} from Google Cloud Platform Marketplace [ec-billing-gcp]
 
 Subscribe to {{ecloud}} directly from the Google Cloud Platform (GCP). You then have the convenience of viewing your {{ecloud}} subscription as part of your GCP bill, and you do not have to supply any additional credit card information to Elastic. Your investment in Elastic draws against your cloud purchase commitment.
 

--- a/redirects.yml
+++ b/redirects.yml
@@ -291,7 +291,7 @@ redirects:
         'ec-restrictions-traffic-filters-kibana-sso': 'ec-restrictions-network-security-kibana-sso'
         'ec-restrictions-traffic-filters-watcher': 'ec-restrictions-network-security-watcher'
   'deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md':
-    anchors: {}
+    to: 'deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md'
     many:
       - to: 'deploy-manage/deploy/elastic-cloud/azure-native-isv-service-troubleshooting.md'
         anchors:


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
I split this page apart but left the old parent in place. When I redirected the moved anchors, I forgot to list the parent page as the fallback. This PR fixes that.

Validated that we use this pattern successfully elsewhere in the redirects file

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [X] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: cursor auto


