### PR TITLE
Mention bucket policies in S3 docs

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/s3-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/s3-repository.md
@@ -174,6 +174,9 @@ You may further restrict the permissions by specifying a prefix within the bucke
 
 The bucket needs to exist to register a repository for snapshots. If you did not create the bucket then the repository registration will fail.
 
+You may also impose similar restrictions using a [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html).
+
+Do not impose any additional restrictions on access to your bucket, for instance by using more restrictive `Condition` clauses than the ones documented above.
 
 #### Using IAM roles for Kubernetes service accounts for authentication [iam-kubernetes-service-accounts]
 

--- a/deploy-manage/tools/snapshot-and-restore/s3-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/s3-repository.md
@@ -176,7 +176,7 @@ The bucket needs to exist to register a repository for snapshots. If you did not
 
 You can also impose similar restrictions using a [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html).
 
-Do not impose any additional restrictions on access to your bucket, for instance by using more restrictive `Condition` clauses than the ones documented above.
+Do not impose any additional restrictions on access to your bucket, for instance by using stricter `Condition` clauses than the ones documented above. Overly-restrictive access policies can prevent {{es}} snapshots from working correctly.
 
 #### Using IAM roles for Kubernetes service accounts for authentication [iam-kubernetes-service-accounts]
 

--- a/deploy-manage/tools/snapshot-and-restore/s3-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/s3-repository.md
@@ -174,7 +174,7 @@ You may further restrict the permissions by specifying a prefix within the bucke
 
 The bucket needs to exist to register a repository for snapshots. If you did not create the bucket then the repository registration will fail.
 
-You may also impose similar restrictions using a [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html).
+You can also impose similar restrictions using a [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html).
 
 Do not impose any additional restrictions on access to your bucket, for instance by using more restrictive `Condition` clauses than the ones documented above.
 


### PR DESCRIPTION
We don't talk about bucket policies today and users may mistakenly
assume that this means they are free to impose additional restrictions
via such a policy. This isn't the case. This commit calls this out in
the docs.