### PR TITLE
docs(fleet): document ssl.certificate_reload settings for Elastic Agent

### DIFF
--- a/reference/fleet/elastic-agent-ssl-configuration.md
+++ b/reference/fleet/elastic-agent-ssl-configuration.md
@@ -147,7 +147,7 @@ $$$client-ssl-options$$$
     **Default:** `true`
 
     ::::{note}
-    This setting is also available on 8.19, 9.3, and 9.4 patch releases, but defaults to `false` on those releases for backward compatibility. Set it to `true` explicitly to opt in.
+    This setting is also available on 8.19, 9.3, and 9.4 patch releases, but defaults to `false` on those releases for backward compatibility. Set it to `true` to opt in.
     ::::
 
 `ssl.certificate_reload.reload_interval` $$$ssl.certificate_reload.reload_interval-client-setting$$$

--- a/reference/fleet/elastic-agent-ssl-configuration.md
+++ b/reference/fleet/elastic-agent-ssl-configuration.md
@@ -141,6 +141,24 @@ $$$client-ssl-options$$$
         -----END CERTIFICATE-----
     ```
 
+`ssl.certificate_reload.enabled` $$$ssl.certificate_reload.enabled-client-setting$$$
+:   {applies_to}`stack: ga 9.5+` (boolean) When `true`, {{agent}} periodically re-reads the `ssl.certificate`, `ssl.key`, and `ssl.certificate_authorities` files from disk so that certificate rotations are picked up without a restart. The new certificate is used on the next TLS handshake within one `ssl.certificate_reload.reload_interval`.
+
+    **Default:** `true`
+
+    ::::{note}
+    This setting is also available on 8.19, 9.3, and 9.4 patch releases, but defaults to `false` on those releases for backward compatibility. Set it to `true` explicitly to opt in.
+    ::::
+
+`ssl.certificate_reload.reload_interval` $$$ssl.certificate_reload.reload_interval-client-setting$$$
+:   {applies_to}`stack: ga 9.5+` (duration) How often {{agent}} checks for changes to the certificate, key, and CA files on disk. Only used when `ssl.certificate_reload.enabled` is `true`.
+
+    **Default:** `5s`
+
+    ::::{note}
+    This setting is also available on 8.19, 9.3, and 9.4 patch releases.
+    ::::
+
 `ssl.key` $$$ssl.key-client-setting$$$
 :   (string) The client certificate key used for client authentication. Only required if `client_authentication` is configured.
 
@@ -228,6 +246,24 @@ $$$server-ssl-options$$$
         CERTIFICATE CONTENT APPEARS HERE
         -----END CERTIFICATE-----
     ```
+
+`ssl.certificate_reload.enabled` $$$ssl.certificate_reload.enabled-server-setting$$$
+:   {applies_to}`stack: ga 9.5+` (boolean) When `true`, {{agent}} periodically re-reads the `ssl.certificate`, `ssl.key`, and `ssl.certificate_authorities` files from disk so that certificate rotations are picked up without a restart. The new certificate is used on the next TLS handshake within one `ssl.certificate_reload.reload_interval`.
+
+    **Default:** `true`
+
+    ::::{note}
+    This setting is also available on 8.19, 9.3, and 9.4 patch releases, but defaults to `false` on those releases for backward compatibility. Set it to `true` explicitly to opt in.
+    ::::
+
+`ssl.certificate_reload.reload_interval` $$$ssl.certificate_reload.reload_interval-server-setting$$$
+:   {applies_to}`stack: ga 9.5+` (duration) How often {{agent}} checks for changes to the certificate, key, and CA files on disk. Only used when `ssl.certificate_reload.enabled` is `true`.
+
+    **Default:** `5s`
+
+    ::::{note}
+    This setting is also available on 8.19, 9.3, and 9.4 patch releases.
+    ::::
 
 `ssl.client_authentication` $$$ssl.client_authentication-server-setting$$$
 :   (string) Configures client authentication. The valid options are:

--- a/reference/fleet/elastic-agent-ssl-configuration.md
+++ b/reference/fleet/elastic-agent-ssl-configuration.md
@@ -253,7 +253,7 @@ $$$server-ssl-options$$$
     **Default:** `true`
 
     ::::{note}
-    This setting is also available on 8.19, 9.3, and 9.4 patch releases, but defaults to `false` on those releases for backward compatibility. Set it to `true` explicitly to opt in.
+    This setting is also available on 8.19, 9.3, and 9.4 patch releases, but defaults to `false` on those releases for backward compatibility. Set it to `true` to opt in.
     ::::
 
 `ssl.certificate_reload.reload_interval` $$$ssl.certificate_reload.reload_interval-server-setting$$$


### PR DESCRIPTION
## Summary

Adds `ssl.certificate_reload.enabled` and `ssl.certificate_reload.reload_interval` to the [Configure SSL/TLS for standalone Elastic Agents](https://www.elastic.co/docs/reference/fleet/elastic-agent-ssl-configuration) reference page, in both the client and server sections.

The feature — periodic hot-reload of cert/key/CA files from disk without restarting — was introduced in `elastic-agent-libs` v0.43.0 and wired into Elastic Agent in:

- elastic/elastic-agent#14597 (9.4)
- elastic/elastic-agent#14598 (9.3)
- elastic/elastic-agent#14599 (8.19)

**Version behaviour:**

| Release | `ssl.certificate_reload.enabled` default |
|---|---|
| 8.19, 9.3, 9.4 patch releases | `false` (opt-in for backward compatibility) |
| 9.5+ | `true` |

The entries use `{applies_to}` badges (`stack: ga 9.5+`) for when the feature is enabled by default, plus prose notes covering the opt-in availability on earlier patch releases, following the style-guide guidance to use prose for patch-level differences.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

Tool(s) and model(s) used: Claude Sonnet 4.6 (claude.ai/claude-code)