### PR TITLE
Refine claim about MPU fallback for S3 registers

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/s3-repository.md
+++ b/deploy-manage/tools/snapshot-and-restore/s3-repository.md
@@ -287,7 +287,7 @@ stack: ga 9.3
 
 From 9.3.0 onwards the linearizable register implementation for S3 repositories is based on [S3's conditional writes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html) using the `If-None-Match` and `If-Match` request headers.
 
-If your storage does not support conditional writes then it is not fully S3-compatible. However, if this is its only deviation in behavior from AWS S3 then it will work correctly with {{es}} as long as its multipart upload APIs have strongly consistent semantics, as described below. Future versions of {{es}} may remove this lenient behavior and require your storage to support conditional writes. Contact the supplier of your storage for further information about conditional writes and the strong consistency of your storage's multipart upload APIs.
+If your storage does not support conditional writes then it is not fully S3-compatible. In this case {{es}} can fall back to using the multipart upload APIs for its linearizable registers, as long as these APIs have strongly consistent semantics as described below. Future versions of {{es}} may remove this lenient behavior and require your storage to support conditional writes. Contact the supplier of your storage for further information about conditional writes and the strong consistency of your storage's multipart upload APIs.
 
 ### Multipart uploads
 


### PR DESCRIPTION
Today we say that if S3-like storage doesn't support conditional writes
then `it will work correctly with {{es}}` (with some extra caveats).
This isn't true, we require overwrite protection to avoid repository
corruption even if linearizable registers work ok with unconditional
MPUs.

This commit adjusts the docs to match.