### PR TITLE
docs: document supported Dashboards API panel types, including Links (#6461)

### DIFF
--- a/explore-analyze/dashboards/create-dashboards-programmatically.md
+++ b/explore-analyze/dashboards/create-dashboards-programmatically.md
@@ -37,7 +37,9 @@ Use the Dashboards API when you need to:
 - Automate dashboard creation or updates as part of your own tooling
 - Create dashboards with [ES|QL](/explore-analyze/query-filter/languages/esql-kibana.md)-powered visualizations. This is the only programmatic path for ES|QL charts.
 
-The API supports all panel types that have a defined schema, including visualizations, Discover sessions, markdown panels, and filter controls. Panel types without a schema, such as Maps and Links, are not supported yet and return an error on write.
+The API supports all panel types that have a defined schema, including visualizations, Discover sessions, markdown panels, and filter controls. Maps panels don't have a defined schema yet, so they're not supported and return an error on write.
+
+{applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Links panels are also supported. Define them inline as a `links` panel with links to dashboards or external URLs, or reference an existing Links panel by its ID.
 
 Dashboard requests are subject to [panel limits](arrange-panels.md#dashboard-panel-limits): up to 100 top-level items (panels and sections combined), 100 panels per section, and 100 pinned controls. Requests that exceed these limits are rejected with a validation error.
 

--- a/explore-analyze/dashboards/create-dashboards-programmatically.md
+++ b/explore-analyze/dashboards/create-dashboards-programmatically.md
@@ -37,9 +37,21 @@ Use the Dashboards API when you need to:
 - Automate dashboard creation or updates as part of your own tooling
 - Create dashboards with [ES|QL](/explore-analyze/query-filter/languages/esql-kibana.md)-powered visualizations. This is the only programmatic path for ES|QL charts.
 
-The API supports all panel types that have a defined schema, including visualizations, Discover sessions, markdown panels, and filter controls. Maps panels don't have a defined schema yet, so they're not supported and return an error on write.
+The API supports any panel type that has a defined schema:
 
-{applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Links panels are also supported. Define them inline as a `links` panel with links to dashboards or external URLs, or reference an existing Links panel by its ID.
+- Visualizations
+- Discover sessions
+- Markdown
+- Image
+- Controls: options list, range slider, time slider, and ES|QL
+- SLO panels: overview, alerts, error budget, and burn rate
+- Synthetics panels: stats overview and monitors
+- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Links
+- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` APM service map
+- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Machine learning panels: single metric viewer, anomaly swim lane, and anomaly charts
+- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Log rate analysis, change point detection, and pattern analysis panels
+
+Panel types without a defined schema, such as Maps, aren't supported yet and return an error on write.
 
 Dashboard requests are subject to [panel limits](arrange-panels.md#dashboard-panel-limits): up to 100 top-level items (panels and sections combined), 100 panels per section, and 100 pinned controls. Requests that exceed these limits are rejected with a validation error.
 

--- a/explore-analyze/dashboards/create-dashboards-programmatically.md
+++ b/explore-analyze/dashboards/create-dashboards-programmatically.md
@@ -46,10 +46,10 @@ The API supports any panel type that has a defined schema:
 - Controls: options list, range slider, time slider, and ES|QL
 - SLO panels: overview, alerts, error budget, and burn rate
 - Synthetics panels: stats overview and monitors
-- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Links
-- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` APM service map
-- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Machine learning panels: single metric viewer, anomaly swim lane, and anomaly charts
-- {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Log rate analysis, change point detection, and pattern analysis panels
+- {applies_to}`stack: ga 9.5` Links
+- {applies_to}`stack: ga 9.5` APM service map
+- {applies_to}`stack: ga 9.5` Machine learning panels: single metric viewer, anomaly swim lane, and anomaly charts
+- {applies_to}`stack: ga 9.5` Log rate analysis, change point detection, and pattern analysis panels
 
 Panel types without a defined schema, such as Maps, aren't supported yet and return an error on write.
 

--- a/explore-analyze/dashboards/create-dashboards-programmatically.md
+++ b/explore-analyze/dashboards/create-dashboards-programmatically.md
@@ -43,7 +43,7 @@ The API supports any panel type that has a defined schema:
 - Discover sessions
 - Markdown
 - Image
-- Controls: options list, range slider, time slider, and ES|QL
+- Controls: options list, range slider, time slider, and {{esql}}
 - SLO panels: overview, alerts, error budget, and burn rate
 - Synthetics panels: stats overview and monitors
 - {applies_to}`stack: ga 9.5` Links


### PR DESCRIPTION
## Summary

This PR addresses #6461. The published page claimed Links panels are unsupported by the Dashboards API; that's no longer true as of 9.5.0 ([elastic/kibana#268965](https://github.com/elastic/kibana/pull/268965) registered the Links embeddable schema). While correcting that, the single prose sentence is reworked into a complete, version-scoped list of supported panel types, since the supported set has grown across releases.

- **`explore-analyze/dashboards/create-dashboards-programmatically.md`**: Replace the prose sentence with a bulleted list of every panel type the Dashboards API accepts. Types available since the API launched (9.4) are listed without a badge; types added in 9.5 (Links, APM service map, machine learning and AIOps panels) carry an `{applies_to}` tag. Maps remains the example of an unsupported (no-schema) panel type.

## Verification

The supported set and per-version boundary were taken from the committed OpenAPI snapshot (`oas_docs/output/kibana.yaml`), diffed between the `9.4` release branch and `main`:

- **9.4 baseline (no badge):** visualizations, Discover sessions, markdown, image, controls (options list, range slider, time slider, ES|QL), SLO panels (overview, alerts, error budget, burn rate), Synthetics panels (stats overview, monitors).
- **Added in 9.5 (`applies_to`):** Links, APM service map, ML panels (single metric viewer, anomaly swim lane, anomaly charts), AIOps panels (log rate analysis, change point detection, pattern analysis).
- **Unsupported (absent from both snapshots):** Maps.

The `9.5` branch does not exist yet, confirming `main` is 9.5 development and the diff reflects genuine 9.5 additions. The Dashboards API itself is public technical preview since 9.4.0 (kibana#256302), matching the page's existing `preview 9.4+` scope.

## Notes

A separate, still-open PR ([elastic/kibana#268783](https://github.com/elastic/kibana/pull/268783)) adds a standalone public `/api/links` REST API for managing by-reference Links panels as library items. It is unmerged, so it is intentionally not documented here. When it ships, a follow-up can add a `/api/links` reference and link it from this page.

## Resolves

Closes #6461

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.