### PR TITLE
[Alerting V2][Serverless & 9.5][M2] Action policy and workflow changes from June 3, 2026

### DIFF
--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -25,9 +25,7 @@ Use these fields in the **Match conditions** expression to filter which alert ep
 | `last_event_timestamp` | string | ISO 8601 timestamp of the most recent event recorded for the alert episode. | ISO 8601 timestamp | `last_event_timestamp > "2026-01-01"` |
 | `rule.id` | string | Unique identifier of the rule that generated the alert episode. | Any string | `rule.id: "rule-001"` |
 | `rule.name` | string | Display name of the rule. | Any string | `rule.name: "High CPU"` |
-| `rule.description` | string | Description of the rule. | Any string | `rule.description: *checkout*` |
 | `rule.tags` | string[] | Tags attached to the rule. Use to match alert episodes from rules with a specific tag. | Any string | `rule.tags: "payment-service"` |
-| `rule.enabled` | boolean | Whether the rule is currently enabled. | `true`, `false` | `rule.enabled: true` |
 | `data.*` | object | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. Use for rule-specific fields not covered by the standard episode fields above. | Depends on rule type | `data.host.name: "web-01"` |
 
 <!--[CONTENT NEEDED: 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -14,12 +14,13 @@ Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page is 
 
 ## Match conditions fields [matcher-fields]
 
-Use these fields in the **Match conditions** expression to filter which alert episodes a policy applies to. Combine them with standard [KQL](../../../query-filter/languages/kql.md) operators, for example `data.severity: "critical" AND episode_status: "active"`.
+Use these fields in the **Match conditions** expression to filter which alert episodes a policy applies to. Combine them with standard [KQL](../../../query-filter/languages/kql.md) operators, for example `episode.severity: "critical" AND episode_status: "active"`.
 
 | Field | Type | Description | Accepted values | Example |
 |---|---|---|---|---|
 | `episode_id` | string | Unique identifier of the alert episode. | Any string | `episode_id: "ep-001"` |
 | `episode_status` | string | Current lifecycle status of the alert episode. | `inactive`, `pending`, `active`, `recovering` | `episode_status: "active"` |
+| `episode.severity` | string | Current severity of the alert episode. Populated when the rule's ES\|QL query includes a `severity` column whose value matches a supported level (case-insensitive). Unrecognized values are silently ignored and the field is absent. Not set during recovery. Use to route high-severity episodes to dedicated workflows. | `info`, `low`, `medium`, `high`, `critical` | `episode.severity: "critical" OR episode.severity: "high"` |
 | `group_hash` | string | Stable hash identifying the alert series the alert episode belongs to. | Any string | `group_hash: "abc123"` |
 | `last_event_timestamp` | string | ISO 8601 timestamp of the most recent event recorded for the alert episode. | ISO 8601 timestamp | `last_event_timestamp > "2026-01-01"` |
 | `rule.id` | string | Unique identifier of the rule that generated the alert episode. | Any string | `rule.id: "rule-001"` |
@@ -27,16 +28,12 @@ Use these fields in the **Match conditions** expression to filter which alert ep
 | `rule.description` | string | Description of the rule. | Any string | `rule.description: *checkout*` |
 | `rule.tags` | string[] | Tags attached to the rule. Use to match alert episodes from rules with a specific tag. | Any string | `rule.tags: "payment-service"` |
 | `rule.enabled` | boolean | Whether the rule is currently enabled. | `true`, `false` | `rule.enabled: true` |
-| `data.*` | object | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. | Depends on rule type | `data.severity: "critical"` |
+| `data.*` | object | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. Use for rule-specific fields not covered by the standard episode fields above. | Depends on rule type | `data.host.name: "web-01"` |
 
-<!--[CONTENT NEEDED for M2: M2 adds two first-class episode-level severity fields that will be directly matchable in KQL:
-
-- `episode.severity` - The current severity of the episode (most recent evaluation). Enables matching like `episode.severity: "CRITICAL"`.
-- `episode.severity_max` - The highest severity seen over the episode's lifetime. Enables matching like `episode.severity_max: "CRITICAL"` to catch episodes that were once critical even if they have since de-escalated.
-
-Add both fields to this table with examples. Update the introductory sentence to include them. Also remove or deprecate the `data.severity` example once `episode.severity` is the preferred approach, otherwise users will get conflicting guidance about which field to use for severity matching.
-
-There is also an open M2 question about whether a severity change mid-episode (de-escalation or escalation) triggers policy re-evaluation. If it does, document the re-evaluation behavior in the frequency options section below, since it interacts with frequency limits.]
+<!--[CONTENT NEEDED: 
+1. Confirm whether `episode.severity_max` (highest severity over the episode's lifetime) is also available. If so, add it to the table after `episode.severity` with the description: "Highest severity reached over the lifetime of the alert episode. Use to catch episodes that were once critical even if they have since de-escalated." Accepted values: `info`, `low`, `medium`, `high`, `critical`.
+2. Confirm whether a severity change mid-episode (escalation or de-escalation of `episode.severity`) triggers policy re-evaluation independently of episode status changes. If it does, a note is needed in the Frequency section below explaining the interaction between severity changes and the "On status change" option.
+3. When rule authoring docs are created (issue #6689), link from this table row to the rule authoring page that explains how to include a `severity` column in the ES|QL query. The full severity contract (column name, case-insensitivity, silent-ignore behavior) belongs in the rule authoring reference, not here.]
 -->
 
 ## Notify per options [notification-grouping]
@@ -60,7 +57,7 @@ Frequency controls how often the policy fires for a given alert episode or notif
 | At most once every… | Caps notifications at one per alert episode or notification group within the chosen interval, regardless of rule frequency. | You want to limit notification volume for noisy rules without missing new or ongoing issues. |
 | Every evaluation | Notifies on every rule evaluation. Can be noisy. Use sparingly and only with infrequent rule schedules. | You need a full audit trail of every evaluation, or the rule runs infrequently enough that noise isn't a concern. |
 
-<!--[CONTENT NEEDED for M2: An open M2 question is whether a severity change mid-episode (escalation or de-escalation of `episode.severity`) triggers policy re-evaluation independently of episode status changes. If it does, this table needs a new strategy option or a note explaining the interaction between severity changes and the "On status change" option. Confirm the M2 decision before updating.]
+<!--[CONTENT NEEDED: Confirm whether a severity change mid-episode (escalation or de-escalation of `episode.severity`) triggers policy re-evaluation independently of episode status changes. If it does, this table needs a note or a new strategy option explaining the interaction between severity changes and the "On status change" option.]
 -->
 
 ### Frequency options for Episode [frequency-when-episode-per_episode]

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -41,9 +41,9 @@ Optional string labels you assign to a policy to categorize it or filter it on t
 
 An optional [KQL](../../../query-filter/languages/kql.md) expression that filters which alert episodes this policy applies to. An empty match condition matches every alert episode covered by the policy's scope. For a global policy, that means all alert episodes in the space. For a per-rule policy, it means all alert episodes from the associated rule.
 
-Use match conditions to route different alert episodes to different policies, for example, one policy for `rule.tags: "payment-service"` alert episodes routed to PagerDuty and another for warnings routed to Slack. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
+Use match conditions to route different alert episodes to different policies, for example, one policy for `episode.severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
 
-<!--[CONTENT NEEDED for M2: The `data.severity: "critical"` example above will become the legacy approach once M2 ships. M2 promotes severity to `episode.severity` and `episode.severity_max` as first-class episode fields. Update this example to use `episode.severity: "CRITICAL"` and update the cross-reference to include the new fields. Also decide whether to retain `data.severity` as an alternative for rules that haven't migrated, or to remove it from guidance entirely.]
+<!--[CONTENT NEEDED: Confirm whether `data.severity` on legacy rules (rules that have not migrated to `episode.severity`) should be documented as an alternative matcher, or removed from guidance entirely. If retained, add a note in the reference explaining when to use `data.*` severity fields versus `episode.severity`.]
 -->
 
 ## Grouping and frequency [reduce-noise-grouping]

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -14,7 +14,7 @@ Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page cov
 
 ## View policy details
 
-From the **Action policies** list, you can open a policy to see its full configuration, including match conditions, grouping mode, frequency, and destinations. You can also edit, clone, delete, enable, disable, snooze, or update its API key without leaving the list page.
+From the **Action policies** list, you can open a policy to see its full configuration, including match conditions, grouping mode, frequency, and destinations. The list also shows the display name of the user who created the policy and the user who last updated it. You can also edit, clone, delete, enable, disable, snooze, or update its API key without leaving the list page.
 
 ## Execution history
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -32,7 +32,7 @@ Because each action policy evaluates alert episodes independently, an episode th
 
 ## Why policies are separate from rules
 
-Policies are independent of rules. A single global policy can cover alert episodes from many rules, so a policy matching `data.severity: "critical"` applies regardless of which rule produced the alert episode. You can also update notification routing without touching any rule, and you can create rules without any action policy, which is useful for testing detection logic before wiring up notifications.
+Policies are independent of rules. A single global policy can cover alert episodes from many rules, so a policy matching `episode.severity: "critical"` applies regardless of which rule produced the alert episode. You can also update notification routing without touching any rule, and you can create rules without any action policy, which is useful for testing detection logic before wiring up notifications.
 
 When you do need routing that is specific to one rule, create a per-rule policy and bind it to that rule at creation.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -15,7 +15,6 @@ Workflows are part of the {{alerting-v2-system}} in {{kib}}. Without a workflow 
 :::{important}
 Before creating an action policy, make sure the workflows you want to use already exist in your space. For information on creating a workflow, refer to [Build your first workflow](../../workflows/get-started/build-your-first-workflow.md).
 
-On {{stack}}, workflows must be enabled before they can be used as destinations in action policies. If workflows are not enabled, you will not be able to select a workflow destination when creating or editing an action policy. To enable workflows, go to **Stack Management > Advanced Settings** and turn on the **Workflows** (`workflows:ui:enabled`) setting.
 :::
 
 ## Runtime execution order [runtime-execution-order]

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -14,6 +14,8 @@ Workflows are part of the {{alerting-v2-system}} in {{kib}}. Without a workflow 
 
 :::{important}
 Before creating an action policy, make sure the workflows you want to use already exist in your space. For information on creating a workflow, refer to [Build your first workflow](../../workflows/get-started/build-your-first-workflow.md).
+
+On {{stack}}, workflows must be enabled before they can be used as destinations in action policies. If workflows are not enabled, you will not be able to select a workflow destination when creating or editing an action policy. To enable workflows, go to **Stack Management > Advanced Settings** and turn on the **Workflows** (`workflows:ui:enabled`) setting.
 :::
 
 ## Runtime execution order [runtime-execution-order]


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary

Updates the action policy, reference, and workflow docs for the experimental alerting features with content from five M2 doc issues. Following the tech preview principle of accuracy over comprehensiveness, content additions focus on confirmed stable behavior. UI details subject to change and API schema changes with no existing reference docs are deferred.

### `episode.severity` as a first-class match condition field (#6834, #6689)

Issues #6834 and #6689 tracked the same underlying feature from two angles. #6689 documented the rule-side contract: severity is populated when a rule's ES|QL query includes a `severity` column with a recognized value (`info`, `low`, `medium`, `high`, `critical`); unrecognized values are silently ignored; the field is absent on recovery events. #6834 documented the dispatcher side: `episode.severity` is now available in the matcher context, making `data.severity` — previously the only way to match on severity — the legacy approach.

**`action-policy-reference.md`** — Added `episode.severity` to the match conditions field reference table with its full behavioral contract: populated from the rule's ES|QL `severity` column, case-insensitive, unrecognized values silently ignored, not set during recovery. Updated the introductory KQL example from `data.severity: "critical"` to `episode.severity: "critical"`. Updated the `data.*` row to clarify it covers rule-specific payload fields not available as standard episode fields, removing the misleading `data.severity: "critical"` example. Narrowed the content-needed comments to three remaining open questions: whether `episode.severity_max` is also available, whether a mid-episode severity change triggers re-evaluation, and a placeholder for a future cross-link to rule authoring docs once they exist.

**`create-configure-action-policy.md`** — Updated the match conditions example to lead with `episode.severity: "critical"` for PagerDuty routing, with `rule.tags` as a secondary scoping example. Narrowed the content-needed comment to the backward-compatibility question of whether `data.severity` on legacy rules should be documented as an alternative or removed from guidance.

**`notifications-actions.md`** — Updated the "Why policies are separate from rules" example from `data.severity: "critical"` to `episode.severity: "critical"`. This was the one remaining reference to `data.severity` as a severity matcher outside the reference table.

The full ES|QL severity authoring contract (column name, case-insensitivity, silent-ignore behavior) belongs in rule authoring docs. Those docs don't exist yet (#6689 notes this). A comment in the `episode.severity` table row flags this as a future cross-link target.

### Matcher context `rule.*` fields reduced to id, name, and tags (#6836)

PR #271768 simplified `MatcherContextRule` to expose only `id`, `name`, and `tags`. The fields `rule.description`, `rule.enabled`, `rule.createdAt`, and `rule.updatedAt` were removed from the matcher context. The same PR added `rule.name`, `rule.tags`, and `rule.description` as payload variables in single-step workflow templates.

**`action-policy-reference.md`** — Removed `rule.description` and `rule.enabled` rows from the match conditions field reference table. Both were previously listed as available matcher fields; both were removed in this PR. `rule.id`, `rule.name`, and `rule.tags` remain. The workflow payload variable additions (`{{rule.name}}`, `{{rule.tags}}`, `{{rule.description}}`) are not documented here — no workflow payload template docs exist yet. When those docs are written, they should document these three variables with example template snippets such as `Alert from rule: {{rule.name}}`.

### Notification policy form: Workflows enablement prerequisite and UI labels (#6843)

PR #260796 introduced a warning callout in the notification policy form when `workflows:ui:enabled` is disabled on Stack, directing users to Advanced Settings to enable it. In 9.4, workflows was enabled by default, so there's no need to doc this as a pre-req.

**`workflows-alerting.md`** — Added a note inside the existing important callout explaining that on Stack, workflows must be enabled before they can be used as destinations in action policies. Includes the path (**Stack Management > Advanced Settings**) and the setting key (`workflows:ui:enabled`). UI label changes from this PR ("Policy scope" section header, "Create a workflow" link in the destination field) are omitted — these are unstable IA details that will be documented once the UI stabilizes post-preview.

### Creator and updater display names in the policy list (#6845)

PR #268426 standardized Alerting v2 on user profile UIDs for `createdBy` and `updatedBy` fields, resolving them to display names on read via the Kibana user profiles API. The policy list page and details flyout now show the full display name of the creator or last updater.

**`manage-action-policies.md`** — Added a sentence noting that the policy list shows the display name of the user who created the policy and the user who last updated it. The API schema breaking change (`createdByUsername`/`updatedByUsername` fields removed in 9.5.0) is not documented here — no public API reference exists yet for the Alerting v2 action policy API, so there is nothing to update. When that reference is written, it should document `createdBy`/`updatedBy` as user profile UIDs and note the removal as a breaking change for pre-release integrations.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes - Cursor + Claude
- [ ] No