### PR TITLE
Add Triage and Size checkboxes to the AI menu

### DIFF
--- a/.github/scripts/docs_ai_menu.cjs
+++ b/.github/scripts/docs_ai_menu.cjs
@@ -2,13 +2,21 @@ const MENU_START = '<!-- docs-ai-menu:start -->';
 const MENU_END = '<!-- docs-ai-menu:end -->';
 
 const WORKFLOW_CONFIG = {
+  triage: {
+    label: 'Triage ([`docs-triage`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-triage.md)).',
+    marker: '<!-- docs-ai-menu:triage -->',
+  },
+  size: {
+    label: 'Size the work ([`docs-size`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-issue-size.md)).',
+    marker: '<!-- docs-ai-menu:size -->',
+  },
   issueScope: {
     label: 'Scope the docs work ([`docs-issue-scope`](https://github.com/elastic/docs-actions/blob/main/.github/workflows/gh-aw-docs-issue-scope.md)).',
     marker: '<!-- docs-ai-menu:issue-scope -->',
   },
 };
 
-const WORKFLOW_ORDER = ['issueScope'];
+const WORKFLOW_ORDER = ['triage', 'size', 'issueScope'];
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/.github/workflows/docs-ai-menu.yml
+++ b/.github/workflows/docs-ai-menu.yml
@@ -66,6 +66,8 @@ jobs:
     permissions:
       contents: read
     outputs:
+      triage_triggered: ${{ steps.evaluate.outputs.triage_triggered }}
+      size_triggered: ${{ steps.evaluate.outputs.size_triggered }}
       issue_scope_triggered: ${{ steps.evaluate.outputs.issue_scope_triggered }}
 
     steps:
@@ -86,14 +88,21 @@ jobs:
 
             const previousState = menu.parseMenuState(previousBody);
             const currentState = menu.parseMenuState(body);
+            const triageTriggered = !previousState.triage.selected && currentState.triage.selected;
+            const sizeTriggered = !previousState.size.selected && currentState.size.selected;
             const issueScopeTriggered = !previousState.issueScope.selected && currentState.issueScope.selected;
 
+            core.setOutput('triage_triggered', String(triageTriggered));
+            core.setOutput('size_triggered', String(sizeTriggered));
             core.setOutput('issue_scope_triggered', String(issueScopeTriggered));
 
   refresh-menu-after-trigger:
     name: Refresh AI menu after trigger
     needs: [evaluate-trigger]
-    if: needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
+    if: >-
+      needs.evaluate-trigger.outputs.triage_triggered == 'true' ||
+      needs.evaluate-trigger.outputs.size_triggered == 'true' ||
+      needs.evaluate-trigger.outputs.issue_scope_triggered == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -118,6 +127,20 @@ jobs:
             const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const statusOverrides = {};
 
+            if ('${{ needs.evaluate-trigger.outputs.triage_triggered }}' === 'true') {
+              statusOverrides.triage = {
+                detailsUrl: progressUrl,
+                status: 'in_progress',
+              };
+            }
+
+            if ('${{ needs.evaluate-trigger.outputs.size_triggered }}' === 'true') {
+              statusOverrides.size = {
+                detailsUrl: progressUrl,
+                status: 'in_progress',
+              };
+            }
+
             if ('${{ needs.evaluate-trigger.outputs.issue_scope_triggered }}' === 'true') {
               statusOverrides.issueScope = {
                 detailsUrl: progressUrl,
@@ -134,6 +157,50 @@ jobs:
               statusOverrides,
             });
 
