### PR TITLE
Kibana --max-old-space-size setting clarification on ECK

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/customize-pods.md
+++ b/deploy-manage/deploy/cloud-on-k8s/customize-pods.md
@@ -58,12 +58,22 @@ spec:
           env:
             - name: NODE_OPTIONS
               value:  "--max-old-space-size=2048"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 0.5
+            limits:
+              memory: 2.5Gi
+              cpu: 2
 ```
+
+::::{note} 
+When manually setting `NODE_OPTIONS`, make sure you adjust the container's `resources.limits.memory` appropriately.
+::::
 
 ::::{note} 
 Configuration for other {{stack}} applications, like APM Server, or Beats, is identical to the {{kib}} configuration except for the `apiVersion` and `kind` fields.
 ::::
-
 
 The following example shows how it’s also possible to customize the init containers created as part of the Pods to initialize the filesystem or to manage the keystores.
 

--- a/deploy-manage/deploy/cloud-on-k8s/customize-pods.md
+++ b/deploy-manage/deploy/cloud-on-k8s/customize-pods.md
@@ -57,7 +57,7 @@ spec:
         - name: kibana
           env:
             - name: NODE_OPTIONS
-              value:  "--max-old-space-size=2048"
+              value:  "--max-old-space-size=2048"  <1>
           resources:
             requests:
               memory: 1Gi
@@ -67,9 +67,7 @@ spec:
               cpu: 2
 ```
 
-::::{note} 
-When manually setting `NODE_OPTIONS`, make sure you adjust the container's `resources.limits.memory` appropriately.
-::::
+1. When manually setting `--max-old-space-size`, make sure you adjust the container's `resources.limits.memory` appropriately.
 
 ::::{note} 
 Configuration for other {{stack}} applications, like APM Server, or Beats, is identical to the {{kib}} configuration except for the `apiVersion` and `kind` fields.

--- a/deploy-manage/deploy/cloud-on-k8s/customize-pods.md
+++ b/deploy-manage/deploy/cloud-on-k8s/customize-pods.md
@@ -60,7 +60,7 @@ spec:
               value:  "--max-old-space-size=2048"  <1>
           resources:
             requests:
-              memory: 1Gi
+              memory: 2Gi
               cpu: 0.5
             limits:
               memory: 2.5Gi

--- a/deploy-manage/production-guidance/kibana-configure-memory.md
+++ b/deploy-manage/production-guidance/kibana-configure-memory.md
@@ -30,5 +30,5 @@ Starting in {{kib}} version 9.4.0, containers set the default Node.js heap to 75
 
 In orchestrated environments like {{ech}}, {{ece}}, you should not override Kibana’s default memory limit using `--max-old-space-size`. Instead, set the desired {{kib}} memory size at the deployment level. This automatically adjusts the container’s memory allocation and ensures more consistent and predictable performance.
 
-In {{eck}}, the {{kib}} memory size is not automatically adjusted, but the default memory size logic mentioned above applies.
+In {{eck}}, the {{kib}} memory size is not automatically adjusted, but the default memory size logic applies.
 ::::

--- a/deploy-manage/production-guidance/kibana-configure-memory.md
+++ b/deploy-manage/production-guidance/kibana-configure-memory.md
@@ -30,5 +30,5 @@ Starting in {{kib}} version 9.4.0, containers set the default Node.js heap to 75
 
 In orchestrated environments like {{ech}}, {{ece}}, you should not override Kibana’s default memory limit using `--max-old-space-size`. Instead, set the desired {{kib}} memory size at the deployment level. This automatically adjusts the container’s memory allocation and ensures more consistent and predictable performance.
 
