### PR TITLE
Document Liquid template rendering limits in Workflows docs

### DIFF
--- a/explore-analyze/workflows/authoring-techniques/troubleshooting.md
+++ b/explore-analyze/workflows/authoring-techniques/troubleshooting.md
@@ -238,6 +238,14 @@ condition: "item.severity : 'critical'"
 
 The same applies to the `if` step's `condition`. Refer to [`data.filter`](/explore-analyze/workflows/steps/data.md#data-filter).
 
+### A Liquid template fails with a rendering limit error [workflows-ts-liquid-limits]
+
+**Symptom.** A step that renders a large template — often a `console` report — fails with an error such as `memory alloc limit exceeded`, `parse length limit exceeded`, or `render limit exceeded`.
+
+**Cause.** The templating engine caps the size, render time, and memory of each template render. A template that builds a large string, such as a final report that concatenates thousands of rows, can exceed one of these limits.
+
+**Resolution.** Reduce the size of the rendered output: return structured data or write results to an index instead of formatting one large string, and move heavy filtering or grouping into [`data.*` steps](/explore-analyze/workflows/steps/data.md). Refer to [Template rendering limits](/explore-analyze/workflows/templating.md#workflows-template-limits).
+
 ## AI steps [workflows-ts-ai]
 
 ### An AI step rejects `connectorId` [workflows-ts-ai-connector-id]

--- a/explore-analyze/workflows/authoring-techniques/troubleshooting.md
+++ b/explore-analyze/workflows/authoring-techniques/troubleshooting.md
@@ -244,7 +244,7 @@ The same applies to the `if` step's `condition`. Refer to [`data.filter`](/explo
 
 **Cause.** The templating engine caps the size, render time, and memory of each template render. A template that builds a large string, such as a final report that concatenates thousands of rows, can exceed one of these limits.
 
-**Resolution.** Reduce the size of the rendered output: return structured data or write results to an index instead of formatting one large string, and move heavy filtering or grouping into [`data.*` steps](/explore-analyze/workflows/steps/data.md). Refer to [Template rendering limits](/explore-analyze/workflows/templating.md#workflows-template-limits).
+**Resolution.** Reduce the size of the rendered output by returning structured data or write results to an index instead of formatting one large string, and move heavy filtering or grouping into [`data.*` steps](/explore-analyze/workflows/steps/data.md). Refer to [Template rendering limits](/explore-analyze/workflows/templating.md#workflows-template-limits).
 
 ## AI steps [workflows-ts-ai]
 

--- a/explore-analyze/workflows/templating.md
+++ b/explore-analyze/workflows/templating.md
@@ -363,6 +363,22 @@ tags: ["admin", "user"]
 | Undefined variables | Returned as empty string in string syntax and as `undefined` in type-preserving syntax |
 | Missing context properties | Treated as undefined |
 
+## Template rendering limits [workflows-template-limits]
+
+To protect execution stability, the templating engine enforces limits on every template render. These limits are most often reached by large `console` reports or loops that concatenate big strings.
+
+| Limit | Default | What it caps |
+|---|---|---|
+| Parse size | 150,000 characters | Total characters allowed in a single template |
+| Render time | 1,000 ms | Time spent rendering a single template |
+| Memory | 15,000,000 operations | Object allocations (array and string operations) during a single render |
+
+If a template exceeds one of these limits, the step fails and the render stops. To stay within the limits:
+
+- Reduce the size of the rendered output. For large reports, write results to an index or return structured data instead of formatting a single large string.
+- Move heavy transformations (filtering, grouping, or parsing large arrays) into [`data.*` steps](/explore-analyze/workflows/steps/data.md) instead of Liquid.
+- Simplify or shorten loops that build large strings.
+
 ## Learn more
 
 - [Liquid templating language](https://shopify.github.io/liquid/)


### PR DESCRIPTION
## Summary

Phase 1 (unblocked) of #6980. Documents the LiquidJS rendering limits already enforced by the Workflows templating engine in the current GA release. Prompted by a user hitting a cryptic `memory alloc limit exceeded` error while rendering a large `console` report.

- **`templating.md`**: New **Template rendering limits** section with the three current defaults (150,000 characters parse size, 1,000 ms render time, 15,000,000 memory operations) and guidance for staying within them.
- **`troubleshooting.md`**: New entry under **Liquid and data flow** covering the limit errors, their cause, and the resolution, linking back to the new limits section.

No new `applies_to` tags are needed — both pages are already `stack: ga 9.4+ / serverless: ga`, matching the engine the limits ship in.

## Out of scope (Phase 2, blocked)

The configurable `settings.liquid` overrides (`parseLimit`, `renderLimit`, `memoryLimit`) and the new human-readable error message are tracked separately in #6980 and depend on [elastic/kibana#273596](https://github.com/elastic/kibana/pull/273596) landing.

## Test plan

- [x] Verify the new section and troubleshooting entry render correctly in the docs preview.
- [x] Confirm the cross-link from troubleshooting to the **Template rendering limits** anchor resolves.

Made with [Cursor](https://cursor.com)