+  run-docs-triage:
+    name: Docs AI / triage
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.triage_triggered == 'true'
+    permissions:
+      actions: read
+      contents: read
+      copilot-requests: write
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v1
+    with:
+      additional-instructions: |
+        ## Team Ownership Mapping
+
+        This mapping is derived from the repository's CODEOWNERS file. Use it to determine which team owns each issue. Match based on the issue title, body, any mentioned URLs, and labels.
+
+        | Team Label | Owns | Keywords / URL paths |
+        |---|---|---|
+        | `Team:Admin` | Elasticsearch admin, cluster mgmt, cloud, deployment docs | Cluster management, index management, auth, roles, API keys, network security, cluster security, snapshots, ILM, data lifecycle, CCR, CCS, licensing, subscriptions, upgrade, monitoring, Elastic Cloud, ECE, ECK, serverless. Paths: `deploy-manage/`, `cloud-account/`, `manage-data/` (except `manage-data/ingest/`), `serverless/`, `troubleshoot/deployments/`, `troubleshoot/elasticsearch/` |
+        | `Team:Experience` | Kibana, observability solution, security solution | Kibana, dashboards, visualizations, Discover, observability, security, APM UI, maps, canvas, Lens, alerting, rules, cases, SIEM, endpoint security, detection rules, security analytics. Paths: `explore-analyze/` (default), `solutions/observability/`, `solutions/security/`, `reference/kibana/`, `reference/observability/`, `reference/security/` |
+        | `Team:Developer` | Elasticsearch developer, search solution docs | Elasticsearch APIs, ES|QL, query DSL, search features, relevance, vector search, semantic search, inference APIs, connectors, developer tools, clients, search applications, App Search, Workplace Search. Paths: `solutions/search/`, `reference/elasticsearch/clients/`, `reference/search/`, `reference/machine-learning/`, `explore-analyze/ai-features/`, `explore-analyze/cross-cluster-search/`, `explore-analyze/cross-project-search/`, `explore-analyze/transforms/` |
+        | `Team:Ingest` | Data ingestion, Fleet, APM agents docs | Fleet, Elastic Agent, Beats, Logstash, pipelines, integrations, data streams, APM agents, APM server, OpenTelemetry. Paths: `manage-data/ingest/`, `reference/apm-agents/`, `reference/fleet/`, `reference/ingestion-tools/`, `solutions/observability/apm/apm-agents/`, `solutions/observability/apm/apm-server/`, `solutions/observability/apm/ingest/`, `solutions/observability/apm/opentelemetry/` |
+        | `Team:DocsEng` | Docs infrastructure | Docs build system, CI/CD, website rendering, broken navigation, docs-builder bugs, elastic.co website issues not related to content. Paths: `.github/workflows/`, `.github/scripts/` |
+        | `Team:Projects` | Internal projects, docs initiatives | Internal documentation projects, content strategy, information architecture, get-started guides. Paths: `get-started/` |
+
+        **Shared ownership**: Some paths have shared ownership (e.g., `/explore-analyze/machine-learning/` is shared by Developer and Experience). Pick the team whose keywords best match the issue content.
+        **Internal projects**: If the issue seems related to an internal documentation project, initiative, or content strategy effort, apply `Team:Projects`.
+        **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
+
+  run-docs-size:
+    name: Docs AI / size
+    needs: [evaluate-trigger]
+    if: needs.evaluate-trigger.outputs.size_triggered == 'true'
+    permissions:
+      actions: read
+      contents: read
+      copilot-requests: write
+      discussions: write
+      issues: write
+      pull-requests: write
+    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-size.lock.yml@v1
+
   run-docs-issue-scope:
     name: Docs AI / issue scope
     needs: [evaluate-trigger]
@@ -146,6 +213,100 @@ jobs:
       issues: write
       pull-requests: write
     uses: elastic/docs-actions/.github/workflows/gh-aw-docs-issue-scope.lock.yml@v1
+
+  refresh-menu-after-docs-triage:
+    name: Refresh AI menu after docs triage
+    needs: [evaluate-trigger, refresh-menu-after-trigger, run-docs-triage]
+    if: always() && needs.evaluate-trigger.outputs.triage_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_ai_menu.cjs`);
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const triageResult = '${{ needs.run-docs-triage.result }}';
+
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              issueNumber,
+              statusOverrides: {
+                triage: {
+                  conclusion: triageResult === 'success'
+                    ? 'success'
+                    : triageResult === 'cancelled'
+                      ? 'cancelled'
+                      : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });
+
+  refresh-menu-after-docs-size:
+    name: Refresh AI menu after docs size
+    needs: [evaluate-trigger, refresh-menu-after-trigger, run-docs-size]
+    if: always() && needs.evaluate-trigger.outputs.size_triggered == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: docs-ai-menu-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Refresh AI menu status
+        uses: actions/github-script@v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const menu = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/docs_ai_menu.cjs`);
+            const issueNumber = context.payload.issue.number;
+            const progressUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sizeResult = '${{ needs.run-docs-size.result }}';
+
+            await menu.upsertMenuComment({
+              core,
+              createIfMissing: false,
+              github,
+              context,
+              issueNumber,
+              statusOverrides: {
+                size: {
+                  conclusion: sizeResult === 'success'
+                    ? 'success'
+                    : sizeResult === 'cancelled'
+                      ? 'cancelled'
+                      : 'failure',
+                  detailsUrl: progressUrl,
+                  status: 'completed',
+                },
+              },
+            });
 
   refresh-menu-after-docs-issue-scope:
     name: Refresh AI menu after docs issue scope


### PR DESCRIPTION
## Summary

Re-adds a **Triage** checkbox and adds a new **Size** checkbox to the issue AI menu, each wired to the reusable workflows in `docs-actions`. Auto-triage on open stays in place; the menu checkboxes are the on-demand path.

- `docs_ai_menu.cjs`: add `triage` and `size` entries (and to `WORKFLOW_ORDER`). The `triage` label matches the original string exactly, so the Triage checkboxes on already-posted menu comments become functional again.
- `docs-ai-menu.yml`: restore the `triage_triggered` output, `run-docs-triage` job (with the team mapping), and triage refresh job; add the equivalent `size_triggered` output, `run-docs-size` job, and size refresh job.

## Test plan

- [ ] Tick **Triage** on an issue -> `run-docs-triage` runs and the menu status updates.
- [ ] Tick **Size** -> `run-docs-size` runs and the menu status updates.
- [ ] Tick **Scope the docs work** -> still works.
- [ ] Tick an old Triage checkbox on a pre-existing issue -> now triggers triage.

Co-authored-by: Claude <noreply@anthropic.com>

Made with [Cursor](https://cursor.com)