### PR TITLE
Adds clarification to config examples in reference docs

### DIFF
--- a/reference/fleet/elasticsearch-output.md
+++ b/reference/fleet/elasticsearch-output.md
@@ -16,7 +16,23 @@ The {{es}} output sends events directly to {{es}} by using the {{es}} HTTP API.
 
 **Compatibility:** This output works with all compatible versions of {{es}}. See the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_compatibility).
 
-This example configures an {{es}} output called `default` in the `elastic-agent.yml` file:
+This example configures an {{es}} output called `default` in the `elastic-agent.yml` file using the recommended [token-based (API key) authentication](#output-elasticsearch-apikey-authentication-settings):
+
+```yaml
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9200]
+    api_key: "id:api_key"
+```
+
+To create an API key with the required privileges, refer to [Grant standalone {{agent}}s access to {{es}}](/reference/fleet/grant-access-to-elasticsearch.md#create-api-key-standalone-agent).
+
+::::{note}
+Token-based authentication is required in an [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md) environment.
+::::
+
+Alternatively, you can use [basic authentication](#output-elasticsearch-basic-authentication-settings):
 
 ```yaml
 outputs:
@@ -26,20 +42,6 @@ outputs:
     username: elastic
     password: changeme
 ```
-
-This example is similar to the previous one, except that it uses the recommended [token-based (API key) authentication](#output-elasticsearch-apikey-authentication-settings):
-
-```yaml
-outputs:
-  default:
-    type: elasticsearch
-    hosts: [127.0.0.1:9200]
-    api_key: "my_api_key"
-```
-
-::::{note}
-Token-based authentication is required in an [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md) environment.
-::::
 
 
 ## {{es}} output configuration settings [_es_output_configuration_settings]

--- a/reference/fleet/elasticsearch-output.md
+++ b/reference/fleet/elasticsearch-output.md
@@ -23,7 +23,7 @@ outputs:
   default:
     type: elasticsearch
     hosts: [127.0.0.1:9200]
-    api_key: "id:api_key"
+    api_key: "<id>:<key>"
 ```
 
 To create an API key with the required privileges, refer to [Grant standalone {{agent}}s access to {{es}}](/reference/fleet/grant-access-to-elasticsearch.md#create-api-key-standalone-agent).

--- a/reference/fleet/elasticsearch-output.md
+++ b/reference/fleet/elasticsearch-output.md
@@ -16,7 +16,7 @@ The {{es}} output sends events directly to {{es}} by using the {{es}} HTTP API.
 
 **Compatibility:** This output works with all compatible versions of {{es}}. See the [Elastic Support Matrix](https://www.elastic.co/support/matrix#matrix_compatibility).
 
-This example configures an {{es}} output called `default` in the `elastic-agent.yml` file using the recommended [token-based (API key) authentication](#output-elasticsearch-apikey-authentication-settings):
+This example configures an {{es}} output called `default` in the `elastic-agent.yml` file using the recommended [token-based authentication (API key)](#output-elasticsearch-apikey-authentication-settings):
 
 ```yaml
 outputs:

--- a/reference/fleet/grant-access-to-elasticsearch.md
+++ b/reference/fleet/grant-access-to-elasticsearch.md
@@ -14,7 +14,7 @@ products:
 You can use either API keys (recommended) or user credentials to grant standalone {{agents}} access to {{es}} resources.
 
 ::::{important}
-API key authentication is required for {{serverless-full}}. API key authentication is recommended for {{stack}} deployments in order to avoid exposing usernames and passwords in configuration files.
+API key authentication is required for {{serverless-full}}. API key authentication is recommended for {{stack}} deployments to avoid exposing usernames and passwords in configuration files.
 ::::
 
 The following minimal permissions are required to send logs, metrics, traces, and synthetics to {{es}}:
@@ -79,7 +79,7 @@ To create an API key for {{agent}}:
     :screenshot:
     :::
 
-7. Copy the API key. You will need this for the next step, and you will not be able to view it again.
+7. Copy the API key. You need this for the next step and won't be able to view it again.
 8. To use the API key, specify the `api_key` setting in the `elastic-agent.yml` file. For example:
 
     ```yaml

--- a/reference/fleet/grant-access-to-elasticsearch.md
+++ b/reference/fleet/grant-access-to-elasticsearch.md
@@ -72,16 +72,15 @@ To create an API key for {{agent}}:
 
     You’ll see a message indicating that the key was created, along with the encoded key. By default, the API key is Base64 encoded, but that won’t work for {{agent}}.
 
-
-1. Click the down arrow next to Base64 and select **Beats**.
+6. Click the down arrow next to Base64 and select **Beats**.
 
     :::{image} images/copy-api-key.png
     :alt: Message with field for copying API key
     :screenshot:
     :::
 
-2. Copy the API key. You will need this for the next step, and you will not be able to view it again.
-3. To use the API key, specify the `api_key` setting in the `elastic-agent.yml` file. For example:
+7. Copy the API key. You will need this for the next step, and you will not be able to view it again.
+8. To use the API key, specify the `api_key` setting in the `elastic-agent.yml` file. For example:
 
     ```yaml
     [...]
@@ -96,13 +95,18 @@ To create an API key for {{agent}}:
 
     1. The format of this key is `<id>:<key>`. Base64 encoded API keys are not currently supported in this configuration.
 
+    On Kubernetes, set the `API_KEY` environment variable in the {{agent}} manifest instead of editing `elastic-agent.yml` directly. For an example, refer to [Run {{agent}} Standalone on Kubernetes](/reference/fleet/running-on-kubernetes-standalone.md#_step_2_connect_to_the_stack).
 
 For more information about creating API keys in {{kib}}, see [API Keys](/deploy-manage/api-keys/elasticsearch-api-keys.md).
 
 
 ## Create a standalone agent role [create-role-standalone-agent]
 
-Although it’s recommended that you use an API key instead of a username and password to access {{es}} (and an API key is required in a {{serverless-short}} environment), you can create a role with the required privileges, assign it to a user, and specify the user’s credentials in the `elastic-agent.yml` file.
+::::{note}
+Use [API keys](#create-api-key-standalone-agent) instead of username and password authentication whenever possible. API key authentication is required in a {{serverless-short}} environment.
+::::
+
+If you cannot use an API key, you can create a role with the required privileges, assign it to a user, and specify the user’s credentials in the `elastic-agent.yml` file.
 
 1. In {{kib}}, go to **{{stack-manage-app}} > Roles**.
 2. Click **Create role** and enter a name for the role.

--- a/reference/fleet/running-on-kubernetes-standalone.md
+++ b/reference/fleet/running-on-kubernetes-standalone.md
@@ -101,7 +101,7 @@ Set the {{es}} connection settings in the manifest before deploying. The manifes
   value: "https://somesuperhostiduuid.europe-west1.gcp.cloud.es.io:9243" <2>
 ```
 
-1. Replace with the API key you created in {{kib}}. Use the **Beats** format (`<id>:<key>`), not the Base64-encoded value shown by default when the key is created.
+1. Replace `<your-api-key-id>:<your-api-key-secret>` with the API key you created in {{kib}}. Use the {{beats}} format (`<id>:<key>`), not the Base64-encoded value shown by default when the key is created.
 2. The {{es}} host to communicate with.
 
 ::::{note}

--- a/reference/fleet/running-on-kubernetes-standalone.md
+++ b/reference/fleet/running-on-kubernetes-standalone.md
@@ -105,7 +105,7 @@ Set the {{es}} connection settings in the manifest before deploying. The manifes
 2. The {{es}} host to communicate with.
 
 ::::{note}
-To use username and password authentication instead, comment out the `api_key` setting in the manifest's `outputs` section, uncomment the `username` and `password` settings, and set the `ES_USERNAME` and `ES_PASSWORD` environment variables. For the required privileges, refer to [Create a standalone agent role](/reference/fleet/grant-access-to-elasticsearch.md#create-role-standalone-agent).
+To authenticate with a username and password instead, comment out the `api_key` setting in the manifest's `outputs` section, uncomment the `username` and `password` settings, and set the `ES_USERNAME` and `ES_PASSWORD` environment variables. For the required privileges, refer to [Create a standalone agent role](/reference/fleet/grant-access-to-elasticsearch.md#create-role-standalone-agent).
 ::::
 
 Refer to [Environment variables](/reference/fleet/agent-environment-variables.md) for all available options.

--- a/reference/fleet/running-on-kubernetes-standalone.md
+++ b/reference/fleet/running-on-kubernetes-standalone.md
@@ -92,21 +92,21 @@ The size and the number of nodes in a Kubernetes cluster can be large at times, 
 
 ### Step 2: Connect to the {{stack}} [_step_2_connect_to_the_stack]
 
-Set the {{es}} settings before deploying the manifest:
+Set the {{es}} connection settings in the manifest before deploying. The manifest uses `api_key` authentication by default. Create an API key with the required privileges described in [Create API keys for standalone agents](/reference/fleet/grant-access-to-elasticsearch.md#create-api-key-standalone-agent), then set these environment variables:
 
 ```yaml
-- name: ES_USERNAME
-  value: "elastic" <1>
-- name: ES_PASSWORD
-  value: "passpassMyStr0ngP@ss" <2>
+- name: API_KEY
+  value: "<your-api-key-id>:<your-api-key-secret>" <1>
 - name: ES_HOST
-  value: "https://somesuperhostiduuid.europe-west1.gcp.cloud.es.io:9243" <3>
+  value: "https://somesuperhostiduuid.europe-west1.gcp.cloud.es.io:9243" <2>
 ```
 
-1. The basic authentication username used to connect to {{es}}.
-2. The basic authentication password used to connect to {{kib}}.
-3. The {{es}} host to communicate with.
+1. Replace with the API key you created in {{kib}}. Use the **Beats** format (`<id>:<key>`), not the Base64-encoded value shown by default when the key is created.
+2. The {{es}} host to communicate with.
 
+::::{note}
+To use username and password authentication instead, comment out the `api_key` setting in the manifest's `outputs` section, uncomment the `username` and `password` settings, and set the `ES_USERNAME` and `ES_PASSWORD` environment variables. For the required privileges, refer to [Create a standalone agent role](/reference/fleet/grant-access-to-elasticsearch.md#create-role-standalone-agent).
+::::
 
 Refer to [Environment variables](/reference/fleet/agent-environment-variables.md) for all available options.
 


### PR DESCRIPTION
Addresses [elastic/docs-feedback#131](https://github.com/elastic/docs-feedback/issues/131): standalone agent docs showed username/password in config examples but not api_key, even though API key auth is recommended (and required on Serverless).

Changes:

- `grant-access-to-elasticsearch.md` — Fixed step numbering in the API key procedure; added a Kubernetes cross-link for the API_KEY env var; added a note in the role section directing readers to API keys first.
- `running-on-kubernetes-standalone.md` — Step 2 now documents API_KEY as the default (matching the manifest); username/password moved to a fallback note; fixed incorrect footnote (password was labeled as connecting to Kibana).
- `elasticsearch-output.md` — Leads with the api_key example and links to the grant-access page; username/password shown as an alternative.

Config examples now consistently treat API key authentication as the primary path across the standalone agent workflow.

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
Claude/Cursor 

