### PR TITLE
Clarify per-model eligibility for organization-level SAML SSO (BYOIdP)

### DIFF
--- a/deploy-manage/users-roles/_snippets/org-vs-deploy-sso.md
+++ b/deploy-manage/users-roles/_snippets/org-vs-deploy-sso.md
@@ -13,4 +13,4 @@ If you want to avoid exposing users to the {{ecloud}} Console, or have users who
 
 In some circumstances, you might want to use both organization-level and deployment-level SSO. For example, if you have a data analyst who interacts only with data in specific deployments, then you might want to configure deployment-level SSO for them. If you manage multiple tenants in a single organization, then you might want to configure organization-level SSO to administer deployments, and deployment-level SSO for the users who are using each deployment.
 
-Availability and entitlement for organization-level SAML SSO vary by deployment model. For details, refer to the [prerequisites for configuring {{ecloud}} SAML SSO](/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md#ec_prerequisites_4).
+Organization-level SAML SSO availability varies by resource type. For details, refer to the [prerequisites for configuring {{ecloud}} SAML SSO](/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md#ec_prerequisites_4).

--- a/deploy-manage/users-roles/_snippets/org-vs-deploy-sso.md
+++ b/deploy-manage/users-roles/_snippets/org-vs-deploy-sso.md
@@ -12,3 +12,5 @@ The option that you choose depends on your requirements:
 If you want to avoid exposing users to the {{ecloud}} Console, or have users who only interact with some deployments, then you might prefer users to interact with your deployment directly.
 
 In some circumstances, you might want to use both organization-level and deployment-level SSO. For example, if you have a data analyst who interacts only with data in specific deployments, then you might want to configure deployment-level SSO for them. If you manage multiple tenants in a single organization, then you might want to configure organization-level SSO to administer deployments, and deployment-level SSO for the users who are using each deployment.
+
+Availability and entitlement for organization-level SAML SSO vary by deployment model. For details, refer to the [prerequisites for configuring {{ecloud}} SAML SSO](/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md#ec_prerequisites_4).

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -48,6 +48,8 @@ For detailed examples of implementing SAML SSO using common identity providers, 
     * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.
     * **ECK, ECE, and self-managed clusters connected through [Cloud Connect](/deploy-manage/cloud-connect.md)**: Each connected cluster qualifies individually based on its license. A cluster with a Platinum or Enterprise license is eligible, with no paid {{ecloud}} subscription required. Clusters on lower tiers, such as Basic, are not eligible, even if other eligible clusters are connected to the same organization.
 
+    Eligibility is assessed independently for each resource type, so meeting the requirement for one does not grant entitlement to another. For example, an organization with both a {{serverless-full}} project and an {{ech}} deployment on a Standard subscription can use organization-level SAML SSO with the Serverless project, where it is included, but the {{ech}} deployment remains ineligible until the organization upgrades to an Enterprise subscription.
+
 
 ## Risks and considerations [ec_risks_and_considerations]
 

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -46,7 +46,7 @@ For detailed examples of implementing SAML SSO using common identity providers, 
 
     * **{{ech}}**: Requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
     * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.
-    * **Self-managed clusters connected through [Cloud Connect](/deploy-manage/cloud-connect.md)**: Included when at least one connected cluster is licensed Platinum or Enterprise. No paid {{ecloud}} subscription is required; clusters on lower tiers, such as Basic, are not eligible.
+    * **Self-managed clusters connected through [Cloud Connect](/deploy-manage/cloud-connect.md)**: Each connected cluster is evaluated individually against its own license. A cluster licensed Platinum or Enterprise is eligible, with no paid {{ecloud}} subscription required. Clusters on lower tiers, such as Basic, are not eligible, even if other eligible clusters are connected to the same organization.
 
 
 ## Risks and considerations [ec_risks_and_considerations]

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -41,8 +41,12 @@ For detailed examples of implementing SAML SSO using common identity providers, 
 
 ## Prerequisites [ec_prerequisites_4]
 
-* This functionality requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
 * You must have a SAML 2.0 compatible identity provider.
+* Eligibility for organization-level SAML SSO depends on your deployment model:
+
+    * **{{ech}}**: Requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
+    * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.
+    * **Self-managed clusters connected through [Cloud Connect](/deploy-manage/cloud-connect.md)**: Included when at least one connected cluster is licensed Platinum or Enterprise. No paid {{ecloud}} subscription is required; clusters on lower tiers, such as Basic, are not eligible.
 
 
 ## Risks and considerations [ec_risks_and_considerations]

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -46,7 +46,7 @@ For detailed examples of implementing SAML SSO using common identity providers, 
 
     * **{{ech}}**: Requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
     * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.
-    * **Self-managed clusters connected through [Cloud Connect](/deploy-manage/cloud-connect.md)**: Each connected cluster is evaluated individually against its own license. A cluster licensed Platinum or Enterprise is eligible, with no paid {{ecloud}} subscription required. Clusters on lower tiers, such as Basic, are not eligible, even if other eligible clusters are connected to the same organization.
+    * **ECK, ECE, and self-managed clusters connected through [Cloud Connect](/deploy-manage/cloud-connect.md)**: Each connected cluster qualifies individually based on its license. A cluster with a Platinum or Enterprise license is eligible, with no paid {{ecloud}} subscription required. Clusters on lower tiers, such as Basic, are not eligible, even if other eligible clusters are connected to the same organization.
 
 
 ## Risks and considerations [ec_risks_and_considerations]

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -42,7 +42,7 @@ For detailed examples of implementing SAML SSO using common identity providers, 
 ## Prerequisites [ec_prerequisites_4]
 
 * You must have a SAML 2.0 compatible identity provider.
-* * Eligibility for organization-level SAML SSO varies by resource type, rather than being a single, organization-wide entitlement:
+* Eligibility for organization-level SAML SSO varies by resource type, rather than being a single, organization-wide entitlement:
 
     * **{{ech}}**: Requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
     * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -42,7 +42,7 @@ For detailed examples of implementing SAML SSO using common identity providers, 
 ## Prerequisites [ec_prerequisites_4]
 
 * You must have a SAML 2.0 compatible identity provider.
-* Eligibility for organization-level SAML SSO depends on the deployment model you use, rather than being a single, organization-wide entitlement:
+* * Eligibility for organization-level SAML SSO varies by resource type, rather than being a single, organization-wide entitlement:
 
     * **{{ech}}**: Requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
     * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.

--- a/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
+++ b/deploy-manage/users-roles/cloud-organization/configure-saml-authentication.md
@@ -42,7 +42,7 @@ For detailed examples of implementing SAML SSO using common identity providers, 
 ## Prerequisites [ec_prerequisites_4]
 
 * You must have a SAML 2.0 compatible identity provider.
-* Eligibility for organization-level SAML SSO depends on your deployment model:
+* Eligibility for organization-level SAML SSO depends on the deployment model you use, rather than being a single, organization-wide entitlement:
 
     * **{{ech}}**: Requires an [Enterprise subscription](https://www.elastic.co/subscriptions/cloud).
     * **{{serverless-full}}**: Included at no additional cost, on any tier across all project types.


### PR DESCRIPTION
Updates the Configure Elastic Cloud SAML SSO Prerequisites to reflect the approved [BYOIdP pricing & packaging decision](https://docs.google.com/document/d/1QYERB-Ic4XBEBBiXDpPYofMJwDNnnjdx66JJgH1RVM8/edit?tab=t.gnnhu5ici4pa): Enterprise on ECH, included on Serverless, and included via Cloud Connect with a Platinum+ connected cluster (no paid cloud subscription). 

Adds a brief consistency note to the shared org-vs-deployment SSO snippet. 