### PR TITLE
docs: raise dashboard panel limit to 1,000 (#6935)

### DIFF
--- a/explore-analyze/dashboards/arrange-panels.md
+++ b/explore-analyze/dashboards/arrange-panels.md
@@ -94,11 +94,13 @@ serverless: ga
 
 Each dashboard enforces the following limits:
 
-- Up to 100 top-level items (panels, including unpinned controls, and sections combined)
-- Up to 100 panels inside each section
+- Up to 1,000 top-level items (panels, including unpinned controls, and sections combined)
+- Up to 1,000 panels inside each section
 - Up to 100 [pinned controls](add-controls.md)
 
-These limits are independent of each other. For example, a single dashboard can have 100 pinned controls, 100 sections at the top level, and 100 panels inside each of those sections.
+These limits are independent of each other. For example, a single dashboard can have 100 pinned controls, 1,000 sections at the top level, and 1,000 panels inside each of those sections.
+
+When you create or update a dashboard with the [Dashboards API](create-dashboards-programmatically.md), an additional combined limit applies: the total number of panels, sections, and pinned controls can't exceed 1,000. Requests that exceed this limit are rejected with a validation error.
 
 ## Arrange panels in collapsible sections [collapsible-sections]
 ```{applies_to}

--- a/explore-analyze/dashboards/create-dashboard.md
+++ b/explore-analyze/dashboards/create-dashboard.md
@@ -41,7 +41,7 @@ Before creating a dashboard, ensure you have:
     * [**Add annotations or navigation panels**](../visualize.md#panels-editors). Make your dashboard more informative and easier to read with sections, text, and images.
     * [**Add controls**](add-controls.md). Define a set of interactive filters (options lists, range or time sliders) that you and future users of this dashboard can use to explore its data.
 
-    {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` You can add up to 100 panels to a dashboard. Refer to [Panel limits](arrange-panels.md#dashboard-panel-limits) for the full breakdown.
+    {applies_to}`stack: ga 9.4` {applies_to}`serverless: ga` You can add up to 1,000 panels to a dashboard. Refer to [Panel limits](arrange-panels.md#dashboard-panel-limits) for the full breakdown.
 
 4. Organize your dashboard by [organizing the various panels](arrange-panels.md).
 5. Define the main settings of your dashboard from the **Settings** menu in the application menu.

--- a/explore-analyze/dashboards/create-dashboards-programmatically.md
+++ b/explore-analyze/dashboards/create-dashboards-programmatically.md
@@ -39,7 +39,7 @@ Use the Dashboards API when you need to:
 
 The API supports all panel types that have a defined schema, including visualizations, Discover sessions, markdown panels, and filter controls. Panel types without a schema, such as Maps and Links, are not supported yet and return an error on write.
 
-Dashboard requests are subject to [panel limits](arrange-panels.md#dashboard-panel-limits): up to 100 top-level items (panels and sections combined), 100 panels per section, and 100 pinned controls. Requests that exceed these limits are rejected with a validation error.
+Dashboard requests are subject to [panel limits](arrange-panels.md#dashboard-panel-limits): up to 1,000 top-level items (panels and sections combined), 1,000 panels per section, and 100 pinned controls. The total number of panels, sections, and pinned controls across the dashboard also can't exceed 1,000. Requests that exceed these limits are rejected with a validation error.
 
 Refer to the [Dashboards API reference](https://elastic.github.io/dashboards-api-spec/dashboards#tag/Dashboards) for the full request schema, panel types, and authentication requirements. For panel sizing and layout guidance when specifying grid coordinates by hand, refer to [Organize dashboard panels](arrange-panels.md#dashboard-grid-layout).
 


### PR DESCRIPTION
## Summary

This PR addresses #6935 with the following changes:

- **`explore-analyze/dashboards/arrange-panels.md`**: Raises the top-level items and per-section panel limits from 100 to 1,000 (pinned controls stays at 100), updates the independence example, and adds the new combined cap that applies to dashboards created or updated through the Dashboards API (panels + sections + pinned controls can't exceed 1,000).
- **`explore-analyze/dashboards/create-dashboard.md`**: Updates the UI panel limit from 100 to 1,000.
- **`explore-analyze/dashboards/create-dashboards-programmatically.md`**: Raises the per-array limits to 1,000 and documents the combined 1,000 cap enforced on API requests.

Version scoping follows the cumulative-docs minor-level policy: the existing `stack: ga 9.4` / `serverless: ga` tags are kept and only the values change. The limit increase ships in Stack 9.4.3 and 9.5.0, and in serverless.

## Hold for merge

The implementation PR [elastic/kibana#272931](https://github.com/elastic/kibana/pull/272931) is open and not yet merged. Hold publication until it merges and is shipped.

## Resolves

Closes #6935

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.