### PR TITLE
[Security] Add EA entry to Stack and Serverless release notes

### DIFF
--- a/release-notes/elastic-cloud-serverless/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/breaking-changes.md
@@ -18,6 +18,37 @@ products:
 :::
 -->
 
+## May 28, 2026 [elastic-cloud-serverless-05282026-breaking]
+
+::::{dropdown} Entity Analytics requires additional index privileges for custom roles
+
+The entity store reads entity data from a new set of indices. Roles that grant access to the Entity Analytics features must now include `read` on the following index patterns:
+
+- `.entities.v2.latest.security_*`
+- `.entities.v2.updates.security_*`
+- `entities-latest-*`
+- `risk-score.risk-score-*`
+- `.entity_analytics.*`
+
+The built-in Security roles have been updated to grant these privileges. Custom roles created against the `v1` index patterns (`.entities.v1.latest.security_*`) are not updated automatically.
+
+**Impact:**
+
+Users assigned a custom role that does not include the index patterns above will see the **Entity Analytics** page load in a degraded state — without entity data and without the standard "insufficient privileges" message. Users assigned built-in Security roles are not affected.
+
+**Action:** If you use custom roles to control access to Entity Analytics, add `read` on the following entity store and risk score index patterns to each affected role:
+
+```yaml
+- names:
+    - ".entities.v2.latest.security_*"
+    - "entities-latest-*"
+    - "risk-score.risk-score-*"
+    - ".entity_analytics.*"
+  privileges:
+    - read
+```
+::::
+
 ## April 15, 2026 [elastic-cloud-serverless-04152026-breaking]
 
 :::{dropdown} Disables sequence numbers for TSDB indices in release builds

--- a/release-notes/elastic-cloud-serverless/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/breaking-changes.md
@@ -47,6 +47,8 @@ Users assigned a custom role that does not include the index patterns above will
   privileges:
     - read
 ```
+
+For more information, view [#255800]({{kib-pull}}255800).
 ::::
 
 ## April 15, 2026 [elastic-cloud-serverless-04152026-breaking]

--- a/release-notes/elastic-security/breaking-changes.md
+++ b/release-notes/elastic-security/breaking-changes.md
@@ -34,6 +34,32 @@ Risk scoring is moving from name-based to ID-based scoring tied to the entity st
 For more information, check [#258197]({{kib-pull}}258197).
 ::::
 
+::::{dropdown} Entity Analytics requires additional index privileges for custom roles
+**Details**<br> Starting in 9.4.0, the entity store reads entity data from a new set of indices. Roles that grant access to the Entity Analytics features must now include `read` on the following index patterns:
+
+- `.entities.v2.latest.security_*`
+- `.entities.v2.updates.security_*`
+- `entities-latest-*`
+- `risk-score.risk-score-*`
+- `.entity_analytics.*`
+
+The built-in Security roles have been updated to grant these privileges. Custom roles created against the `v1` index patterns (`.entities.v1.latest.security_*`) are not updated automatically.
+
+**Impact**<br> Users assigned a custom role that does not include the index patterns above will see the **Entity Analytics** page load in a degraded state — without entity data and without the standard "insufficient privileges" message. Users assigned built-in Security roles are not affected.
+
+**Action**<br> If you use custom roles to control access to Entity Analytics, add `read` on the following entity store and risk score index patterns to each affected role:
+
+```yaml
+- names:
+    - ".entities.v2.latest.security_*"
+    - "entities-latest-*"
+    - "risk-score.risk-score-*"
+    - ".entity_analytics.*"
+  privileges:
+    - read
+```
+::::
+
 ::::{dropdown} Entity Analytics: Risk engine management APIs removed
 The standalone risk engine is replaced by an entity maintainer integrated into the entity store. The following risk engine management API endpoint is removed:
 

--- a/release-notes/elastic-security/breaking-changes.md
+++ b/release-notes/elastic-security/breaking-changes.md
@@ -58,6 +58,8 @@ The built-in Security roles have been updated to grant these privileges. Custom 
   privileges:
     - read
 ```
+
+For more information, check [#255800]({{kib-pull}}255800).
 ::::
 
 ::::{dropdown} Entity Analytics: Risk engine management APIs removed


### PR DESCRIPTION

## Summary
Replaces https://github.com/elastic/kibana/pull/273264. Adds a missing Entity Analytics breaking change entry to Security Stack and Serverless release notes.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

