### PR TITLE
[Alerting V2][Serverless & 9.5][M2] Action policy and workflow changes from June 22, 2026

### DIFF
--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -5,7 +5,7 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "Grouping modes, frequency options, dispatch outcomes, and match conditions field reference for action policies in the {{alerting-v2-system}}."
+description: "Grouping modes, frequency options, dispatch outcomes, and match conditions field reference for action policies in the experimental alerting system."
 ---
 
 # Action policy reference for the {{alerting-v2-system}} [action-policy-reference]

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -29,8 +29,8 @@ Action policies only process alert episodes from rules running in Alert mode. Si
 
 An action policy can be global or per-rule:
 
-- **Global**: Global policies apply to any alert episode in the space. Use a global policy when you want to route alert episodes from multiple rules. For example, a policy matching `rule.tags: "checkout"` applies to every rule with that tag.
-- **Per-rule**: Per-rule policies are scoped to a single rule. Use a per-rule policy when notification routing is specific to one rule and you don't want it to affect other rules in the space.
+- **Global** - Global policies apply to any alert episode in the space. Use a global policy when you want to route alert episodes from multiple rules. For example, a policy matching `rule.tags: "checkout"` applies to every rule with that tag.
+- **Per-rule** - Per-rule policies are scoped to a single rule. Use a per-rule policy when notification routing is specific to one rule and you don't want it to affect other rules in the space.
 
 The policy type is set at creation and cannot be changed. If you need a different type, create a new policy.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -5,7 +5,7 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "Create action policies in the {{alerting-v2-system}}, configure match conditions, Notify per, Frequency, and workflow destinations."
+description: "Create action policies in the experimental alerting system, configure match conditions, Notify per, Frequency, and workflow destinations."
 ---
 
 # Create an action policy for the {{alerting-v2-system}} [create-manage-action-policies]
@@ -25,6 +25,8 @@ For match conditions fields, grouping modes, frequency options, and dispatch out
 
 ## Policy type [policy-type]
 
+Action policies only process alert episodes from rules running in Alert mode. Signals produced by rules running in Detect mode are not eligible for action policy evaluation.
+
 An action policy can be global or per-rule:
 
 - **Global**: Global policies apply to any alert episode in the space. Use a global policy when you want to route alert episodes from multiple rules. For example, a policy matching `rule.tags: "checkout"` applies to every rule with that tag.
@@ -40,6 +42,8 @@ Optional string labels you assign to a policy to categorize it or filter it on t
 
 
 An optional [KQL](../../../query-filter/languages/kql.md) expression that filters which alert episodes this policy applies to. An empty match condition matches every alert episode covered by the policy's scope. For a global policy, that means all alert episodes in the space. For a per-rule policy, it means all alert episodes from the associated rule.
