### PR TITLE
[agent builder] Clarify that index search tools select a single index per query

### DIFF
--- a/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
+++ b/explore-analyze/ai-features/agent-builder/tools/builtin-tools-reference.md
@@ -52,8 +52,8 @@ Platform core tools provide fundamental capabilities for interacting with {{es}}
 `platform.core.list_indices` {applies_to}`stack: preview 9.2` {applies_to}`stack: ga 9.3+`
 :   Lists the indices, aliases, and data streams in the {{es}} cluster the current user has access to.
 
-`platform.core.search` {applies_to}`stack: preview 9.2` {applies_to}`stack: ga 9.3+`
-:   Searches and analyzes data within your {{es}} cluster using full-text relevance searches or structured analytical queries.
+$$$agent-builder-builtin-search-tool$$$ `platform.core.search` {applies_to}`stack: preview 9.2` {applies_to}`stack: ga 9.3+`
+:   Searches {{es}} data using natural language, automatically selecting between query DSL and {{esql}} based on the query intent.
 
 $$$agent-builder-product-documentation-tool$$$ `platform.core.product_documentation` {applies_to}`stack: ga 9.3+`
 :   Searches and retrieves documentation about Elastic products. To use this tool, search for **GenAI Settings** in the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md) and install **Elastic documentation** from the **Documentation** section. This takes a few minutes.

--- a/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
@@ -55,7 +55,7 @@ Index search tools support the following configuration parameters:
 When an agent calls an index search tool:
 
 1. The agent provides a natural language query (for example, "find recent errors related to authentication")
-2. The tool selects a **single index** from the configured pattern based on the query intent and available index metadata
+2. The tool selects a single index from the configured pattern based on the query intent and available index metadata
 3. It automatically orchestrates built-in tools to:
    - Explore the selected index's structure and mappings
    - Generate appropriate queries ({{esql}} or query DSL)

--- a/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/index-search-tools.md
@@ -55,13 +55,19 @@ Index search tools support the following configuration parameters:
 When an agent calls an index search tool:
 
 1. The agent provides a natural language query (for example, "find recent errors related to authentication")
-2. The tool analyzes the query intent and available indices
+2. The tool selects a **single index** from the configured pattern based on the query intent and available index metadata
 3. It automatically orchestrates built-in tools to:
-   - Explore the index structure and mappings
+   - Explore the selected index's structure and mappings
    - Generate appropriate queries ({{esql}} or query DSL)
    - Execute semantic search if relevant
    - Rank and format results
 4. Returns results in a format the agent can interpret and present
+
+:::{important}
+Even when the configured pattern matches multiple indices, the tool selects only one index per query. It does not search across all matching indices simultaneously.
+
+If your use case requires searching across multiple indices in a single query, use the built-in [search tool](builtin-tools-reference.md#agent-builder-builtin-search-tool) instead, which supports multi-index {{esql}} queries across index patterns. {applies_to}`stack: ga 9.4+`
+:::
 
 To help agents make better decisions during the source selection phase, you can optimize your index metadata and tool configurations.
 


### PR DESCRIPTION
## Summary

- Clarify in the "How it works" section that index search tools select a single index from the configured pattern per query, not all matching indices
- Add callout directing users to the built-in search tool for multi-index ES|QL queries (9.4+)
- Add anchor to `platform.core.search` in the builtin tools reference for targeted linking
- Tighten `platform.core.search` description

🤖 Generated with [Claude Code](https://claude.com/claude-code)