-In {{eck}}, the {{kib}} memory size is not automatically adjusted, but the default memory size logic applies.
+In {{eck}}, the {{kib}} memory size is not automatically adjusted, but the default memory size logic applies. You can override the default memory settings if they do not meet your requirements. Review [ECK - Manage compute resources](../deploy/cloud-on-k8s/manage-compute-resources.md#k8s-compute-resources-kibana-and-apm) for more guidance.
 ::::

--- a/deploy-manage/production-guidance/kibana-configure-memory.md
+++ b/deploy-manage/production-guidance/kibana-configure-memory.md
@@ -26,5 +26,9 @@ The option accepts a limit in MB:
 ```
 
 ::::{note}
-In orchestrated environments like {{ech}}, {{ece}}, or {{eck}}, you should not override Kibana’s default memory limit using `--max-old-space-size`. Instead, set the desired {{kib}} memory size at the deployment level. This automatically adjusts the container’s memory allocation and ensures more consistent and predictable performance.
+Starting in {{kib}} version 9.4.0, containers set the default Node.js heap to 75% of available memory, up to a maximum of 4096 MB. Previously, this was set to 50% regardless of the environment.
+
+In orchestrated environments like {{ech}}, {{ece}}, you should not override Kibana’s default memory limit using `--max-old-space-size`. Instead, set the desired {{kib}} memory size at the deployment level. This automatically adjusts the container’s memory allocation and ensures more consistent and predictable performance.
+
+In {{eck}}, the {{kib}} memory size is not automatically adjusted, but the default memory size logic mentioned above applies.
 ::::


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

* To address https://github.com/elastic/docs-content-internal/issues/1251

As mentioned in https://github.com/elastic/docs-content-internal/issues/1251#issuecomment-4569664586, 

### [1] kibana memory - default memory calculation logic

By default, it sets `--max-old-space-size` automatically, already.

https://www.elastic.co/docs/release-notes/kibana
> Containers now set the default Node.js heap to 75% of available memory up to a maximum of 4096 Mb. Previously, this was set to 50% [#246073](https://github.com/elastic/kibana/pull/246073).

Before Kibana 9.4 (< 9.4), it's set to 50% of the container memory.
Starting in Kibana 9.4 (>= 9.4.0), it's set to 75% of the container memory (with max cap to 4096MB).

*The "Mb" (small b) is a mistake per [this](https://www.elastic.co/docs/deploy-manage/production-guidance/kibana-configure-memory): `The option accepts a limit in MB`.*

### [2] kibana memory - on ECH and ECE

In ECE and ECH, it is further overridden based on [our internal code](https://github.com/elastic/cloud/blob/4.1.0/scala-services/runner/src/main/resources/templates/allocator/kibana/kibana.sh#L60-L64), which is 800MB per 1GB. (MiB and GiB). 

This is the reason why we have `In orchestrated environments like ..., you should not override Kibana's default memory limit using --max-old-space-size.`

### [3] kibana memory - on ECK

However, in ECK, there's no such auto-adjust / override code piece. 
Instead, it uses the default logic.

So on ECK, the behavior is same as [1]:
* Before Kibana 9.4 (< 9.4), it's set to 50% of the container memory.
* Starting in Kibana 9.4 (>= 9.4.0), it's set to 75% of the container memory (with max cap to 4096MB).

### [4] One more different topic - ECK customize pods doc

https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/customize-pods gives the example of overriding kibana `--max-old-space-size=2048` to 2GiB which is based on https://github.com/elastic/cloud-on-k8s/blob/v3.4.0/deploy/eck-stack/examples/custom-elasticsearch-kibana.yaml#L70-L78, and has a pair of container memory setting be up-lifted to 2.5GiB. 

But this 2.5GiB is not correctly propagated in the doc. If we tweak the kibana memory setting without giving enough container memory (limits), then it may experience OOM. So we need to also put the container memory (limits) description in doc (in addition to the code).

---

So we need to tweak https://www.elastic.co/docs/deploy-manage/production-guidance/kibana-configure-memory and make it clear of below:
* to address [1], Kibana default memory logic difference before and after 9.4
* to address [2], on ECE and ECH, this setting is auto-adjusted
* to address [3], on ECK, this setting is not auto-adjusted

Also re https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/customize-pods,
* to address [4], we need to include the container memory limits pieces.

---

Thanks!

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