+
+The match condition is the sole mechanism for scoping a policy beyond its base type. There are no separate rule type or rule ID selector fields. All scoping is done through this expression. For a global policy that should target a specific rule, use `rule.id: "my-rule-id"` or `rule.tags: "my-tag"` in the match condition.
 
 Use match conditions to route different alert episodes to different policies, for example, one policy for `episode.severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -27,7 +27,7 @@ After each dispatcher run, {{kib}} records the outcome in the `.alert-actions` i
 | `suppressed` | Dispatch was blocked. The alert episode was acknowledged, snoozed, or deactivated, or the space is currently in a [maintenance window](../../alerts/maintenance-windows.md). |
 | `unmatched` | No action policy matched the alert episode. No workflow ran. |
 
-The Execution history view lets you search these records by policy name, rule name, or saved-object ID, and filter by outcome. Use the outcome filter to isolate `dispatched` or `throttled` events when troubleshooting delivery issues. The count of new events shown in the view reflects the active search and filter criteria.
+The **Execution history** view lets you search these records by policy name, rule name, or saved-object ID, and filter by outcome.
 
 To query raw dispatch records directly, open Discover and query the `.alert-actions` index. Filter by `action_type` to narrow by outcome, or by `policy_id` to filter by policy.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -5,7 +5,7 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "View policy details, enable, disable, snooze, review execution history, and rotate API keys for action policies in the {{alerting-v2-system}}."
+description: "View policy details, enable, disable, snooze, review execution history, and rotate API keys for action policies in the experimental alerting system."
 ---
 
 # Manage action policies for the {{alerting-v2-system}}
@@ -27,9 +27,11 @@ After each dispatcher run, {{kib}} records the outcome in the `.alert-actions` i
 | `suppressed` | Dispatch was blocked. The alert episode was acknowledged, snoozed, or deactivated, or the space is currently in a [maintenance window](../../alerts/maintenance-windows.md). |
 | `unmatched` | No action policy matched the alert episode. No workflow ran. |
 
-To investigate delivery issues or audit which policies ran for an alert episode, open Discover and query the `.alert-actions` index. Filter by `action_type` to narrow by outcome, or by `policy_id` to filter by policy.
+The Execution history view lets you search these records by policy name, rule name, or saved-object ID, and filter by outcome. Use the outcome filter to isolate `dispatched` or `throttled` events when troubleshooting delivery issues. The count of new events shown in the view reflects the active search and filter criteria.
 
-## Enable and snooze
+To query raw dispatch records directly, open Discover and query the `.alert-actions` index. Filter by `action_type` to narrow by outcome, or by `policy_id` to filter by policy.
+
+## Enable, disable, and snooze
 
 You can disable a policy so it is not evaluated for new alert episodes. You can snooze a policy for a defined window so that it does not dispatch notifications during that period. Policies that are not enabled or are snoozed are skipped when the dispatcher evaluates policies.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
@@ -35,7 +35,7 @@ For instructions on snoozing and unsnoozing single or multiple episodes, refer t
 -->
 
 :::{note}
-Snoozing an alert episode differs from [snoozing an action policy](manage-action-policies.md#enable-and-snooze). When you snooze a policy, the dispatch mechanism is paused and every series the policy would process is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy would have handled it. Use policy snooze when you want to pause all notifications from a given policy, for example, during planned maintenance on a destination system.
+Snoozing an alert episode differs from [snoozing an action policy](manage-action-policies.md#enable-disable-and-snooze). When you snooze a policy, the dispatch mechanism is paused and every series the policy would process is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy would have handled it. Use policy snooze when you want to pause all notifications from a given policy, for example, during planned maintenance on a destination system.
 :::
 
 ## Related pages

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
@@ -5,12 +5,14 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "How to reduce notification noise in the {{alerting-v2-system}} using acknowledge, snooze, and deactivate to silence alert episodes."
+description: "How to reduce notification noise in the experimental alerting system using acknowledge, snooze, and deactivate to silence alert episodes."
 ---
 
 # Reduce notification noise for the {{alerting-v2-system}} [reduce-notification-noise]
 
-Acknowledge, snooze, and deactivate are part of the {{alerting-v2-system}} in {{kib}}. Each one silences notifications for an alert episode at a different scope. When an alert episode is silenced, the dispatcher stops processing it before any action policy matching, grouping, or frequency evaluation runs. For an overview of where this fits in the full dispatch cycle, refer to [Notifications and actions in {{alerting-v2-system}}](../notifications-actions.md).
+Acknowledge, snooze, and deactivate are part of the {{alerting-v2-system}} in {{kib}}. Each one silences notifications for an alert episode at a different scope. When an alert episode is silenced, the dispatcher stops processing it before any action policy matching, grouping, or frequency evaluation runs.
+
+This page covers when to use each silencing mechanism and how the scope of an alert episode snooze differs from the scope of a policy snooze. For an overview of where this fits in the full dispatch cycle, refer to [Notifications and actions in {{alerting-v2-system}}](../notifications-actions.md).
 
 ## Silencing mechanisms [silencing-mechanisms]
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -20,9 +20,9 @@ An action policy is the gating layer between an alert episode and a workflow. It
 
 The three gates are suppression, match conditions, and frequency:
 
-* **Suppression**: Suppression checks whether the alert episode should be silenced. Episodes that are acknowledged, snoozed, or inside a maintenance window are stopped here and no workflow is invoked. For details on each mechanism and its scope, refer to [Reduce notification noise](action-policies/reduce-notification-noise.md).
-* **Match conditions**: Match conditions filter which alert episodes the policy applies to. You define them using [KQL](../../query-filter/languages/kql.md). An empty match condition applies to all alert episodes within the policy's scope.
-* **Frequency**: Frequency controls how often the policy can invoke its workflows for the same group of episodes, and how episodes batch before a workflow is invoked. Options are one notification per alert episode, one per notification group, or one digest for all matching episodes. If a workflow was already invoked within the cooldown period, the episode waits.
+* **Suppression** - Suppression checks whether the alert episode should be silenced. Episodes that are acknowledged, snoozed, or inside a maintenance window are stopped here and no workflow is invoked. For details on each mechanism and its scope, refer to [Reduce notification noise](action-policies/reduce-notification-noise.md).
+* **Match conditions** - Match conditions filter which alert episodes the policy applies to. You define them using [KQL](../../query-filter/languages/kql.md). An empty match condition applies to all alert episodes within the policy's scope.
+* **Frequency** - Frequency controls how often the policy can invoke its workflows for the same group of episodes, and how episodes batch before a workflow is invoked. Options are one notification per alert episode, one per notification group, or one digest for all matching episodes. If a workflow was already invoked within the cooldown period, the episode waits.
 
 If any gate stops the episode, the workflow is not invoked for that policy.
 
@@ -64,7 +64,7 @@ Per-rule policies are bound to a specific rule at creation. They apply only to a
 
 {{kib}} runs a background process called the dispatcher that checks for eligible alert episodes on a short interval (around 5 seconds) and evaluates action policies against them. The dispatcher runs on its own cycle, separate from the rule schedule.
 
-For each enabled policy that is not snoozed, the dispatcher works through the following steps.
+For each enabled policy that is not snoozed, the dispatcher works through the following steps:
 
 1. **Gating:** Is the alert episode acknowledged, snoozed, or deactivated? If so, skip. Refer to [Reduce notification noise](action-policies/reduce-notification-noise.md) to learn more.
 2. **Matcher:** Does the alert episode match the policy's KQL? If not, skip this policy.

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -5,14 +5,14 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "How {{alerting-v2-system}} action policies route alert episodes to notifications and actions."
+description: "How experimental alerting system action policies route alert episodes to notifications and actions."
 ---
 
 # Notifications and actions for the {{alerting-v2-system}}
 
-Action policies are part of the {{alerting-v2-system}} in {{kib}}. After a rule produces alert episodes, action policies decide whether and when to invoke workflows. Workflows are what actually send the notification or run the automation.
+Action policies are part of the {{alerting-v2-system}} in {{kib}}. After a rule produces alert episodes in Alert mode, action policies decide whether and when to invoke workflows. Workflows are what actually send the notification or run the automation. Rules running in Detect mode produce signals, which are not processed by action policies.
 
-This page explains how action policies work. For creating and configuring them step by step, refer to [Create and configure an action policy](action-policies/create-configure-action-policy.md).
+This page covers how action policies gate alert episodes before invoking a workflow, the difference between global and per-rule policies, and how the dispatcher evaluates them on a continuous cycle. For creating and configuring them step by step, refer to [Create and configure an action policy](action-policies/create-configure-action-policy.md).
 
 ## What is an action policy [action-policies]
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -16,16 +16,16 @@ This page covers how action policies drive workflow invocations at runtime, the 
 
 The {{alerting-v2-system}} connects to workflows through two pathways.
 
-- **Action policies** evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions and frequency settings.
-- **Alert episode lifecycle triggers** fire a workflow once when a specific state change occurs on an alert episode, such as when it is activated, assigned, or resolved.
+- **Action policies** - Action policies evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions and frequency settings.
+- **Alert episode lifecycle triggers** - Workflows are invoked when a specific state change occurs on an alert episode, such as when the alert episode is activated, assigned, or resolved.
 
-## Action policy-driven workflows [action-policy-driven-workflows]
+## How action policies invoke workflows [action-policy-driven-workflows]
 
 :::{important}
-Before creating an action policy, make sure the workflows you want to use already exist in your space. For information on creating a workflow, refer to [Build your first workflow](../../workflows/get-started/build-your-first-workflow.md).
+Action policies need a workflow to act on alert episodes. Without one, the policy has nowhere to send notifications or run automations. If you haven't created a workflow yet, [build your first workflow](../../workflows/get-started/build-your-first-workflow.md) before continuing.
 :::
 
-Without a workflow attached, an action policy cannot act on an alert episode. After a rule runs, processing follows these steps.
+After a rule runs, the system routes alert episodes to workflows through the following steps.
 
 ```
 Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notification
