### PR TITLE
test: EUI icon aliases and new icons (docs-builder#3378)

### DIFF
--- a/contribute-docs/syntax-quick-reference.md
+++ b/contribute-docs/syntax-quick-reference.md
@@ -529,7 +529,9 @@ Include icons inline using the `` {icon}`icon-name` `` syntax.
 :open:
 ```markdown
 Click the {icon}`gear` **Settings** icon.
-Status: {icon}`checkCircle` Success | {icon}`warning` Warning | {icon}`error` Error
+Status: {icon}`check_circle` Success | {icon}`warning` Warning | {icon}`error` Error
+New icons: {icon}`ellipsis` {icon}`cloud` {icon}`chart_bar_vertical`
+Aliases still work: {icon}`checkCircle` {icon}`bellSlash` {icon}`pipeBreaks`
 ```
 :::
 
@@ -537,7 +539,11 @@ Status: {icon}`checkCircle` Success | {icon}`warning` Warning | {icon}`error` Er
 :open:
 Click the {icon}`gear` **Settings** icon.
 
-Status: {icon}`checkCircle` Success | {icon}`warning` Warning | {icon}`error` Error
+Status: {icon}`check_circle` Success | {icon}`warning` Warning | {icon}`error` Error
+
+New icons: {icon}`ellipsis` {icon}`cloud` {icon}`chart_bar_vertical`
+
+Aliases still work: {icon}`checkCircle` {icon}`bellSlash` {icon}`pipeBreaks`
 :::
 
 **DOs**<br>


### PR DESCRIPTION
## Why

Tests elastic/docs-builder#3378 (merged), which synced the EUI icon library with Jan–May 2026 renames and added ~97 camelCase aliases.

## What

Extends the icons example in `syntax-quick-reference.md` to exercise:

- **New canonical snake_case names** added in the sync: `check_circle`, `ellipsis`, `cloud`, `chart_bar_vertical`
- **Old camelCase aliases** that must still resolve: `checkCircle` → `check_circle`, `bellSlash` → `bell_slash`, `pipeBreaks` → `line_break`

The PR preview build will fail if any of these names are unresolved, making it a direct smoke test for the icon sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)