### PR TITLE
docs: document Lens Metric style templates (#6477)

### DIFF
--- a/explore-analyze/visualize/charts/metric-charts.md
+++ b/explore-analyze/visualize/charts/metric-charts.md
@@ -512,6 +512,16 @@ serverless: ga
 ```
 When creating or editing a visualization, you can customize several appearance options. To do that, look for the {icon}`brush` icon.
 
+**Style template** {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga`
+:   Apply a preset that sets the position and alignment of the primary metric, title, and secondary value in one step. Choose between:
+
+    - **Top**: Primary value at the top, title and secondary value below. All elements are left-aligned.
+    - **Middle**: Title at the top, primary value centered, secondary value below. All elements are center-aligned.
+    - **Bottom**: Title and secondary value at the top, primary value at the bottom. The primary and secondary values are right-aligned. New metric visualizations use this template by default.
+    - **Custom**: Keep your individual appearance settings. Select **Custom** to expand the **Details** section and adjust each control independently. Lens switches to **Custom** automatically when your settings no longer match any preset.
+
+    The detailed appearance controls described below are grouped under a **Details** accordion. Select **Details** to expand the section and adjust individual settings, or select a different template to apply its preset values to all controls at once.
+
 **Primary metric**
 :   Define the formatting of the primary metric in terms of **Position**, **Alignment**, and **Font size**.
 

--- a/explore-analyze/visualize/charts/metric-charts.md
+++ b/explore-analyze/visualize/charts/metric-charts.md
@@ -518,9 +518,9 @@ When creating or editing a visualization, you can customize several appearance o
     - **Top**: Primary value at the top, title and secondary value below. All elements are left-aligned.
     - **Middle**: Title at the top, primary value centered, secondary value below. All elements are center-aligned.
     - **Bottom**: Title and secondary value at the top, primary value at the bottom. The primary and secondary values are right-aligned. New metric visualizations use this template by default.
-    - **Custom**: Keep your individual appearance settings. Select **Custom** to expand the **Details** section and adjust each control independently. Lens switches to **Custom** automatically when your settings no longer match any preset.
+    - **Custom**: Keep your individual appearance settings. Select **Custom**, then expand the **Details** section and adjust each control independently. Lens switches to **Custom** automatically when your settings no longer match any preset.
 
-    The detailed appearance controls described below are grouped under a **Details** accordion. Select **Details** to expand the section and adjust individual settings, or select a different template to apply its preset values to all controls at once.
+    The detailed appearance controls described in the next section are grouped under a **Details** accordion. Select **Details** to expand the section and adjust individual settings, or select a different template to apply its preset values to all styling settings at once.
 
 **Primary metric**
 :   Define the formatting of the primary metric in terms of **Position**, **Alignment**, and **Font size**.

--- a/explore-analyze/visualize/charts/metric-charts.md
+++ b/explore-analyze/visualize/charts/metric-charts.md
@@ -515,10 +515,10 @@ When creating or editing a visualization, you can customize several appearance o
 **Style template** {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga`
 :   Apply a preset that sets the position and alignment of the primary metric, title, and secondary value in one step. Choose between:
 
-    - **Top**: Primary value at the top, title and secondary value below. All elements are left-aligned.
+    - **Top**: Primary value and title at the top, secondary value below. All elements are left-aligned.
     - **Middle**: Title at the top, primary value centered, secondary value below. All elements are center-aligned.
-    - **Bottom**: Title and secondary value at the top, primary value at the bottom. The primary and secondary values are right-aligned. New metric visualizations use this template by default.
-    - **Custom**: Keep your individual appearance settings. Select **Custom**, then expand the **Details** section and adjust each control independently. Lens switches to **Custom** automatically when your settings no longer match any preset.
+    - **Bottom**: Title at the top, secondary and primary values at the bottom. The primary and secondary values are right-aligned. New metric visualizations use this template by default.
+    - **Custom**: Keep your individual appearance settings. Select **Custom**, then adjust each control independently in the **Details** section. Lens switches to **Custom** automatically when your settings no longer match any preset.
 
     The detailed appearance controls described in the next section are grouped under a **Details** accordion. Select **Details** to expand the section and adjust individual settings, or select a different template to apply its preset values to all styling settings at once.
 


### PR DESCRIPTION
## Summary

This PR addresses #6477 by documenting the new **Style template** selector added to Lens Metric charts in 9.5.

- **`explore-analyze/visualize/charts/metric-charts.md`**: Adds a new **Style template** entry at the top of the **General layout settings** section, documenting the **Top / Middle / Bottom / Custom** presets, the default (**Bottom** for new metrics), and how Lens infers the active template from current settings. Also notes that the existing per-control settings are grouped under a **Details** accordion in 9.5+.

## Resolves

Closes elastic/docs-content#6477

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.