### PR TITLE
Fix typo in trustStorePassword environment variable

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+++ b/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
@@ -480,7 +480,7 @@ spec:
                 mountPath: /usr/share/elasticsearch/config/custom-truststore
               env:
               - name: ES_JAVA_OPTS
-                value: "-Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/custom-truststore/cacerts -Djavax.net.ssl.trustStorePassword==changeit"
+                value: "-Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/custom-truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
     ```
 
 7. Create the snapshot repository

--- a/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+++ b/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
@@ -480,7 +480,7 @@ spec:
                 mountPath: /usr/share/elasticsearch/config/custom-truststore
               env:
               - name: ES_JAVA_OPTS
-                value: "-Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/custom-truststore/cacerts -Djavax.net.ssl.keyStorePassword=changeit"
+                value: "-Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/custom-truststore/cacerts -Djavax.net.ssl.trustStorePassword==changeit"
     ```
 
 7. Create the snapshot repository


### PR DESCRIPTION
It was observed in a recent support case that Step 6 currently has inconsistent logic in that you upload the certificate to the trust store, but add the key store password and not the expected trust store password. When using this command as-is results in the error `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty` 

`-Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/custom-truststore/cacerts -Djavax.net.ssl.keyStorePassword=changeit`

Changed to:

`-Djavax.net.ssl.trustStore=/usr/share/elasticsearch/config/custom-truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit`

Tested in a lab and that change resolved the issue and cleared the error.

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

