### PR TITLE
[Alerting V2][Serverless & 9.5][M2]  Add action policies conceptual page, common scenarios, and nav restructure

### DIFF
--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
@@ -1,0 +1,81 @@
+---
+navigation_title: About action policies
+applies_to:
+  stack: experimental 9.5+
+  serverless: experimental
+products:
+  - id: kibana
+description: "How action policies gate alert episodes through suppression, match conditions, and frequency before invoking workflows in the experimental alerting system."
+---
+
+# About action policies [about-action-policies]
+
+Action policies are part of the {{alerting-v2-system}} in {{kib}}. An action policy is the gating layer between an alert episode and a workflow. It decides whether and when to invoke a workflow by running the alert episode through a sequence of gates. A workflow runs only if the alert episode clears each gate in sequence.
+
+## Why policies are separate from rules [policies-separate-from-rules]
+
+Policies are independent of rules. A single global policy can cover alert episodes from many rules, so a policy matching `severity: "critical"` applies regardless of which rule produced the alert episode. You can also update notification routing without touching any rule, and you can create rules without any action policy, which is useful for testing detection logic before wiring up notifications.
+
+When you do need routing that is specific to one rule, create a per-rule policy and bind it to that rule at creation.
+
+## How alert episodes are gated [action-policy-gates]
+
+The three gates are suppression, match conditions, and frequency:
+
+* **Suppression** - Suppression checks whether the alert episode should be silenced. Episodes that are acknowledged, snoozed, or inside a maintenance window are stopped here and no workflow is invoked. For details on each mechanism and its scope, refer to [Reduce notification noise](reduce-notification-noise.md).
+* **Match conditions** - Match conditions filter which alert episodes the policy applies to. You define them using [KQL](../../../query-filter/languages/kql.md). An empty match condition applies to all alert episodes within the policy's scope.
+* **Frequency** - Frequency controls how often the policy can invoke its workflows for the same group of episodes, and how episodes batch before a workflow is invoked. Options are one notification per alert episode, one per notification group, or one digest for all matching episodes. If a workflow was already invoked within the cooldown period, the episode waits.
+
+If any gate stops the episode, the workflow is not invoked for that policy.
+
+:::{note}
+Because each action policy evaluates alert episodes independently, an episode that is blocked by one policy can still trigger a workflow through a second policy with different conditions.
+:::
+
+## How policy types differ [policy-types]
+
+Policies can be global or per-rule. Global policies apply across all rules in a space and suit most use cases. Per-rule policies apply to a single rule and give you precise control over routing for that rule without affecting anything else in the space.
+
+### Global policies
+
+A global policy applies to all alert episodes in the space, from any rule. When an alert episode is produced, the dispatcher evaluates all enabled global policies that are not snoozed. Global is the default type and suits most use cases.
+
+### Per-rule policies
+
+A per-rule policy is scoped to a single rule. It applies only to alert episodes produced by that specific rule. Use a per-rule policy when routing is specific to one rule and you do not want it to affect other rules in the space. The rule association is set at creation and cannot be changed.
+
+## How policies apply to rules [how-policies-apply]
+
+How a policy applies depends on whether it is global or per-rule. Multiple policies can match the same alert episode, and each runs independently. There is no precedence or merging between them. If no policy matches an alert episode, no workflow is invoked and no notification is sent.
+
+### Global policies
+
+Global policies don't reference rules directly. You scope them using KQL over alert episode and rule fields, for example `rule.tags: "checkout"` or `data.severity: "critical"`. A global policy applies to every matching alert episode in the space, from any rule.
+
+### Per-rule policies
+
+Per-rule policies are bound to a specific rule at creation. They apply only to alert episodes from that rule, and you can still use match conditions to filter further within that rule's alert episodes.
+
+## How action policies are evaluated [how-action-policies-evaluated]
+
+{{kib}} runs a background process called the dispatcher that checks for eligible alert episodes on a short interval (around 5 seconds) and evaluates action policies against them. The dispatcher runs on its own cycle, separate from the rule schedule.
+
+For each enabled policy that is not snoozed, the dispatcher works through the following steps:
+
+1. **Gating:** Is the alert episode acknowledged, snoozed, or deactivated? If so, skip. Refer to [Reduce notification noise](reduce-notification-noise.md) to learn more.
+2. **Matcher:** Does the alert episode match the policy's KQL? If not, skip this policy.
+3. **Grouping:** How should matching alert episodes batch into notification groups?
+4. **Frequency:** Has a workflow already been invoked for this notification group recently? If so, wait.
+5. **Destinations:** Invoke the configured workflows.
+
+Workflow invocations may not happen immediately after a rule evaluates.
+
+:::{tip}
+Severity changes can cause a policy to match an episode for the first time, which fires a notification even if the episode is not new. For example, if a policy is scoped to `severity: "critical"` and an episode escalates from `low` to `critical`, the policy fires because it has no prior notification record for that episode. However, a severity change alone does not re-trigger a policy that already matched the episode — only a status change or the expiry of a time-based throttle can do that. For details and examples, refer to [Severity escalation and de-escalation](common-action-policy-scenarios.md#severity-escalation).
+:::
+
+## Next steps
+
+- [Create and configure an action policy](create-configure-action-policy.md) to set up policy type, match conditions, grouping, frequency, and workflow destinations.
+- [Manage action policies](manage-action-policies.md) to enable, disable, snooze, edit, or delete the policies in your space.
+- [Action policy reference](action-policy-reference.md) to look up available match condition fields, grouping modes, and frequency options.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
@@ -71,7 +71,7 @@ For each enabled policy that is not snoozed, the dispatcher works through the fo
 Workflow invocations may not happen immediately after a rule evaluates.
 
 :::{tip}
-Severity changes can cause a policy to match an episode for the first time, which fires a notification even if the episode is not new. For example, if a policy is scoped to `severity: "critical"` and an episode escalates from `low` to `critical`, the policy fires because it has no prior notification record for that episode. However, a severity change alone does not re-trigger a policy that already matched the episode — only a status change or the expiry of a time-based throttle can do that. For details and examples, refer to [Severity escalation and de-escalation](common-action-policy-scenarios.md#severity-escalation).
+Severity changes can cause a policy to match an episode for the first time, which fires a notification even if the episode is not new. For example, if a policy is scoped to `severity: "critical"` and an episode escalates from `low` to `critical`, the policy fires because it has no prior notification record for that episode. However, a severity change alone does not re-trigger a policy that already matched the episode. Only a status change or the expiry of a time-based throttle can do that. For details and examples, refer to [Severity escalation and de-escalation](common-action-policy-scenarios.md#severity-escalation).
 :::
 
 ## Next steps

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -29,9 +29,7 @@ Use these fields in the **Match conditions** expression to filter which alert ep
 | `data.*` | object | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. Use for rule-specific fields not covered by the standard episode fields above. | Depends on rule type | `data.host.name: "web-01"` |
 
 <!--[CONTENT NEEDED: 
-1. Confirm whether `severity_max` (highest severity over the episode's lifetime) is also available. If so, add it to the table after `severity` with the description: "Highest severity reached over the lifetime of the alert episode. Use to catch episodes that were once critical even if they have since de-escalated." Accepted values: `info`, `low`, `medium`, `high`, `critical`.
-2. Confirm whether a severity change mid-episode (escalation or de-escalation of `severity`) triggers policy re-evaluation independently of episode status changes. If it does, a note is needed in the Frequency section below explaining the interaction between severity changes and the "On status change" option.
-3. When rule authoring docs are created (issue #6689), link from this table row to the rule authoring page that explains how to include a `severity` column in the ES|QL query. The full severity contract (column name, case-insensitivity, silent-ignore behavior) belongs in the rule authoring reference, not here.]
+When rule authoring docs are created (issue #6689), link from this table row to the rule authoring page that explains how to include a `severity` column in the ES|QL query. The full severity contract (column name, case-insensitivity, silent-ignore behavior) belongs in the rule authoring reference, not here.]
 -->
 
 ## Notify per options [notification-grouping]
@@ -54,9 +52,6 @@ Frequency controls how often the policy fires for a given alert episode or notif
 | On status change + repeat at interval | Notifies on status change, then resends notifications at a regular interval while the alert episode remains in the same status. | You want status change notifications plus periodic reminders that a problem is still unresolved, in case it has been missed or pushed aside. |
 | At most once every… | Caps notifications at one per alert episode or notification group within the chosen interval, regardless of rule frequency. | You want to limit notification volume for noisy rules without missing new or ongoing issues. |
 | Every evaluation | Notifies on every rule evaluation. Can be noisy. Use sparingly and only with infrequent rule schedules. | You need a full audit trail of every evaluation, or the rule runs infrequently enough that noise isn't a concern. |
-
-<!--[CONTENT NEEDED: Confirm whether a severity change mid-episode (escalation or de-escalation of `severity`) triggers policy re-evaluation independently of episode status changes. If it does, this table needs a note or a new strategy option explaining the interaction between severity changes and the "On status change" option.]
--->
 
 ### Frequency options for Episode [frequency-when-episode-per_episode]
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -14,13 +14,13 @@ Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page is 
 
 ## Match conditions fields [matcher-fields]
 
-Use these fields in the **Match conditions** expression to filter which alert episodes a policy applies to. Combine them with standard [KQL](../../../query-filter/languages/kql.md) operators, for example `episode.severity: "critical" AND episode_status: "active"`.
+Use these fields in the **Match conditions** expression to filter which alert episodes a policy applies to. Combine them with standard [KQL](../../../query-filter/languages/kql.md) operators, for example `severity: "critical" AND episode_status: "active"`.
 
 | Field | Type | Description | Accepted values | Example |
 |---|---|---|---|---|
 | `episode_id` | string | Unique identifier of the alert episode. | Any string | `episode_id: "ep-001"` |
 | `episode_status` | string | Current lifecycle status of the alert episode. | `inactive`, `pending`, `active`, `recovering` | `episode_status: "active"` |
-| `episode.severity` | string | Current severity of the alert episode. Populated when the rule's ES\|QL query includes a `severity` column whose value matches a supported level (case-insensitive). Unrecognized values are silently ignored and the field is absent. Not set during recovery. Use to route high-severity episodes to dedicated workflows. | `info`, `low`, `medium`, `high`, `critical` | `episode.severity: "critical" OR episode.severity: "high"` |
+| `severity` | string | Current severity of the alert episode. Populated when the rule's ES\|QL query includes a `severity` column whose value matches a supported level (case-insensitive). Unrecognized values are silently ignored and the field is absent. Not set during recovery. Use to route high-severity episodes to dedicated workflows. | `info`, `low`, `medium`, `high`, `critical` | `severity: "critical" OR severity: "high"` |
 | `group_hash` | string | Stable hash identifying the alert series the alert episode belongs to. | Any string | `group_hash: "abc123"` |
 | `last_event_timestamp` | string | ISO 8601 timestamp of the most recent event recorded for the alert episode. | ISO 8601 timestamp | `last_event_timestamp > "2026-01-01"` |
 | `rule.id` | string | Unique identifier of the rule that generated the alert episode. | Any string | `rule.id: "rule-001"` |
@@ -29,8 +29,8 @@ Use these fields in the **Match conditions** expression to filter which alert ep
 | `data.*` | object | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. Use for rule-specific fields not covered by the standard episode fields above. | Depends on rule type | `data.host.name: "web-01"` |
 
 <!--[CONTENT NEEDED: 
-1. Confirm whether `episode.severity_max` (highest severity over the episode's lifetime) is also available. If so, add it to the table after `episode.severity` with the description: "Highest severity reached over the lifetime of the alert episode. Use to catch episodes that were once critical even if they have since de-escalated." Accepted values: `info`, `low`, `medium`, `high`, `critical`.
-2. Confirm whether a severity change mid-episode (escalation or de-escalation of `episode.severity`) triggers policy re-evaluation independently of episode status changes. If it does, a note is needed in the Frequency section below explaining the interaction between severity changes and the "On status change" option.
+1. Confirm whether `severity_max` (highest severity over the episode's lifetime) is also available. If so, add it to the table after `severity` with the description: "Highest severity reached over the lifetime of the alert episode. Use to catch episodes that were once critical even if they have since de-escalated." Accepted values: `info`, `low`, `medium`, `high`, `critical`.
+2. Confirm whether a severity change mid-episode (escalation or de-escalation of `severity`) triggers policy re-evaluation independently of episode status changes. If it does, a note is needed in the Frequency section below explaining the interaction between severity changes and the "On status change" option.
 3. When rule authoring docs are created (issue #6689), link from this table row to the rule authoring page that explains how to include a `severity` column in the ES|QL query. The full severity contract (column name, case-insensitivity, silent-ignore behavior) belongs in the rule authoring reference, not here.]
 -->
 
@@ -55,7 +55,7 @@ Frequency controls how often the policy fires for a given alert episode or notif
 | At most once every… | Caps notifications at one per alert episode or notification group within the chosen interval, regardless of rule frequency. | You want to limit notification volume for noisy rules without missing new or ongoing issues. |
 | Every evaluation | Notifies on every rule evaluation. Can be noisy. Use sparingly and only with infrequent rule schedules. | You need a full audit trail of every evaluation, or the rule runs infrequently enough that noise isn't a concern. |
 
-<!--[CONTENT NEEDED: Confirm whether a severity change mid-episode (escalation or de-escalation of `episode.severity`) triggers policy re-evaluation independently of episode status changes. If it does, this table needs a note or a new strategy option explaining the interaction between severity changes and the "On status change" option.]
+<!--[CONTENT NEEDED: Confirm whether a severity change mid-episode (escalation or de-escalation of `severity`) triggers policy re-evaluation independently of episode status changes. If it does, this table needs a note or a new strategy option explaining the interaction between severity changes and the "On status change" option.]
 -->
 
 ### Frequency options for Episode [frequency-when-episode-per_episode]
@@ -101,4 +101,4 @@ The dispatcher records each run with one of the following outcomes. To investiga
 
 - [Create and configure an action policy](create-configure-action-policy.md) to apply these fields and options when setting up a policy.
 - [Manage action policies in {{alerting-v2-system}}](manage-action-policies.md) to enable, disable, snooze, or audit your policies.
-- [Notifications and actions in {{alerting-v2-system}}](../notifications-actions.md) to understand how action policies evaluate and gate alert episodes.
+- [About action policies](about-action-policies.md) to understand how action policies evaluate and gate alert episodes.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
@@ -99,6 +99,6 @@ If you want re-notification for episodes that stay active without a status chang
 
 ## Related pages
 
-- [Action policy reference](action-policy-reference.md) - Find descriptions of match condition fields, grouping modes, and frequency options.
-- [About action policies](about-action-policies.md) - Understand how action policies evaluate and gate alert episodes.
-- [Create and configure an action policy](create-configure-action-policy.md) - Learn how to set up policy type, match conditions, grouping, frequency, and workflow destinations.
+- [Action policy reference](action-policy-reference.md) to find descriptions of match condition fields, grouping modes, and frequency options.
+- [About action policies](about-action-policies.md) to understand how action policies evaluate and gate alert episodes.
+- [Create and configure an action policy](create-configure-action-policy.md) to learn how to set up policy type, match conditions, grouping, frequency, and workflow destinations.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
@@ -30,7 +30,7 @@ Each policy evaluates alert episodes independently:
 
 - An episode with `severity: "critical"` matches Policy A but not Policy B.
 - An episode with `severity: "high"` matches Policy B but not Policy A.
-- If an episode's severity changes mid-lifecycle, the policies that match it change accordingly. For example, if an episode escalates from `high` to `critical`, Policy A starts matching and Policy B stops matching. Policy A also then executes because it has no prior notification record for that episode.
+- If an episode's severity changes mid-lifecycle, the policies that match it change accordingly. For example, if an episode escalates from `high` to `critical`, Policy A starts matching and Policy B stops matching. Policy A fires because it has no prior notification record for that episode.
 
 ## Manage notifications across severity changes [severity-escalation]
 
@@ -59,7 +59,7 @@ If a policy already matched an episode at a lower severity and the episode escal
 | Field | Value |
 |---|---|
 | **Policy type** | Global |
-| **Match conditions** | (none — matches all episodes) |
+| **Match conditions** | (None, matches all episodes) |
 | **Notify per** | Episode |
 | **Frequency** | On status change |
 | **Destinations** | Slack workflow |
@@ -94,7 +94,7 @@ If you want re-notification for episodes that stay active without a status chang
 | **Policy type** | Global |
 | **Match conditions** | `severity: "critical"` |
 | **Notify per** | Episode |
-| **Frequency** | At most once every 1h |
+| **Frequency** | At most once every 1 hour |
 | **Destinations** | PagerDuty workflow |
 
 ## Related pages

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
@@ -1,0 +1,104 @@
+---
+navigation_title: Common scenarios
+applies_to:
+  stack: experimental 9.5+
+  serverless: experimental
+products:
+  - id: kibana
+description: "Common action policy scenarios for the experimental alerting system, including routing by severity, handling severity escalation, and controlling re-notification."
+---
+
+# Common action policy scenarios [common-action-policy-scenarios]
+
+Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page covers common situations you're likely to encounter when setting up action policies, and explains how to configure them to get the behavior you expect.
+
+## Route alert episodes to different workflows by severity [routing-by-severity]
+
+When your rules produce alert episodes at different severity levels, you'll often want to route them to different workflows. For example, you might page an on-call team for critical episodes while sending lower-severity episodes to a Slack channel for async review.
+
+To do this, create separate policies scoped to specific severity values using match conditions:
+
+| Field | Policy A | Policy B |
+|---|---|---|
+| **Policy type** | Global | Global |
+| **Match conditions** | `severity: "critical"` | `severity: "low" OR severity: "medium" OR severity: "high"` |
+| **Notify per** | Episode | Episode |
+| **Frequency** | On status change | On status change |
+| **Destinations** | PagerDuty workflow | Slack workflow |
+
+Each policy evaluates alert episodes independently:
+
+- An episode with `severity: "critical"` matches Policy A but not Policy B.
+- An episode with `severity: "high"` matches Policy B but not Policy A.
+- If an episode's severity changes mid-lifecycle, the policies that match it change accordingly. For example, if an episode escalates from `high` to `critical`, Policy A starts matching and Policy B stops matching. Policy A also then executes because it has no prior notification record for that episode.
+
+## Manage notifications across severity changes [severity-escalation]
+
+To manage notifications effectively when episode severity changes, you need to understand how policies match and re-match episodes as severity shifts. Whether a severity change fires a notification depends on whether the policy has matched the episode before and what frequency option is set.
+
+### Notify when an episode escalates into a new severity threshold
+
+Scope a policy to the severity level you want to be notified about. When an episode escalates into that severity level for the first time, the policy fires because it has no prior notification record for the episode.
+
+**Example:** Policy B is scoped to `severity: "critical"`. An episode starts at `low` severity, so Policy B does not match. When the episode escalates to `critical`, Policy B now matches and fires (regardless of the frequency setting) because it has never notified for this episode before.
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | `severity: "critical"` |
+| **Notify per** | Episode |
+| **Frequency** | On status change |
+| **Destinations** | PagerDuty workflow |
+
+### Prevent duplicate notifications when severity changes within an existing match
+
+If a policy already matched an episode at a lower severity and the episode escalates, the policy does not automatically re-notify. With `On status change` frequency, a severity change alone does not count as a status change.
+
+**Example:** Policy A matches all episodes regardless of severity. It notified when the episode was `low`. The episode escalates to `critical`, but Policy A still matches and the status has not changed, only the severity has. The throttle blocks re-notification. To re-notify on escalation, use a time-based throttle or create separate policies per severity level as described in [Route alert episodes to different workflows by severity](#routing-by-severity).
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | (none — matches all episodes) |
+| **Notify per** | Episode |
+| **Frequency** | On status change |
+| **Destinations** | Slack workflow |
+
+### Stop notifications when an episode de-escalates below a policy's threshold
+
+If an episode drops below a policy's severity threshold, the policy stops matching and sends no further notifications. If the episode later escalates back above the threshold, the policy fires again as if it were the first match.
+
+**Example:** Policy B is scoped to `severity: "critical"`. An episode de-escalates from `critical` to `high`. Policy B no longer matches and stops sending notifications. If the episode later escalates back to `critical`, Policy B fires again.
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | `severity: "critical"` |
+| **Notify per** | Episode |
+| **Frequency** | On status change |
+| **Destinations** | PagerDuty workflow |
+
+## Re-notify for persistently active episodes [controlling-re-notification]
+
+The `On status change` frequency option notifies once per status transition (for example, when an episode activates or resolves). This is efficient for reducing noise, but it means that a persistently active episode that only changes in severity won't re-trigger a notification.
+
+If you want re-notification for episodes that stay active without a status change, use a time-based throttle instead:
+
+- **`At most once every…`:** Re-notifies after the configured interval regardless of whether severity or status changed. For example, `1h` sends a follow-up notification every hour while the episode remains active and matched.
+- **`On status change + repeat at interval`:** Notifies on status change and then repeats at the configured interval while the episode stays in the same status.
+
+**Example:** You want to be re-paged if a critical episode stays open for more than an hour. Set the policy frequency to `At most once every 1h`. The policy fires when the episode first matches and then again each hour until the episode resolves or no longer matches.
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | `severity: "critical"` |
+| **Notify per** | Episode |
+| **Frequency** | At most once every 1h |
+| **Destinations** | PagerDuty workflow |
+
+## Related pages
+
+- [Action policy reference](action-policy-reference.md) - Find descriptions of match condition fields, grouping modes, and frequency options.
+- [About action policies](about-action-policies.md) - Understand how action policies evaluate and gate alert episodes.
+- [Create and configure an action policy](create-configure-action-policy.md) - Learn how to set up policy type, match conditions, grouping, frequency, and workflow destinations.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -45,9 +45,9 @@ An optional [KQL](../../../query-filter/languages/kql.md) expression that filter
 
 The match condition is the sole mechanism for scoping a policy beyond its base type. There are no separate rule type or rule ID selector fields. All scoping is done through this expression. For a global policy that should target a specific rule, use `rule.id: "my-rule-id"` or `rule.tags: "my-tag"` in the match condition.
 
-Use match conditions to route different alert episodes to different policies, for example, one policy for `episode.severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
+Use match conditions to route different alert episodes to different policies, for example, one policy for `severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
 
-<!--[CONTENT NEEDED: Confirm whether `data.severity` on legacy rules (rules that have not migrated to `episode.severity`) should be documented as an alternative matcher, or removed from guidance entirely. If retained, add a note in the reference explaining when to use `data.*` severity fields versus `episode.severity`.]
+<!--[CONTENT NEEDED: Confirm whether `data.severity` on legacy rules (rules that have not migrated to `severity`) should be documented as an alternative matcher, or removed from guidance entirely. If retained, add a note in the reference explaining when to use `data.*` severity fields versus `severity`.]
 -->
 
 ## Grouping and frequency [reduce-noise-grouping]
@@ -73,6 +73,10 @@ For detailed descriptions, frequency options, and examples for each mode, refer 
 
 **Frequency** limits how often the policy can fire for a given notification group. The interval resets from the last time the policy fired, so successive notifications stay at least `interval` apart. Set a duration such as `1h` or `30m`. For available options by **Notify per** mode, refer to [Frequency](action-policy-reference.md#throttle-strategies).
 
+:::{note}
+`On status change` only re-notifies when the alert episode's status changes, not when its severity changes. If an episode escalates from `low` to `critical` but the policy already matched it and the status hasn't changed, the throttle blocks re-notification. To receive escalation notifications, either create separate policies scoped to specific severity levels, or use a time-based throttle such as `At most once every 1h` so the policy re-notifies after the interval regardless of severity or status changes. For examples, refer to [Controlling re-notification](common-action-policy-scenarios.md#controlling-re-notification).
+:::
+
 ## Destinations
 
 One or more workflows to invoke when the policy matches. Use the search field to find and attach workflows.
@@ -81,4 +85,4 @@ One or more workflows to invoke when the policy matches. Use the search field to
 
 - [Manage action policies in {{alerting-v2-system}}](manage-action-policies.md) to view, enable, disable, or snooze the policies you create.
 - [Action policy reference in {{alerting-v2-system}}](action-policy-reference.md) to look up match condition fields, grouping modes, and frequency options.
-- [Notifications and actions in {{alerting-v2-system}}](../notifications-actions.md) to understand how action policies evaluate and gate alert episodes.
+- [About action policies](about-action-policies.md) to understand how action policies evaluate and gate alert episodes.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -17,12 +17,6 @@ Because policies are separate from rules, you can update notification behavior a
 
 For match conditions fields, grouping modes, frequency options, and dispatch outcomes, refer to [Action policy reference](action-policy-reference.md).
 
-<!--
-## Create an action policy
-
-[CONTENT NEEDED for M2: UI. Once the navigation and action policy settings have been confirmed, add instructions for creating an action policy.]
--->
-
 ## Policy type [policy-type]
 
 Action policies only process alert episodes from rules running in Alert mode. Signals produced by rules running in Detect mode are not eligible for action policy evaluation.
@@ -46,9 +40,6 @@ An optional [KQL](../../../query-filter/languages/kql.md) expression that filter
 The match condition is the sole mechanism for scoping a policy beyond its base type. There are no separate rule type or rule ID selector fields. All scoping is done through this expression. For a global policy that should target a specific rule, use `rule.id: "my-rule-id"` or `rule.tags: "my-tag"` in the match condition.
 
 Use match conditions to route different alert episodes to different policies, for example, one policy for `severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
-
-<!--[CONTENT NEEDED: Confirm whether `data.severity` on legacy rules (rules that have not migrated to `severity`) should be documented as an alternative matcher, or removed from guidance entirely. If retained, add a note in the reference explaining when to use `data.*` severity fields versus `severity`.]
--->
 
 ## Grouping and frequency [reduce-noise-grouping]
 
@@ -74,12 +65,14 @@ For detailed descriptions, frequency options, and examples for each mode, refer 
 **Frequency** limits how often the policy can fire for a given notification group. The interval resets from the last time the policy fired, so successive notifications stay at least `interval` apart. Set a duration such as `1h` or `30m`. For available options by **Notify per** mode, refer to [Frequency](action-policy-reference.md#throttle-strategies).
 
 :::{note}
-`On status change` only re-notifies when the alert episode's status changes, not when its severity changes. If an episode escalates from `low` to `critical` but the policy already matched it and the status hasn't changed, the throttle blocks re-notification. To receive escalation notifications, either create separate policies scoped to specific severity levels, or use a time-based throttle such as `At most once every 1h` so the policy re-notifies after the interval regardless of severity or status changes. For examples, refer to [Controlling re-notification](common-action-policy-scenarios.md#controlling-re-notification).
+`On status change` only re-notifies when the alert episode's status changes, not when its severity changes. If an episode escalates from `low` to `critical` but the policy already matched it and the status hasn't changed, the throttle blocks re-notification. 
+
+To receive escalation notifications, either create separate policies scoped to specific severity levels, or use a time-based throttle such as `At most once every 1h` so the policy re-notifies after the interval regardless of severity or status changes. For examples, refer to [Controlling re-notification](common-action-policy-scenarios.md#controlling-re-notification).
 :::
 
 ## Destinations
 
-One or more workflows to invoke when the policy matches. Use the search field to find and attach workflows.
+One or more [workflows](../../../workflows.md) to invoke when the policy matches. Use the search field to find and attach workflows.
 
 ## Related pages
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
@@ -12,7 +12,7 @@ description: "How to reduce notification noise in the experimental alerting syst
 
 Acknowledge, snooze, and deactivate are part of the {{alerting-v2-system}} in {{kib}}. Each one silences notifications for an alert episode at a different scope. When an alert episode is silenced, the dispatcher stops processing it before any action policy matching, grouping, or frequency evaluation runs.
 
-This page covers when to use each silencing mechanism and how the scope of an alert episode snooze differs from the scope of a policy snooze. For an overview of where this fits in the full dispatch cycle, refer to [Notifications and actions in {{alerting-v2-system}}](../notifications-actions.md).
+This page covers when to use each silencing mechanism and how the scope of an alert episode snooze differs from the scope of a policy snooze. For an overview of where this fits in the full dispatch cycle, refer to [About action policies](about-action-policies.md).
 
 ## Silencing mechanisms [silencing-mechanisms]
 
@@ -44,6 +44,6 @@ Snoozing an alert episode differs from [snoozing an action policy](manage-action
 - [View and manage alerts](../alerts/view-and-manage-alerts.md) to apply gating actions from the alerts table or episode detail page.
 - [{{alerting-v2-system}} alerts](../alerts.md) to understand alert episode lifecycle, series, and where alert data is stored.
 -->
-- [Notifications and actions in {{alerting-v2-system}}](../notifications-actions.md) to learn how action policies route and throttle alert episodes after silencing.
+- [About action policies](about-action-policies.md) to learn how action policies route and throttle alert episodes after silencing.
 - [Create and configure an action policy](create-configure-action-policy.md) to set up the policies that run after gating checks pass.
 - [Action policy reference](action-policy-reference.md) to look up match condition fields, grouping modes, and frequency options.

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -30,7 +30,7 @@ If you need an action to fire exactly once in response to a specific alert episo
 
 - [Connect workflows](workflows-alerting.md) - How action policies and lifecycle triggers invoke workflows at runtime.
 - [About action policies](action-policies/about-action-policies.md) - How action policies evaluate and gate alert episodes.
-- [Create an action policy](action-policies/create-configure-action-policy.md) - Cnfigure policy type, match conditions, grouping, frequency, and destinations.
+- [Create an action policy](action-policies/create-configure-action-policy.md) - Configure policy type, match conditions, grouping, frequency, and destinations.
 - [Action policy reference](action-policies/action-policy-reference.md) - Available match condition fields, grouping modes, and frequency options.
 - [Manage action policies](action-policies/manage-action-policies.md) - Enable, disable, snooze, edit, or delete policies.
 - [Reduce notification noise](action-policies/reduce-notification-noise.md) - Suppress alerts using acknowledgment, snooze, and maintenance windows.

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -5,77 +5,32 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "How experimental alerting system action policies route alert episodes to notifications and actions."
+description: "How to set up notifications and actions for rules in the experimental alerting system using workflows and action policies."
 ---
 
 # Notifications and actions for the {{alerting-v2-system}}
 
-Action policies are part of the {{alerting-v2-system}} in {{kib}}. After a rule produces alert episodes in Alert mode, action policies decide whether and when to invoke workflows. Workflows are what actually send the notification or run the automation. Rules running in Detect mode produce signals, which are not processed by action policies.
+Rules in the {{alerting-v2-system}} don't send notifications directly. Instead, they produce alert episodes, and you use workflows and action policies to decide what happens next.
 
-This page covers how action policies gate alert episodes before invoking a workflow, the difference between global and per-rule policies, and how the dispatcher evaluates them on a continuous cycle. For creating and configuring them step by step, refer to [Create and configure an action policy](action-policies/create-configure-action-policy.md).
+- **Workflows** are the delivery layer. They define what happens when the system decides to act, such as sending a message, calling a webhook, or triggering an automation.
+- **Action policies** are the gating layer. They evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions, grouping, and frequency settings.
 
-## What is an action policy [action-policies]
+## Get started
 
-An action policy is the gating layer between an alert episode and a workflow. It decides whether and when to invoke a workflow by running the alert episode through a sequence of gates. A workflow runs only if the alert episode clears each gate in sequence.
+To send notifications or run actions from an alerting v2 rule:
 
-The three gates are suppression, match conditions, and frequency:
+1. [Build a workflow](../../workflows/get-started/build-your-first-workflow.md) that defines the action to take.
+2. [Create an action policy](action-policies/create-configure-action-policy.md) that routes alert episodes to that workflow.
 
-* **Suppression** - Suppression checks whether the alert episode should be silenced. Episodes that are acknowledged, snoozed, or inside a maintenance window are stopped here and no workflow is invoked. For details on each mechanism and its scope, refer to [Reduce notification noise](action-policies/reduce-notification-noise.md).
-* **Match conditions** - Match conditions filter which alert episodes the policy applies to. You define them using [KQL](../../query-filter/languages/kql.md). An empty match condition applies to all alert episodes within the policy's scope.
-* **Frequency** - Frequency controls how often the policy can invoke its workflows for the same group of episodes, and how episodes batch before a workflow is invoked. Options are one notification per alert episode, one per notification group, or one digest for all matching episodes. If a workflow was already invoked within the cooldown period, the episode waits.
-
-If any gate stops the episode, the workflow is not invoked for that policy.
-
-:::{note}
-Because each action policy evaluates alert episodes independently, an episode that is blocked by one policy can still trigger a workflow through a second policy with different conditions.
+:::{tip}
+If you need an action to fire exactly once in response to a specific alert episode state change (such as opening a ticket when an episode is assigned) use an alert episode lifecycle trigger instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a comparison of both approaches.
 :::
 
-## Why policies are separate from rules
+## In this section
 
-Policies are independent of rules. A single global policy can cover alert episodes from many rules, so a policy matching `episode.severity: "critical"` applies regardless of which rule produced the alert episode. You can also update notification routing without touching any rule, and you can create rules without any action policy, which is useful for testing detection logic before wiring up notifications.
-
-When you do need routing that is specific to one rule, create a per-rule policy and bind it to that rule at creation.
-
-## Policy types [policy-types]
-
-Policies can be global or per-rule. Global policies apply across all rules in a space and suit most use cases. Per-rule policies apply to a single rule and give you precise control over routing for that rule without affecting anything else in the space.
-
-### Global policies
-
-A global policy applies to all alert episodes in the space, from any rule. When an alert episode is produced, the dispatcher evaluates all enabled global policies that are not snoozed. Global is the default type and suits most use cases.
-
-### Per-rule policies
-
-A per-rule policy is scoped to a single rule. It applies only to alert episodes produced by that specific rule. Use a per-rule policy when routing is specific to one rule and you do not want it to affect other rules in the space. The rule association is set at creation and cannot be changed.
-
-## How policies apply to rules
-
-How a policy applies depends on whether it is global or per-rule. Multiple policies can match the same alert episode, and each runs independently. There is no precedence or merging between them. If no policy matches an alert episode, no workflow is invoked and no notification is sent.
-
-### Global policy application
-
-Global policies don't reference rules directly. You scope them using KQL over alert episode and rule fields, for example `rule.tags: "checkout"` or `data.severity: "critical"`. A global policy applies to every matching alert episode in the space, from any rule.
-
-### Per-rule policy application
-
-Per-rule policies are bound to a specific rule at creation. They apply only to alert episodes from that rule, and you can still use match conditions to filter further within that rule's alert episodes.
-
-## How action policies are evaluated [how-action-policies-evaluated]
-
-{{kib}} runs a background process called the dispatcher that checks for eligible alert episodes on a short interval (around 5 seconds) and evaluates action policies against them. The dispatcher runs on its own cycle, separate from the rule schedule.
-
-For each enabled policy that is not snoozed, the dispatcher works through the following steps:
-
-1. **Gating:** Is the alert episode acknowledged, snoozed, or deactivated? If so, skip. Refer to [Reduce notification noise](action-policies/reduce-notification-noise.md) to learn more.
-2. **Matcher:** Does the alert episode match the policy's KQL? If not, skip this policy.
-3. **Grouping:** How should matching alert episodes batch into notification groups?
-4. **Frequency:** Has a workflow already been invoked for this notification group recently? If so, wait.
-5. **Destinations:** Invoke the configured workflows.
-
-Workflow invocations may not happen immediately after a rule evaluates.
-
-## Next steps
-
-- [Create and configure an action policy](action-policies/create-configure-action-policy.md) to set up policy type, match conditions, grouping, frequency, and workflow destinations.
-- [Manage action policies](action-policies/manage-action-policies.md) to enable, disable, snooze, edit, or delete the policies in your space.
-- [Action policy reference](action-policies/action-policy-reference.md) to look up available match condition fields, grouping modes, and frequency options.
+- [Connect workflows](workflows-alerting.md) - How action policies and lifecycle triggers invoke workflows at runtime.
+- [About action policies](action-policies/about-action-policies.md) - How action policies evaluate and gate alert episodes.
+- [Create an action policy](action-policies/create-configure-action-policy.md) - Cnfigure policy type, match conditions, grouping, frequency, and destinations.
+- [Action policy reference](action-policies/action-policy-reference.md) - Available match condition fields, grouping modes, and frequency options.
+- [Manage action policies](action-policies/manage-action-policies.md) - Enable, disable, snooze, edit, or delete policies.
+- [Reduce notification noise](action-policies/reduce-notification-noise.md) - Suppress alerts using acknowledgment, snooze, and maintenance windows.

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -10,22 +10,20 @@ description: "How workflows connect to the experimental alerting system through 
 
 # Connect workflows to the {{alerting-v2-system}} [connect-workflows-experimental-alerting-system]
 
-Workflows are part of the {{alerting-v2-system}} in {{kib}}. [Workflows](../../workflows.md) are the delivery layer. They define what happens when the {{alerting-v2-system}} decides to act, such as sending a message, calling a webhook, or triggering an automation. Setting up a workflow is what connects the {{alerting-v2-system}} to the tools your team uses for incident response.
+[Workflows](../../workflows.md) are part of the {{alerting-v2-system}} in {{kib}}. They are the delivery layer that defines what happens when the {{alerting-v2-system}} takes an action, such as sending a message, calling a webhook, or triggering an automation. Workflows are what allow your team's incident response tools to connect with the {{alerting-v2-system}}.
 
 This page covers how action policies drive workflow invocations at runtime, the available alert episode lifecycle triggers, and when to use each pathway.
+
+## How the alerting system connects to workflows [connection-pathways]
 
 The {{alerting-v2-system}} connects to workflows through two pathways.
 
 - **Action policies** - Action policies evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions and frequency settings.
 - **Alert episode lifecycle triggers** - Workflows are invoked when a specific state change occurs on an alert episode, such as when the alert episode is activated, assigned, or resolved.
 
-## How action policies invoke workflows [action-policy-driven-workflows]
+### Action policies [action-policy-driven-workflows]
 
-:::{important}
-Action policies need a workflow to act on alert episodes. Without one, the policy has nowhere to send notifications or run automations. If you haven't created a workflow yet, [build your first workflow](../../workflows/get-started/build-your-first-workflow.md) before continuing.
-:::
-
-After a rule runs, the system routes alert episodes to workflows through the following steps.
+Action policies evaluate alert episodes on a continuous schedule and invoke workflows when an episode meets the configured conditions. After a rule runs, the system routes alert episodes to workflows through the following steps.
 
 ```
 Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notification
@@ -38,15 +36,15 @@ Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notif
 5. For policies where the episode clears all gates, the dispatcher invokes the configured workflows.
 6. Workflows deliver the notification or run the automation.
 
-## Alert episode lifecycle triggers [alert-episode-lifecycle-triggers]
+### Alert episode lifecycle triggers [alert-episode-lifecycle-triggers]
 
-Alert episode lifecycle triggers are a type of [event-driven trigger](../../workflows/triggers/event-driven-triggers.md) that start a workflow automatically when a specific event occurs. 
+Lifecycle triggers start a workflow immediately in response to a specific state change on an alert episode, without any scheduling or gating. Alert episode lifecycle triggers are a type of [event-driven trigger](../../workflows/triggers/event-driven-triggers.md) that start a workflow automatically when a specific event occurs. 
 
 The {{alerting-v2-system}} emits a trigger event each time an alert episode changes state (for example, when it's activated, assigned to a user, acknowledged, or snoozed) and any workflow attached to that trigger type runs immediately in response. 
 
 For a list of available triggers and event payload fields, refer to [Alert episode lifecycle triggers](../../workflows/triggers/event-driven-triggers.md). 
 
-## Choosing between lifecycle triggers and action policies [choosing-lifecycle-triggers-action-policies]
+### When to use action policies or lifecycle triggers [when-to-use-action-policies-lifecycle-triggers]
 
 If you're unsure whether to use lifecycle triggers or action policies, the following table compares when each option is a good fit. Both can run different workflows simultaneously and coexist without conflict.
 
@@ -59,5 +57,5 @@ If you're unsure whether to use lifecycle triggers or action policies, the follo
 ## Next steps
 
 - [Create and configure an action policy](action-policies/create-configure-action-policy.md) to start routing alert episodes to workflows.
-- [Notifications and actions in {{alerting-v2-system}}](notifications-actions.md) to learn how action policies evaluate and gate alert episodes before invoking a workflow.
+- [About action policies](action-policies/about-action-policies.md) to learn how action policies evaluate and gate alert episodes before invoking a workflow.
 

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -382,9 +382,11 @@ toc:
           - file: report-and-share/reporting-troubleshooting-pdf.md
   - file: alerting.md
     children:
-      - file: alerting/kibana-alerting-experimental/workflows-alerting.md
       - file: alerting/kibana-alerting-experimental/notifications-actions.md
         children:
+          - file: alerting/kibana-alerting-experimental/workflows-alerting.md
+          - file: alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
+          - file: alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
           - file: alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
           - file: alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
           - file: alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->


This PR restructures the experimental alerting (alerting v2) notification and action policies documentation. The main goals are to separate conceptual content from how-to content, improve navigation, and add new pages that address common user questions about severity-based routing and notification behavior.

### Structural changes

- **Splits `notifications-actions.md`** into a brief section landing page and a new dedicated conceptual page (`about-action-policies.md`), so that the landing page orients users and the conceptual content has its own focused home.
- **Moves `workflows-alerting.md`** from a top-level sibling of `notifications-actions.md` to a child, grouping all notification-related content under one section in the sidebar.
- **Adds `common-action-policy-scenarios.md`** — a new page with annotated, table-backed examples for three common scenarios: routing by severity, managing notifications across severity changes, and re-notifying for persistently active episodes.

### Content changes

- **`notifications-actions.md`** — Rewritten as a brief landing page explaining the two-layer model (workflows + action policies) with a get-started flow and an in-section index.
- **`about-action-policies.md`** (new) — Consolidates conceptual content: the three gates (suppression, match conditions, frequency), policy types (global vs per-rule), how the dispatcher evaluates policies, and a tip callout explaining how severity changes interact with policy matching.
- **`workflows-alerting.md`** — Restructured with a new "How the alerting system connects to workflows" section containing the two pathways as subsections, with intro sentences added to each.
- **`create-configure-action-policy.md`** — Adds a note in the Frequency section explaining the `on_status_change` + severity change interaction and when to use a time-based throttle instead.
- **`action-policy-reference.md`**, **`reduce-notification-noise.md`**, **`create-configure-action-policy.md`** — Cross-links updated to reflect the new page structure.
- `episode.severity` replaced with `severity` throughout the action policies pages.

### Navigation (`toc.yml`)

```
Notifications and actions          ← section landing page
  ├── Connect workflows
  ├── About action policies        ← new
  ├── Common scenarios             ← new
  ├── Create an action policy
  ├── Action policy reference
  ├── Manage action policies
  └── Reduce notification noise
```

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes - Cursor + Claude
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

