### PR TITLE
Add documentation for new delete backing index action

### DIFF
--- a/manage-data/data-store/data-streams/modify-data-stream.md
+++ b/manage-data/data-store/data-streams/modify-data-stream.md
@@ -529,15 +529,23 @@ POST /_data_stream/_modify
 {
   "actions": [
     {
-      "add_backing_index": {
+      "add_backing_index": { <1>
         "data_stream": "my-data-stream",
         "index": "new-index"
       },
-      "remove_backing_index": {
+      "remove_backing_index": { <2>
         "data_stream": "my-data-stream",
         "index": "old-index"
+      },
+      "delete_backing_index": { <3>
+        "data_stream": "my-data-stream",
+        "index": "reduntant-index
       }
     }
   ]
 }
 ```
+
+1. Adds an index to the data stream's backing indices
+2. Remove and keep an index from the data stream's backing indices
+3. Remove and delete an index from the data stream's backing indices

--- a/manage-data/data-store/data-streams/modify-data-stream.md
+++ b/manage-data/data-store/data-streams/modify-data-stream.md
@@ -548,4 +548,4 @@ POST /_data_stream/_modify
 
 1. Adds an index to the data stream's backing indices
 2. Remove and keep an index from the data stream's backing indices
-3. Remove and delete an index from the data stream's backing indices
+3. Remove and delete an index from the data stream's backing indices {applies_to}`stack: ga 9.5+`


### PR DESCRIPTION
## Summary
Adds documentation for the new `delete_backing_index` action on the modify data streams API.

See https://github.com/elastic/elasticsearch/pull/151137

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

