### PR TITLE
Restructure serverless project management with API

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
+++ b/deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
@@ -18,9 +18,13 @@ On this page, you can find examples of how to create and manage serverless proje
 - [Updating a project](#general-manage-project-with-api-update-project)
 - [Listing regions where projects can be created](#general-manage-project-with-api-list-available-regions)
 
+To try the examples in this section, start by [setting up an API key](#general-manage-project-with-api-set-up-api-key).
+
 :::{agent-skill}
 :url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/manage-project
 :::
+
+## API resources
 
 To learn about API principles, authentication, and how to use the OpenAPI specification, refer to the [Elastic Cloud Serverless API]({{cloud-serverless-apis}}) documentation.
 
@@ -29,8 +33,6 @@ The available APIs are grouped by project type:
 - APIs for [Search projects]({{cloud-serverless-apis}}group/endpoint-elasticsearch-projects)
 - APIs for [Observability projects]({{cloud-serverless-apis}}group/endpoint-observability-projects)
 - APIs for [Security projects]({{cloud-serverless-apis}}group/endpoint-security-projects)
-
-To try the examples in this section, start by [setting up an API key](#general-manage-project-with-api-set-up-api-key).
 
 ## Set up an API key [general-manage-project-with-api-set-up-api-key]
 

--- a/deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
+++ b/deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
@@ -8,7 +8,19 @@ navigation_title: Manage projects with API
 
 # Manage serverless projects using the API [serverless-api]
 
-On this page, you can find examples of how to create and manage serverless projects using the [Elastic Cloud Serverless API]({{cloud-serverless-apis}}).
+On this page, you can find examples of how to create and manage serverless projects using the [Elastic Cloud Serverless API]({{cloud-serverless-apis}}), covering common operations such as:
+
+- [Creating a project](#general-manage-project-with-api-create-a-serverless-elasticsearch-project)
+- [Retrieving project details](#general-manage-project-with-api-get-project)
+- [Retrieving the project's status](#general-manage-project-with-api-get-project-status)
+- [Resetting credentials](#general-manage-project-with-api-reset-credentials)
+- [Deleting a project](#general-manage-project-with-api-delete-project)
+- [Updating a project](#general-manage-project-with-api-update-project)
+- [Listing regions where projects can be created](#general-manage-project-with-api-list-available-regions)
+
+:::{agent-skill}
+:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/manage-project
+:::
 
 To learn about API principles, authentication, and how to use the OpenAPI specification, refer to the [Elastic Cloud Serverless API]({{cloud-serverless-apis}}) documentation.
 
@@ -18,7 +30,7 @@ The available APIs are grouped by project type:
 - APIs for [Observability projects]({{cloud-serverless-apis}}group/endpoint-observability-projects)
 - APIs for [Security projects]({{cloud-serverless-apis}}group/endpoint-security-projects)
 
-To try the examples in this section, [set up an API key](#general-manage-project-with-api-set-up-api-key) and [create an {{serverless-full}} project](#general-manage-project-with-api-create-a-serverless-elasticsearch-project).
+To try the examples in this section, start by [setting up an API key](#general-manage-project-with-api-set-up-api-key).
 
 ## Set up an API key [general-manage-project-with-api-set-up-api-key]
 
@@ -72,23 +84,7 @@ You can store the project ID as an environment variable for the next requests:
 export PROJECT_ID=cace8e65457043698ed3d99da2f053f6
 ```
 
-## API examples
-
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/manage-project
-:::
-
-The following examples show how to interact with the APIs, covering common operations such as:
-
-- [Creating a project](#general-manage-project-with-api-create-a-serverless-elasticsearch-project)
-- [Retrieving project details](#general-manage-project-with-api-get-project)
-- [Retrieving the project's status](#general-manage-project-with-api-get-project-status)
-- [Resetting credentials](#general-manage-project-with-api-reset-credentials)
-- [Deleting a project](#general-manage-project-with-api-delete-project)
-- [Updating a project](#general-manage-project-with-api-update-project)
-- [Listing regions where projects can be created](#general-manage-project-with-api-list-available-regions)
-
-### Get project details [general-manage-project-with-api-get-project]
+## Get project details [general-manage-project-with-api-get-project]
 
 You can retrieve your project details through an API call:
 
@@ -97,7 +93,7 @@ curl -H "Authorization: ApiKey $API_KEY" \
     "https://api.elastic-cloud.com/api/v1/serverless/projects/elasticsearch/${PROJECT_ID}"
 ```
 
-### Get the project status [general-manage-project-with-api-get-project-status]
+## Get the project status [general-manage-project-with-api-get-project-status]
 
 The 'status' endpoint indicates whether the project is initialized and ready to be used. In the response, the project's `phase` will change from "initializing" to "initialized" when it is ready:
 
@@ -114,7 +110,7 @@ Example response:
 }
 ```
 
-### Reset credentials [general-manage-project-with-api-reset-credentials]
+## Reset credentials [general-manage-project-with-api-reset-credentials]
 
 If you lose the credentials provided at the time of the project creation, you can reset the credentials by using the following endpoint:
 
@@ -124,7 +120,7 @@ curl -H "Authorization: ApiKey $API_KEY" \
     "https://api.elastic-cloud.com/api/v1/serverless/projects/elasticsearch/${PROJECT_ID}/_reset-credentials"
 ```
 
-### Delete a project [general-manage-project-with-api-delete-project]
+## Delete a project [general-manage-project-with-api-delete-project]
 
 You can delete your project via the API:
 
@@ -133,7 +129,7 @@ curl -XDELETE -H "Authorization: ApiKey $API_KEY" \
     "https://api.elastic-cloud.com/api/v1/serverless/projects/elasticsearch/${PROJECT_ID}"
 ```
 
-### Update a project [general-manage-project-with-api-update-project]
+## Update a project [general-manage-project-with-api-update-project]
 
 You can update your project using a PATCH request. Only the fields included in the body of the request will be updated.
 
@@ -147,7 +143,7 @@ curl -H "Authorization: ApiKey $API_KEY" \
      }'
 ```
 
-### List available regions [general-manage-project-with-api-list-available-regions]
+## List available regions [general-manage-project-with-api-list-available-regions]
 
 You can obtain the list of regions where projects can be created using the API:
 


### PR DESCRIPTION
Updated heading anchors and removed "API examples" header, as all the doc is about API examples.

Closes https://github.com/elastic/docs-content/issues/5494