@@ -40,47 +40,23 @@ Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notif
 
 ## Alert episode lifecycle triggers [alert-episode-lifecycle-triggers]
 
-:::{note}
-Alert episode lifecycle triggers are available in Stack deployments only, from 9.5.0.
+A workflow trigger is a signal that starts a workflow automatically when a specific event occurs. Alert episode lifecycle triggers are a type of [event-driven trigger](../../workflows/triggers/event-driven-triggers.md). The {{alerting-v2-system}} emits one each time an alert episode changes state, for example, when an alert episode is activated, assigned to a user, acknowledged, or snoozed. Any workflow attached to that trigger type runs immediately in response.
+
+:::{tip}
+If you're unsure whether to use a lifecycle trigger or an action policy, refer to [Choosing between lifecycle triggers and action policies](#choosing-lifecycle-triggers-action-policies).
 :::
 
-The {{alerting-v2-system}} emits a workflow trigger event each time a significant state change occurs on an alert episode. You can attach a workflow to any of these triggers to run automations in response to specific transitions without routing through an action policy.
+For the full list of available triggers and event payload fields, refer to [Alert episode lifecycle triggers](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven).
 
-### Available triggers
+## Choosing between lifecycle triggers and action policies [choosing-lifecycle-triggers-action-policies]
 
