### PR TITLE
Add explicit workflow write permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/add-new-team-label.yml
+++ b/.github/workflows/add-new-team-label.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   add-needs-triage-label:
     name: Add `needs-team` label

--- a/.github/workflows/add-new-team-label.yml
+++ b/.github/workflows/add-new-team-label.yml
@@ -4,13 +4,14 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  issues: write
+permissions: {}
 
 jobs:
   add-needs-triage-label:
     name: Add `needs-team` label
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Add the needs-team label
         uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/update-kube-stack-version.yml
+++ b/.github/workflows/update-kube-stack-version.yml
@@ -12,13 +12,14 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-kube-stack-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/update-kube-stack-version.yml
+++ b/.github/workflows/update-kube-stack-version.yml
@@ -12,6 +12,10 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-kube-stack-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit `contents: write` and `pull-requests: write` permissions to `update-kube-stack-version.yml`
- add explicit `issues: write` permissions to `add-new-team-label.yml`
- scope write permissions to the owning jobs while keeping workflow-level permissions denied by default

Contributes to elastic/docs-actions#187.

## Test plan
- [x] Reviewed both workflows to confirm they write through `GITHUB_TOKEN`
- [x] Verified the diff only adds the required explicit permissions
- [ ] Optional: run the workflows in GitHub after merge or in a test branch if you want runtime confirmation