### PR TITLE
Clarify that byte and bit vectors default to plain hnsw

### DIFF
--- a/solutions/search/vector/dense-vector.md
+++ b/solutions/search/vector/dense-vector.md
@@ -53,7 +53,7 @@ For more information about how the profile affects virtual compute unit (VCU) al
 
 Better Binary Quantization (BBQ) is an advanced vector quantization technique for `dense_vector` fields. It compresses embeddings into compact binary form, enabling faster similarity search and reducing memory usage. This improves both search relevance and cost efficiency, especially when used with HNSW (Hierarchical Navigable Small World).
 
-New indices with 384 or more dimensions will default to BBQ HNSW automatically for optimal performance and memory efficiency.
+New indices with `float` or `bfloat16` vectors and 384 or more dimensions will default to BBQ HNSW automatically for optimal performance and memory efficiency. Other element types, such as `byte` and `bit`, default to plain `hnsw` with no quantization.
 
 Learn more about how BBQ works, supported algorithms, and configuration examples in the [Better Binary Quantization (BBQ) documentation](https://www.elastic.co/docs/reference/elasticsearch/index-settings/bbq).
 

--- a/solutions/search/vector/knn.md
+++ b/solutions/search/vector/knn.md
@@ -257,7 +257,7 @@ POST byte-image-index/_search
 If you want to provide `float` vectors but still get the memory savings of `byte` vectors, use the [quantization](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md#dense-vector-quantization) feature. Quantization allows you to provide `float` vectors, but internally they are indexed as `byte` vectors. Additionally, the original `float` vectors are still retained in the index.
 
 ::::{note}
-The default index type for `dense_vector` is either `bbq_hnsw` or `int8_hnsw`, depending on your product version. Refer to [Dense vector field type](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md).
+The default index type for `float` vectors is either `bbq_hnsw` or `int8_hnsw`, depending on your product version and vector dimensions. Other element types, such as `byte`, default to plain `hnsw` with no quantization. Refer to [Dense vector field type](elasticsearch://reference/elasticsearch/mapping-reference/dense-vector.md).
 ::::
 
 You can use the default quantization strategy or specify an index option.


### PR DESCRIPTION
## Summary

- Clarifies that automatic quantization defaults (`int8_hnsw`, `bbq_hnsw`, `bbq_disk`) only apply to `float` and `bfloat16` element types
- States explicitly that `byte` and `bit` vectors default to plain `hnsw` with no quantization
- Updates `dense-vector.md` and `knn.md` in the solutions section

Companion PR: https://github.com/elastic/elasticsearch/pull/151557

Closes https://github.com/elastic/docs-content-internal/issues/448