### PR TITLE
docs: note descending default sort for numeric heat map Y axis (#7051)

### DIFF
--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -315,7 +315,7 @@ When creating or editing a visualization, you can customize several appearance o
 :   Control the sort order of the vertical axis values:
     - **Unsorted**: Use the default sort order (default).
 
-       {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+       {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, descending numeric order is used. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
    
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -314,8 +314,8 @@ When creating or editing a visualization, you can customize several appearance o
 **Sort order** {applies_to}`serverless: ga` {applies_to}`stack: ga 9.4`
 :   Control the sort order of the vertical axis values:
     - **Unsorted**: Use the default sort order (default).
-
-       {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, descending numeric order is used. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+      
+      {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, descending numeric order is used. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
    
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -314,6 +314,7 @@ When creating or editing a visualization, you can customize several appearance o
 **Sort order** {applies_to}`serverless: ga` {applies_to}`stack: ga 9.4`
 :   Control the sort order of the vertical axis values:
     - **Unsorted**: Use the default sort order (default).
+        - {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default is descending numeric order. String axes keep their existing default order, and you can still set the sort order manually.
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
 

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -314,7 +314,8 @@ When creating or editing a visualization, you can customize several appearance o
 **Sort order** {applies_to}`serverless: ga` {applies_to}`stack: ga 9.4`
 :   Control the sort order of the vertical axis values:
     - **Unsorted**: Use the default sort order (default).
-        - {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+
+      {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
 

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -314,7 +314,7 @@ When creating or editing a visualization, you can customize several appearance o
 **Sort order** {applies_to}`serverless: ga` {applies_to}`stack: ga 9.4`
 :   Control the sort order of the vertical axis values:
     - **Unsorted**: Use the default sort order (default).
-        - {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default is descending numeric order. String axes keep their existing default order, and you can still set the sort order manually.
+        - {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
 

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -313,9 +313,10 @@ When creating or editing a visualization, you can customize several appearance o
 
 **Sort order** {applies_to}`serverless: ga` {applies_to}`stack: ga 9.4`
 :   Control the sort order of the vertical axis values:
-    - **Unsorted**: Use the default sort order (default).
+- **Unsorted**: Use the default sort order (default).
 
-        {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+   {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+   
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
 

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -315,7 +315,7 @@ When creating or editing a visualization, you can customize several appearance o
 :   Control the sort order of the vertical axis values:
     - **Unsorted**: Use the default sort order (default).
 
-      {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+        {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
 

--- a/explore-analyze/visualize/charts/heat-map-charts.md
+++ b/explore-analyze/visualize/charts/heat-map-charts.md
@@ -313,9 +313,9 @@ When creating or editing a visualization, you can customize several appearance o
 
 **Sort order** {applies_to}`serverless: ga` {applies_to}`stack: ga 9.4`
 :   Control the sort order of the vertical axis values:
-- **Unsorted**: Use the default sort order (default).
+    - **Unsorted**: Use the default sort order (default).
 
-   {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
+       {applies_to}`stack: ga 9.5` {applies_to}`serverless: ga` When the vertical axis uses numeric data, the unsorted default sorts rows in descending numeric order. Axes that use other data types, such as strings, are unaffected: their rows appear in the order the data is returned. You can still set the sort order manually.
    
     - **Ascending**: Sort values in ascending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.
     - **Descending**: Sort values in descending order. Automatically detects whether to use numeric or alphabetical sorting based on the data type.


### PR DESCRIPTION
## Summary

This PR addresses #7051 with the following change:

- **`explore-analyze/visualize/charts/heat-map-charts.md`**: Clarifies the **Vertical axis** > **Sort order** > **Unsorted** behavior. As of Stack 9.5 and in serverless, when the vertical axis uses numeric bucket data, the unsorted default resolves to descending numeric order (Kibana PR [#268961](https://github.com/elastic/kibana/pull/268961)). The change is added as a version-tagged sub-bullet so the existing wording is preserved for earlier versions, and the note records that string axes keep their previous default and that the sort order can still be set manually. The horizontal axis Sort order is unchanged, since the new default applies only to the Y axis.

## Resolves

Closes #7051

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.