### PR TITLE
[Security] Clarify guidance for custom roles on EA overview page

### DIFF
--- a/solutions/security/advanced-entity-analytics/overview.md
+++ b/solutions/security/advanced-entity-analytics/overview.md
@@ -21,8 +21,9 @@ The **Entity analytics** page provides a centralized workspace for investigating
 * This feature requires the appropriate [subscription](https://www.elastic.co/pricing) in {{stack}} or [project feature tier](/deploy-manage/deploy/elastic-cloud/project-settings.md) in {{serverless-short}}.
 
 * {applies_to}`stack: ga 9.4+` {applies_to}`serverless: ga` To access this page, you need the following privileges:
-  * `read` for `entities-latest-<space-id>` and `.entities.v2.latest.security_<space-id>-*`
+  * `read` for `entities-latest-<space-id>`, `.entities.v2.latest.security_<space-id>-*`, and `risk-score.risk-score-<space-id>`
   * **Read** for the **Management > Saved Objects Management** feature 
+* {applies_to}`serverless: ga` If you're using a [custom role](/deploy-manage/users-roles/cloud-organization/user-roles.md), make sure it grants `read` access to all the required index patterns.
 * {applies_to}`serverless: removed` {applies_to}`stack: removed 9.3` To get access to this page, turn on the `securitySolution:enablePrivilegedUserMonitoring` [advanced setting](/solutions/security/get-started/configure-advanced-settings.md#access-privileged-user-monitoring).
 :::
 

--- a/solutions/security/advanced-entity-analytics/overview.md
+++ b/solutions/security/advanced-entity-analytics/overview.md
@@ -22,7 +22,7 @@ The **Entity analytics** page provides a centralized workspace for investigating
 
 * {applies_to}`stack: ga 9.4+` {applies_to}`serverless: ga` To access this page, you need the following privileges:
   * `read` for `entities-latest-<space-id>`, `.entities.v2.latest.security_<space-id>-*`, and `risk-score.risk-score-<space-id>`
-  * **Read** for the **Management > Saved Objects Management** feature 
+  * **Read** for the **Management → Saved Objects Management** feature 
 * {applies_to}`serverless: ga` If you're using a [custom role](/deploy-manage/users-roles/cloud-organization/user-roles.md), make sure it grants `read` access to all the required index patterns.
 * {applies_to}`serverless: removed` {applies_to}`stack: removed 9.3` To get access to this page, turn on the `securitySolution:enablePrivilegedUserMonitoring` [advanced setting](/solutions/security/get-started/configure-advanced-settings.md#access-privileged-user-monitoring).
 :::


### PR DESCRIPTION

## Summary
Resolves https://github.com/elastic/docs-content/issues/6790:
- Adds a missing index pattern to the Requirements callout on the Entity Analytics overview page
- Adds guidance that serverless custom roles must include all the required index privs.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

