### PR TITLE
Generate Kibana Serverless release notes for Jun 25

### DIFF
--- a/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/breaking-changes.md
@@ -1,0 +1,2 @@
+﻿## June 25, 2026 [elastic-2026-06-25-breaking-changes]
+_There are no breaking changes associated with this release._

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/deprecations.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/deprecations.md
@@ -1,0 +1,2 @@
+﻿## June 25, 2026 [elastic-2026-06-25-deprecations]
+_There are no deprecations associated with this release._

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/index.md
@@ -1,0 +1,38 @@
+﻿## June 25, 2026 [elastic-release-notes-2026-06-25]
+
+<!-- _Released: June 25, 2026_ -->
+### Features and enhancements [elastic-2026-06-25-features-enhancements]
+* Add Box data source. [#271306](https://github.com/elastic/kibana/pull/271306)
+* Improve Synthetics search performance by honoring excluded data tiers setting. [#273418](https://github.com/elastic/kibana/pull/273418) [#273086](https://github.com/elastic/kibana/issues/273086)
+* Add Amazon CloudWatch (OTel) quickstart tile to the Add data Cloud category. [#273736](https://github.com/elastic/kibana/pull/273736)
+* Add server-side sorting for Name and Enabled columns in the workflows table. [#271286](https://github.com/elastic/kibana/pull/271286)
+* Add sample report empty state. [#265091](https://github.com/elastic/kibana/pull/265091)
+* Add OpenTelemetry-first Kubernetes onboarding flow. [#271387](https://github.com/elastic/kibana/pull/271387)
+* Add embeddable Agent Builder conversation input for solution plugins. [#272166](https://github.com/elastic/kibana/pull/272166)
+* Add output filtering in the Console. [#272078](https://github.com/elastic/kibana/pull/272078)
+* Remove feedback button from Fleet. [#273641](https://github.com/elastic/kibana/pull/273641)
+* Add timelines table to cases. [#272768](https://github.com/elastic/kibana/pull/272768)
+* Add 'Add to chat' action to alert table row actions. [#273740](https://github.com/elastic/kibana/pull/273740)
+* Improve default Y axis sort order for numeric heatmap buckets. [#268961](https://github.com/elastic/kibana/pull/268961)
+* Add feedback when filters and drilldowns cannot apply to computed values on ES|QL charts. [#269722](https://github.com/elastic/kibana/pull/269722) [#260185](https://github.com/elastic/kibana/issues/260185)
+* Add recommended ES|QL queries for remote cluster sources. [#273292](https://github.com/elastic/kibana/pull/273292) [#257704](https://github.com/elastic/kibana/issues/257704)
+
+### Fixes [elastic-2026-06-25-fixes]
+* Fix incorrect Kibana version on alerts CSV report info panel. [#272418](https://github.com/elastic/kibana/pull/272418) [#272275](https://github.com/elastic/kibana/issues/272275)
+* Fix alert flyout showing only the first assignee. [#273801](https://github.com/elastic/kibana/pull/273801)
+* Fix KQL suggestions in autocomplete. [#273931](https://github.com/elastic/kibana/pull/273931)
+* Fix inability to insert newlines in the ES|QL editor. [#272669](https://github.com/elastic/kibana/pull/272669) [#269421](https://github.com/elastic/kibana/issues/269421)
+* Fix issue displaying null values in ES|QL summary column. [#273610](https://github.com/elastic/kibana/pull/273610) [#273562](https://github.com/elastic/kibana/issues/273562)
+* Fix object field editing in the index editor. [#273303](https://github.com/elastic/kibana/pull/273303) [#273146](https://github.com/elastic/kibana/issues/273146)
+* Fix slow Fleet setup when many outputs are configured. [#273848](https://github.com/elastic/kibana/pull/273848) [#273373](https://github.com/elastic/kibana/issues/273373)
+* Fix Fleet output save timeouts when many agent policies are affected. [#272428](https://github.com/elastic/kibana/pull/272428) [#267748](https://github.com/elastic/kibana/issues/267748)
+* Fix slow Fleet setup with large numbers of agent policies. [#272604](https://github.com/elastic/kibana/pull/272604)
+* Fix repeated machine learning capability checks on non-ML Kibana pages. [#273887](https://github.com/elastic/kibana/pull/273887) [#273798](https://github.com/elastic/kibana/issues/273798)
+* Fix attachments leaking between AI assistant conversations. [#273017](https://github.com/elastic/kibana/pull/273017) [#273014](https://github.com/elastic/kibana/issues/273014)
+* Fix unbounded string length validation in machine learning API schemas. [#273518](https://github.com/elastic/kibana/pull/273518)
+* Fix error toast when viewing memory usage on the machine learning overview page without ML node permissions. [#273898](https://github.com/elastic/kibana/pull/273898)
+* Fix unreadable wrapped log messages in Logs Anomalies example table. [#273221](https://github.com/elastic/kibana/pull/273221)
+* Fix Entity Analytics watchlist sync to use the watchlist creator's credentials. [#270292](https://github.com/elastic/kibana/pull/270292)
+* Fix all Security AI Assistant conversations deleted when saving one after select all. [#274033](https://github.com/elastic/kibana/pull/274033) [#243315](https://github.com/elastic/kibana/issues/243315)
+* Fix dashboard panel column type inference. [#270563](https://github.com/elastic/kibana/pull/270563)
+* Fix save and return for maps opened from the Visualize library. [#274002](https://github.com/elastic/kibana/pull/274002) [#273690](https://github.com/elastic/kibana/issues/273690)

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/index.md
@@ -4,8 +4,8 @@
 ### Features and enhancements [elastic-2026-06-25-features-enhancements]
 * Add Box data source. [#271306](https://github.com/elastic/kibana/pull/271306)
 * Improve Synthetics search performance by honoring excluded data tiers setting. [#273418](https://github.com/elastic/kibana/pull/273418) [#273086](https://github.com/elastic/kibana/issues/273086)
-* Add Amazon CloudWatch (OTel) quickstart tile to the Add data Cloud category. [#273736](https://github.com/elastic/kibana/pull/273736)
-* Add server-side sorting for Name and Enabled columns in the workflows table. [#271286](https://github.com/elastic/kibana/pull/271286)
+* Add Amazon CloudWatch (OTel) quickstart tile to the Cloud category on the Add data page. [#273736](https://github.com/elastic/kibana/pull/273736)
+* Add server-side sorting for the Name and Enabled columns in the workflows table. [#271286](https://github.com/elastic/kibana/pull/271286)
 * Add sample report empty state. [#265091](https://github.com/elastic/kibana/pull/265091)
 * Add OpenTelemetry-first Kubernetes onboarding flow. [#271387](https://github.com/elastic/kibana/pull/271387)
 * Add embeddable Agent Builder conversation input for solution plugins. [#272166](https://github.com/elastic/kibana/pull/272166)
@@ -33,6 +33,6 @@
 * Fix error toast when viewing memory usage on the machine learning overview page without ML node permissions. [#273898](https://github.com/elastic/kibana/pull/273898)
 * Fix unreadable wrapped log messages in Logs Anomalies example table. [#273221](https://github.com/elastic/kibana/pull/273221)
 * Fix Entity Analytics watchlist sync to use the watchlist creator's credentials. [#270292](https://github.com/elastic/kibana/pull/270292)
-* Fix all Security AI Assistant conversations deleted when saving one after select all. [#274033](https://github.com/elastic/kibana/pull/274033) [#243315](https://github.com/elastic/kibana/issues/243315)
+* Fix an issue where all Security AI Assistant conversations were deleted after selecting all conversations and saving one. [#274033](https://github.com/elastic/kibana/pull/274033) [#243315](https://github.com/elastic/kibana/issues/243315)
 * Fix dashboard panel column type inference. [#270563](https://github.com/elastic/kibana/pull/270563)
 * Fix save and return for maps opened from the Visualize library. [#274002](https://github.com/elastic/kibana/pull/274002) [#273690](https://github.com/elastic/kibana/issues/273690)

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/known-issues.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-06-25/known-issues.md
@@ -1,0 +1,2 @@
+﻿## June 25, 2026 [elastic-2026-06-25-known-issues]
+_There are no known issues associated with this release._

--- a/release-notes/elastic-cloud-serverless/index.md
+++ b/release-notes/elastic-cloud-serverless/index.md
@@ -12,6 +12,9 @@ Review the changes, fixes, and more to {{serverless-full}}.
 <!-- :::{changelog} /releases
 ::: -->
 
+:::{include} _snippets/2026-06-25/index.md
+:::
+
 :::{include} _snippets/2026-06-18/index.md
 :::
 


### PR DESCRIPTION
## Summary

This PR adds changelog snippets to the Elastic Cloud Serverless release note pages that are derived from https://github.com/elastic/kibana/pull/275120

This is a stop-gap until we can publish directly from the bundles.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

