### PR TITLE
Document conversation-migration limitation in 9.4 Observability deprecation notice

### DIFF
--- a/release-notes/elastic-observability/deprecations.md
+++ b/release-notes/elastic-observability/deprecations.md
@@ -29,6 +29,8 @@ Review the deprecated functionality for Elastic {{observability}}. While depreca
 The Observability agent has been removed from Agent Builder, replaced by skills in the Elastic AI agent.
 
 View [#262937]({{kib-pull}}262937).
+
+**Impact**<br> Conversations stored with the Observability agent will no longer appear in the conversation list and cannot be continued from the UI. No automatic migration is planned.
 ::::
 
 ::::{dropdown} Metrics Explorer is deprecated in favor of Discover


### PR DESCRIPTION
Closes #6739.

A customer who upgraded to 9.4 reported their Observability AI Assistant chat history "disappeared." As confirmed in [this Slack thread](https://elastic.slack.com/archives/C08LX7YSHU2/p1779793777161459), conversations are persisted in the index but no longer surfaced in the UI now that the Observability agent has been removed from Agent Builder, and no automatic migration is planned.

The [Security 9.4 deprecation entry](https://www.elastic.co/docs/release-notes/security/deprecations) for the Threat Hunting Agent removal already documents this same limitation with an explicit **Impact** statement. This PR mirrors that language in the equivalent Observability entry.

## Change

- `release-notes/elastic-observability/deprecations.md` — Adds an **Impact** statement to the "Remove Observability Agent from Agent Builder" 9.4 entry, parallel to the Security entry's wording.

## AI Disclosure

Made with Claude Opus 4.7 and Cursor.

Made with [Cursor](https://cursor.com)