### PR TITLE
Add references to EDOT troubleshooting pages

### DIFF
--- a/reference/observability/observability-container-metrics.md
+++ b/reference/observability/observability-container-metrics.md
@@ -23,7 +23,7 @@ These are the key metrics displayed for Docker containers.
 
 :::{note}
 :applies_to: stack: ga 9.3
-For Docker container metrics, the [Infrastructure UI](/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md) and [inventory rules](/solutions/observability/incident-management/create-an-inventory-rule.md) only support metric data collected by the [Docker integration](integration-docs://reference/docker.md).
+For Docker container metrics, the [Infrastructure UI](/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md) and [inventory rules](/solutions/observability/incident-management/create-an-inventory-rule.md) only support metric data collected by the [Docker integration](integration-docs://reference/docker.md). If you're using {{edot}} and these views appear empty, refer to [{{k8s}} Pods and Docker Containers views empty when using EDOT](/troubleshoot/observability/troubleshooting-infrastructure-monitoring/kubernetes-pods-docker-containers-empty-otel.md).
 :::
 
 ### Entity definition [monitor-docker-container-entity]
@@ -72,8 +72,8 @@ stack: ga 9.3
 These are the key metrics displayed for {{k8s}} (containerd) containers.
 
 :::{note}
-:applies_to: stack: ga 9.3
-For {{k8s}} container metrics, the [Infrastructure UI](/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md) and [inventory rules](/solutions/observability/incident-management/create-an-inventory-rule.md) only support metric data collected by the [{{k8s}} integration](integration-docs://reference/kubernetes.md).
+:applies_to: stack: ga 9.3+
+For {{k8s}} container metrics, the [Infrastructure UI](/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md) and [inventory rules](/solutions/observability/incident-management/create-an-inventory-rule.md) only support metric data collected by the [{{k8s}} integration](integration-docs://reference/kubernetes.md). If you're using {{edot}} and these views appear empty, refer to [{{k8s}} Pods and Docker Containers views empty when using EDOT](/troubleshoot/observability/troubleshooting-infrastructure-monitoring/kubernetes-pods-docker-containers-empty-otel.md).
 :::
 
 ### Entity definition [monitor-k8s-container-entity]

--- a/reference/observability/observability-kubernetes-pod-metrics.md
+++ b/reference/observability/observability-kubernetes-pod-metrics.md
@@ -15,8 +15,8 @@ products:
 To analyze {{k8s}} pod metrics, you can select view filters based on the following predefined metrics, or you can add [custom metrics](/solutions/observability/infra-and-hosts/view-infrastructure-metrics-by-resource-type.md#custom-metrics).
 
 :::{note}
-:applies_to: stack: ga 9.3
-For {{k8s}} pod metrics, the [Infrastructure UI](/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md) and [inventory rules](/solutions/observability/incident-management/create-an-inventory-rule.md) only support metric data collected by the [{{k8s}} integration](integration-docs://reference/kubernetes.md).
+:applies_to: stack: ga 9.3+
+For {{k8s}} pod metrics, the [Infrastructure UI](/solutions/observability/infra-and-hosts/analyze-infrastructure-host-metrics.md) and [inventory rules](/solutions/observability/incident-management/create-an-inventory-rule.md) only support metric data collected by the [{{k8s}} integration](integration-docs://reference/kubernetes.md). If you're using {{edot}} and these views appear empty, refer to [{{k8s}} Pods and Docker Containers views empty when using EDOT](/troubleshoot/observability/troubleshooting-infrastructure-monitoring/kubernetes-pods-docker-containers-empty-otel.md).
 :::
 
 ## Entity definition [monitor-k8s-pods-entity]


### PR DESCRIPTION
Here's a summary of the changes:

- [observability-container-metrics.md](vscode-webview://1s9l97q8srd3egl8p2jmanqpb19kuni5cfl9slck2lvtp8n4g1m2/reference/observability/observability-container-metrics.md) — Both the Docker (line 26) and {{k8s}} (line 77) notes now end with: "If you're using {{edot}} and these views appear empty, refer to [{{k8s}} Pods and Docker Containers views empty when using EDOT](vscode-webview://1s9l97q8srd3egl8p2jmanqpb19kuni5cfl9slck2lvtp8n4g1m2/troubleshoot/%E2%80%A6/kubernetes-pods-docker-containers-empty-otel.md)."
- [observability-kubernetes-pod-metrics.md](vscode-webview://1s9l97q8srd3egl8p2jmanqpb19kuni5cfl9slck2lvtp8n4g1m2/reference/observability/observability-kubernetes-pod-metrics.md) — Same sentence added to the existing note (line 19).

Closes https://github.com/elastic/docs-content/issues/6542

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