-<!-- [CONTENT NEEDED: Issue #6873 (Jun 8) documents a trigger with the ID `alertingV2.episodeAssigned`, while issue #7006 (Jun 19) lists the same trigger as `alerting.episodeAssigned`. Confirm the correct trigger ID prefix before publishing. The table below uses `alerting.*` per the more recent issue.] -->
+Action policies and lifecycle triggers serve different purposes. Both can run different workflows simultaneously and coexist without conflict.
 
-| Trigger ID | When it fires |
-|---|---|
-| `alerting.episodeActivated` | An alert episode transitions to the active state. |
-| `alerting.episodeDeactivated` | An alert episode is manually deactivated or recovers. |
-| `alerting.episodeSnoozed` | An alert episode is snoozed. |
-| `alerting.episodeUnsnoozed` | An alert episode is unsnoozed. |
-| `alerting.episodeAcked` | An alert episode is acknowledged. |
-| `alerting.episodeAssigned` | An alert episode is assigned to a user. |
-| `alerting.episodeUnassigned` | An alert episode assignment is removed. |
-| `alerting.episodeTagged` | A tag is applied to an alert episode. |
-
-### Event payload
-
-All lifecycle triggers include these common fields in the event payload.
-
-| Field | Description |
-|---|---|
-| `episodeId` | Unique identifier of the alert episode. |
-| `ruleId` | ID of the rule that produced the alert episode. |
-| `spaceId` | ID of the Kibana space where the event occurred. |
-
-Use these fields to write workflow conditions that scope the automation to specific rules or episodes. For example, use `event.ruleId: "my-rule-id"` to scope the workflow to alert episodes from a specific rule.
-
-### When to use lifecycle triggers vs action policies
-
-Action policies and lifecycle triggers serve different purposes.
-
-- **Use action policies** when you need recurring notifications or escalation logic that runs as long as a problem persists. Action policies evaluate continuously and apply frequency controls, grouping, and suppression.
-- **Use lifecycle triggers** when you need a one-shot response to a specific state change, such as opening a ticket when an alert episode is first assigned, or posting a summary when it resolves.
-
-Both can run different workflows simultaneously and coexist without conflict.
+| | Action policies | Lifecycle triggers |
+|---|---|---|
+| **How they run** | Evaluate alert episodes on a continuous schedule | React immediately to a specific state change |
+| **Frequency control** | Apply suppression, grouping, and frequency gates | Fire exactly once per state change, no gates to configure |
+| **Best for** | Recurring notifications and escalation logic that runs as long as a problem persists | One-shot automations, such as opening a ticket when an episode is assigned or posting a message when it resolves |
 
 ## Next steps
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -40,17 +40,15 @@ Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notif
 
 ## Alert episode lifecycle triggers [alert-episode-lifecycle-triggers]
 
-A workflow trigger is a signal that starts a workflow automatically when a specific event occurs. Alert episode lifecycle triggers are a type of [event-driven trigger](../../workflows/triggers/event-driven-triggers.md). The {{alerting-v2-system}} emits one each time an alert episode changes state, for example, when an alert episode is activated, assigned to a user, acknowledged, or snoozed. Any workflow attached to that trigger type runs immediately in response.
+Alert episode lifecycle triggers are a type of [event-driven trigger](../../workflows/triggers/event-driven-triggers.md) that start a workflow automatically when a specific event occurs. 
 
-:::{tip}
-If you're unsure whether to use a lifecycle trigger or an action policy, refer to [Choosing between lifecycle triggers and action policies](#choosing-lifecycle-triggers-action-policies).
-:::
+The {{alerting-v2-system}} emits a trigger event each time an alert episode changes state (for example, when it's activated, assigned to a user, acknowledged, or snoozed) and any workflow attached to that trigger type runs immediately in response. 
 
-For the full list of available triggers and event payload fields, refer to [Alert episode lifecycle triggers](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven).
+For a list of available triggers and event payload fields, refer to [Alert episode lifecycle triggers](../../workflows/triggers/event-driven-triggers.md). 
 
 ## Choosing between lifecycle triggers and action policies [choosing-lifecycle-triggers-action-policies]
 
-Action policies and lifecycle triggers serve different purposes. Both can run different workflows simultaneously and coexist without conflict.
+If you're unsure whether to use lifecycle triggers or action policies, the following table compares when each option is a good fit. Both can run different workflows simultaneously and coexist without conflict.
 
 | | Action policies | Lifecycle triggers |
 |---|---|---|

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -5,21 +5,27 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "How workflows connect to the {{alerting-v2-system}} action policies and rule automation, and where to configure them."
+description: "How workflows connect to the experimental alerting system through action policies and alert episode lifecycle triggers, and when to use each."
 ---
 
 # Connect workflows to the {{alerting-v2-system}} [connect-workflows-experimental-alerting-system]
 
-Workflows are part of the {{alerting-v2-system}} in {{kib}}. Without a workflow attached, an action policy cannot act on an alert episode. [Workflows](../../workflows.md) are the delivery layer. They define what happens when an action policy decides to act, such as sending a message, calling a webhook, or triggering automation. Setting up a workflow is what connects the {{alerting-v2-system}} to the tools your team uses for incident response.
+Workflows are part of the {{alerting-v2-system}} in {{kib}}. [Workflows](../../workflows.md) are the delivery layer. They define what happens when the {{alerting-v2-system}} decides to act, such as sending a message, calling a webhook, or triggering an automation. Setting up a workflow is what connects the {{alerting-v2-system}} to the tools your team uses for incident response.
+
+This page covers how action policies drive workflow invocations at runtime, the available alert episode lifecycle triggers, and when to use each pathway.
+
+The {{alerting-v2-system}} connects to workflows through two pathways.
+
+- **Action policies** evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions and frequency settings.
+- **Alert episode lifecycle triggers** fire a workflow once when a specific state change occurs on an alert episode, such as when it is activated, assigned, or resolved.
+
+## Action policy-driven workflows [action-policy-driven-workflows]
 
 :::{important}
 Before creating an action policy, make sure the workflows you want to use already exist in your space. For information on creating a workflow, refer to [Build your first workflow](../../workflows/get-started/build-your-first-workflow.md).
-
 :::
 
-## Runtime execution order [runtime-execution-order]
-
-After a rule runs, processing follows this sequence:
+Without a workflow attached, an action policy cannot act on an alert episode. After a rule runs, processing follows these steps.
 
 ```
 Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notification
@@ -28,9 +34,53 @@ Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notif
 1. A rule evaluates data on a schedule and writes a rule event.
 2. In Alert mode, the rule event opens or updates an alert episode.
 3. The dispatcher runs on a short interval, independently of the rule schedule, and picks up active alert episodes.
-4. For each active alert episode, the dispatcher evaluates all enabled action policies. Each policy runs the episode through a sequence of gates: suppression, match conditions, grouping, and frequency.
+4. For each active alert episode, the dispatcher evaluates all enabled action policies. Each policy runs the episode through suppression, match conditions, grouping, and frequency gates.
 5. For policies where the episode clears all gates, the dispatcher invokes the configured workflows.
 6. Workflows deliver the notification or run the automation.
+
+## Alert episode lifecycle triggers [alert-episode-lifecycle-triggers]
+
+:::{note}
+Alert episode lifecycle triggers are available in Stack deployments only, from 9.5.0.
+:::
+
+The {{alerting-v2-system}} emits a workflow trigger event each time a significant state change occurs on an alert episode. You can attach a workflow to any of these triggers to run automations in response to specific transitions without routing through an action policy.
+
+### Available triggers
+
+<!-- [CONTENT NEEDED: Issue #6873 (Jun 8) documents a trigger with the ID `alertingV2.episodeAssigned`, while issue #7006 (Jun 19) lists the same trigger as `alerting.episodeAssigned`. Confirm the correct trigger ID prefix before publishing. The table below uses `alerting.*` per the more recent issue.] -->
+
+| Trigger ID | When it fires |
+|---|---|
+| `alerting.episodeActivated` | An alert episode transitions to the active state. |
+| `alerting.episodeDeactivated` | An alert episode is manually deactivated or recovers. |
+| `alerting.episodeSnoozed` | An alert episode is snoozed. |
+| `alerting.episodeUnsnoozed` | An alert episode is unsnoozed. |
+| `alerting.episodeAcked` | An alert episode is acknowledged. |
+| `alerting.episodeAssigned` | An alert episode is assigned to a user. |
+| `alerting.episodeUnassigned` | An alert episode assignment is removed. |
+| `alerting.episodeTagged` | A tag is applied to an alert episode. |
+
+### Event payload
+
+All lifecycle triggers include these common fields in the event payload.
+
+| Field | Description |
+|---|---|
+| `episodeId` | Unique identifier of the alert episode. |
+| `ruleId` | ID of the rule that produced the alert episode. |
+| `spaceId` | ID of the Kibana space where the event occurred. |
+
+Use these fields to write workflow conditions that scope the automation to specific rules or episodes. For example, use `event.ruleId: "my-rule-id"` to scope the workflow to alert episodes from a specific rule.
+
+### When to use lifecycle triggers vs action policies
+
+Action policies and lifecycle triggers serve different purposes.
+
+- **Use action policies** when you need recurring notifications or escalation logic that runs as long as a problem persists. Action policies evaluate continuously and apply frequency controls, grouping, and suppression.
+- **Use lifecycle triggers** when you need a one-shot response to a specific state change, such as opening a ticket when an alert episode is first assigned, or posting a summary when it resolves.
+
+Both can run different workflows simultaneously and coexist without conflict.
 
 ## Next steps
 

--- a/explore-analyze/workflows/triggers/event-driven-triggers.md
+++ b/explore-analyze/workflows/triggers/event-driven-triggers.md
@@ -3,7 +3,7 @@ navigation_title: Event-driven triggers
 applies_to:
   stack: preview 9.4+
   serverless: preview
-description: Run a workflow in response to a platform event. Includes workflows.failed and the cases trigger family.
+description: Run a workflow in response to a platform event. Includes workflows.failed, the cases trigger family, and alert episode lifecycle triggers.
 products:
   - id: kibana
   - id: cloud-serverless
@@ -15,10 +15,11 @@ products:
 
 # Event-driven triggers [workflows-event-driven-triggers]
 
-Event-driven triggers let workflows react to events elsewhere in {{kib}}. Two trigger families are available:
+Event-driven triggers let workflows react to events elsewhere in {{kib}}. Three trigger families are available:
 
 - **`workflows.failed`** — Fires when another workflow's execution fails. {applies_to}`stack: preview 9.4+` {applies_to}`serverless: preview`
 - **Cases triggers** — Fire when cases change (created, updated, status changed, attachments added, comments added). {applies_to}`stack: preview 9.5+` {applies_to}`serverless: preview`
+- **Alert episode lifecycle triggers** — Fire when an alert episode changes state in the experimental {{alerting-v2-system}}, such as when it is activated, assigned, acknowledged, or snoozed. {applies_to}`stack: experimental 9.5+` {applies_to}`serverless: experimental`
 
 :::{warning}
 The event-driven trigger system is in technical preview, including the triggers documented on this page. The schema and semantics can change in future releases.
@@ -340,7 +341,54 @@ triggers:
       condition: 'event.owner: "securitySolution"'
 ```
 
+## Alert episode lifecycle triggers [alert-episode-lifecycle-triggers-event-driven]
+
+```{applies_to}
+stack: experimental 9.5+
+serverless: experimental
+```
+
+Alert episode lifecycle triggers fire when an alert episode changes state in the experimental {{alerting-v2-system}}. Unlike `workflows.failed` and cases triggers, they are not configured through a `triggers` block in your workflow YAML. They are emitted by the alerting system and automatically invoke any workflow attached to the matching trigger type. Each trigger fires exactly once per state change. There is no polling interval or frequency gate.
+
+### Available triggers [alert-episode-lifecycle-triggers-available]
+
+| Trigger ID | When it fires |
+|---|---|
+| `alerting.episodeActivated` | An alert episode transitions to the active state. |
+| `alerting.episodeDeactivated` | An alert episode is manually deactivated or recovers. |
+| `alerting.episodeSnoozed` | An alert episode is snoozed. |
+| `alerting.episodeUnsnoozed` | An alert episode is unsnoozed. |
+| `alerting.episodeAcked` | An alert episode is acknowledged. |
+| `alerting.episodeUnacked` | An alert episode acknowledgement is removed. |
+| `alerting.episodeAssigned` | An alert episode is assigned to a user. |
+| `alerting.episodeUnassigned` | An alert episode assignment is removed. |
+| `alerting.episodeTagged` | A tag is applied to an alert episode. |
+
+### Event payload [alert-episode-lifecycle-triggers-event]
+
+All lifecycle triggers include these common fields in the event payload.
+
+| `event.*` field | Contains |
+|---|---|
+| `event.episodeId` | Unique identifier of the alert episode. |
+| `event.ruleId` | ID of the rule that produced the alert episode. |
+| `event.spaceId` | ID of the {{kib}} space where the event occurred. |
+
+Reference these fields with Liquid templating in workflow steps:
+
+```yaml
+- name: log
+  type: console
+  with:
+    message: |
+      Episode {{ event.episodeId }} from rule {{ event.ruleId }} changed state.
+```
+
+Use these fields to write workflow conditions that scope the automation to specific rules or episodes. For example, use `event.ruleId: "my-rule-id"` to scope the workflow to alert episodes from a specific rule.
+
 ## Prevent cascading handler loops
+
+This section applies to `workflows.failed` handlers. Alert episode lifecycle triggers fire once per state change and do not re-trigger on workflow failure.
 
 If a handler workflow itself fails, it can re-trigger itself. Two safeguards help you avoid infinite loops:
 
@@ -354,3 +402,4 @@ In practice, keep handler workflows simpler than the workflows they monitor. A h
 - [Triggers overview](/explore-analyze/workflows/triggers.md): All trigger types.
 - [Pass data and handle errors](/explore-analyze/workflows/authoring-techniques/pass-data-handle-errors.md): Per-step `on-failure` strategies complement event-driven handlers.
 - [Cases steps](/explore-analyze/workflows/steps/cases.md): Open cases from your handler.
+- [Connect workflows to the {{alerting-v2-system}}](../../alerting/kibana-alerting-experimental/workflows-alerting.md): Full reference for alert episode lifecycle triggers, including available trigger IDs, event payload fields, and when to use lifecycle triggers versus action policies.

--- a/explore-analyze/workflows/triggers/event-driven-triggers.md
+++ b/explore-analyze/workflows/triggers/event-driven-triggers.md
@@ -359,7 +359,7 @@ Alert episode lifecycle triggers fire when an alert episode changes state in the
 | `alerting.episodeSnoozed` | An alert episode is snoozed. |
 | `alerting.episodeUnsnoozed` | An alert episode is unsnoozed. |
 | `alerting.episodeAcked` | An alert episode is acknowledged. |
-| `alerting.episodeUnacked` | An alert episode acknowledgement is removed. |
+| `alerting.episodeUnacked` | An alert episode acknowledgment is removed. |
 | `alerting.episodeAssigned` | An alert episode is assigned to a user. |
 | `alerting.episodeUnassigned` | An alert episode assignment is removed. |
 | `alerting.episodeTagged` | A tag is applied to an alert episode. |


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->


Updates action policy, workflow, and notification docs for the experimental alerting system with content from five M2 doc issues. Following the tech preview principle of accuracy over comprehensiveness, additions focus on stable concepts — architectural constraints, when to choose features, and how the system works. UI step-by-step procedures, unstable IA details, and unconfirmed API identifiers are deferred to post-preview docs.

### Action policies target only Alert mode rules (#6877)

PR #272302 fixes a bug where rule quick filters in the action policy form surfaced all rule kinds instead of alert-kind rules only.

**`notifications-actions.md`** — Integrated the Alert mode constraint into the opening paragraph so readers immediately understand the scope of action policies. The specific UI detail about quick filters is omitted; no existing docs described the incorrect behavior.

**`action-policies/create-configure-action-policy.md`** — Added the Alert mode constraint as the opening sentence of the Policy type section so it reads as a foundational rule before the global/per-rule choice, not as an afterthought.

### Action policy scope uses matcher expressions only (#7012)

PR #272196 removes `type` and `ruleId` fields from action policy scope and replaces them with a matcher-based pattern.

**`action-policies/create-configure-action-policy.md`** — Added a sentence to the Match conditions section clarifying that the matcher expression is the sole mechanism for scoping a policy. There are no separate rule type or rule ID selector fields. The existing docs already reflected the KQL-based approach; this change makes the constraint explicit for users who may have encountered older API references.

### Execution history search and outcome filter (#7011)

PR #272914 adds a search bar and outcome filter to the Execution history Policies tab.

**`action-policies/manage-action-policies.md`** — Added a conceptual sentence noting that execution history supports search by policy name, rule name, or saved-object ID, and filtering by outcome. Explains that the new-events count reflects active filters. UI control details are omitted. Also updated the section heading from "Enable and snooze" to "Enable, disable, and snooze" so the section is findable by scanning.

### Alert episode lifecycle triggers (#6873, #7006)

PR #268915 registers an `episodeAssigned` workflow trigger. PR #272504 adds triggers for eight alert episode lifecycle events including activation, deactivation, snooze, acknowledge, assign, unassign, and tag.

**`workflows-alerting.md`** — Restructured the page to document both integration pathways: action policy-driven workflows and event-driven lifecycle triggers. Added a new Alert episode lifecycle triggers section with a table of all eight trigger IDs, the common event payload fields (`episodeId`, `ruleId`, `spaceId`), an example condition, and guidance on when to use triggers vs action policies. Marked the section as Stack only from 9.5.0. A TODO comment flags a discrepancy between trigger ID prefixes (`alertingV2.*` in issue #6873 vs `alerting.*` in issue #7006) for engineering confirmation before publishing.

### Description field cleanup (all pages)

Replaced `{{alerting-v2-system}}` with the literal string "experimental alerting system" in the `description` frontmatter field across all six pages in the set. The variable is not valid in that field.

### Scope statement improvements (all pages)

Added or sharpened "This page covers..." statements on `notifications-actions.md`, `workflows-alerting.md`, and `action-policies/reduce-notification-noise.md` to explicitly tell readers what they will understand or be able to do after reading.

---

### Issues confirmed as already covered or out of scope

No issues from this batch were already covered or out of scope. The trigger ID prefix discrepancy between issues #6873 and #7006 is flagged with a TODO comment in `workflows-alerting.md` and is not blocking publication of the stable concepts documented here.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes - Cursor + Claude
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->
