### PR TITLE
Change authentication method from Basic to Dev Tools

### DIFF
--- a/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
+++ b/deploy-manage/monitor/autoops/cc-connect-self-managed-to-autoops.md
@@ -106,7 +106,7 @@ Depending on your selected installation method, you might have to provide some o
 * **Preferred authentication method**: Choose one of the following:
   
   :::::{tab-set}
-  :group: api-key-or-basic
+  :group: api-key-or-devtools
 
   ::::{tab-item} API key
   :sync: api-key
@@ -153,8 +153,8 @@ Depending on your selected installation method, you might have to provide some o
 
   ::::
 
-  ::::{tab-item} Basic
-  :sync: basic
+  ::::{tab-item} Dev Tools
+  :sync: devtools
 
   With this authentication method, you need the username and password of a user with the necessary privileges to grant access to your cluster. There are two ways to set up a user with these privileges:
 


### PR DESCRIPTION
Updated authentication method options in documentation.

Basic is kinda misleading when I look it up, I would love to have Dev Tools to know "ah that is where I need to copy from". Only thing I am wondering if it makes sense to make the Dev Tools tab the primary one
