### PR TITLE
docs: single-zone ECH snapshot repository recovery guidance

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md
+++ b/deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md
@@ -58,6 +58,9 @@ High availability is achieved by running a cluster with replicas in multiple dat
 
 Running in two data centers or availability zones is our default high availability configuration. It provides reasonably high protection against infrastructure failures and intermittent network problems. You might want three data centers if you need even higher fault tolerance. Just one zone might be sufficient, if the cluster is mainly used for testing or development.
 
+::::{include} /deploy-manage/tools/snapshot-and-restore/_snippets/ech-non-ha-snapshot-repositories.md
+::::
+
 ::::{important}
 Some [regions](cloud://reference/cloud-hosted/regions.md) might have only two availability zones.
 ::::

--- a/deploy-manage/deploy/elastic-cloud/elastic-cloud-hosted-planning.md
+++ b/deploy-manage/deploy/elastic-cloud/elastic-cloud-hosted-planning.md
@@ -38,6 +38,8 @@ Moreover, a high availability (HA) cluster requires at least three master-eligib
 
 The data in your {{es}} clusters is also backed up every 30 minutes, 4 hours, or 24 hours, depending on which snapshot interval you choose. These regular intervals provide an extra level of redundancy. We do support [snapshot and restore](/deploy-manage/tools/snapshot-and-restore.md), regardless of whether you use one, two, or three availability zones. However, with only a single availability zone and in the event of an outage, it might take a while for your cluster come back online. Using a single availability zone also leaves your cluster exposed to the risk of data loss, if the backups you need are not usable (failed or partial snapshots missing the indices to restore) or no longer available by the time that you realize that you might need the data (snapshots have a retention policy).
 
+Registered snapshot repositories are not included in snapshots. If you use a single availability zone and must recover from a snapshot after node failure, you might need to restore repository registration before you can restore index data. Custom repositories must be re-registered manually. See [Manage snapshot repositories in {{ech}}](/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md) and [Fault tolerance](/deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md#ec-high-availability).
+
 ::::{warning}
 Clusters that use only one availability zone are not highly
 available and are at risk of data loss. To safeguard against data loss,

--- a/deploy-manage/tools/snapshot-and-restore/_snippets/ech-non-ha-snapshot-repositories.md
+++ b/deploy-manage/tools/snapshot-and-restore/_snippets/ech-non-ha-snapshot-repositories.md
@@ -1,0 +1,19 @@
+:::::{important} Snapshot repositories and single-zone deployments
+If your deployment runs in a **single availability zone** (one data center), it is not highly available. Node or infrastructure failures can require you to [restore data from a snapshot](/deploy-manage/tools/snapshot-and-restore/restore-snapshot.md).
+
+**Registered snapshot repositories are not stored in snapshots.** A restore recovers index data and, if you choose, parts of the cluster state from the snapshot. It does **not** restore which snapshot repositories were registered on the cluster. Repository registration lives in cluster metadata and must exist **before** you can run a snapshot restore.
+
+On a single-zone deployment, that cluster metadata can be lost when nodes fail. Restore operations can then fail with repository errors—even when snapshot files still exist in storage.
+
+**`found-snapshots` (default):** {{ech}} registers and manages this repository for you. If it is missing after an outage, you cannot recreate it yourself. Edit and save your deployment configuration (no other changes required) to trigger a deployment plan that re-registers the repository, or [contact Elastic Support](/troubleshoot/index.md#contact-us).
+
+**Custom repositories (S3, GCS, Azure, and so on):** You must [re-register the repository](/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md#register-snapshot-repos-ech) with the same name, type, and settings as before the failure (including credentials in the deployment keystore where applicable). Document your repository configuration outside the cluster so you can restore registration after an outage.
+
+Verify registration before you restore:
+
+```console
+GET _snapshot/_all
+```
+
+For production workloads, use [at least two availability zones](/deploy-manage/deploy/elastic-cloud/elastic-cloud-hosted-planning.md#ec-ha) and configure index replicas. See [Plan for production](/deploy-manage/deploy/elastic-cloud/elastic-cloud-hosted-planning.md#ec-ha) and [Fault tolerance](/deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md#ec-high-availability).
+:::::

--- a/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
+++ b/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
@@ -31,6 +31,9 @@ From within {{ech}}, you can restore a snapshot from a different deployment in t
 
 ## Considerations
 
+::::{include} _snippets/ech-non-ha-snapshot-repositories.md
+::::
+
 When working with snapshot repositories in {{ech}}, keep the following in mind:
 
 - Each snapshot repository is separate and independent. {{es}} doesn’t share data between repositories.

--- a/deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
+++ b/deploy-manage/tools/snapshot-and-restore/restore-snapshot.md
@@ -41,6 +41,12 @@ This guide also provides tips for [restoring to another cluster](#restore-differ
 - If no such template exists, you can [matching index template](/manage-data/use-case-use-elasticsearch-to-manage-time-series-data.md#create-ts-index-template) or restore a cluster state that contains one. Without a matching index template, a data stream can’t roll over or create backing indices.
 - If your snapshot contains data from App Search or Workplace Search, ensure you’ve restored the Enterprise Search encryption key before restoring the snapshot.
 
+:::{note}
+:applies_to: deployment: ess
+
+On {{ech}} deployments that use a [single availability zone](/deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md#ec-high-availability), registered snapshot repositories are not stored in snapshots and might need to be restored before you can run a restore. See [Manage snapshot repositories in {{ech}}](elastic-cloud-hosted.md).
+:::
+
 ## Considerations
 
 When restoring data from a snapshot, keep the following in mind:


### PR DESCRIPTION
(just an AI draft)

## Summary

- Adds a reusable snippet explaining that **registered snapshot repositories are not stored in snapshots** and must exist before a restore can run.
- Targets customers who choose a **single availability zone** (non-HA) on {{ech}}, where cluster metadata loss is more likely after node failure.
- Distinguishes recovery for **`found-snapshots`** (platform re-registration via deployment plan or Support) vs **custom repositories** (manual re-registration by the customer).

## Pages updated

- `deploy-manage/deploy/elastic-cloud/ec-customize-deployment-components.md` (Fault tolerance)
- `deploy-manage/deploy/elastic-cloud/elastic-cloud-hosted-planning.md` (HA planning)
- `deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md` (Considerations)
- `deploy-manage/tools/snapshot-and-restore/restore-snapshot.md` (ECH prerequisites note)
- New snippet: `deploy-manage/tools/snapshot-and-restore/_snippets/ech-non-ha-snapshot-repositories.md`

## Test plan

- [ ] Preview docs build / link check for included snippet paths
- [ ] Confirm admonition renders correctly on fault tolerance and ECH snapshot pages
- [ ] Editorial review for tone and accuracy of `found-snapshots` vs custom repo guidance


Made with [Cursor](https://cursor.com)