### PR TITLE
Document remote Elasticsearch output support for OTel input packages in Fleet

### DIFF
--- a/reference/fleet/otel-integrations.md
+++ b/reference/fleet/otel-integrations.md
@@ -42,10 +42,12 @@ When the integration policy for the input package is created, {{fleet}} creates 
 
 On the OpenTelemetry input package's **Configs** page, you can view a generated sample configuration, which you can use as a starting point to set up the integration on a standalone {{agent}}. 
 
-This is a partial configuration because it doesn't include an exporter component. For more information on setting up the exporter, refer to [{{es}} exporter](elastic-agent://reference/edot-collector/components/elasticsearchexporter.md).
+This is a partial configuration because it doesn't include an exporter component. OpenTelemetry input packages support sending data using the {{es}} output. For more information on setting up the exporter, refer to [{{es}} exporter](elastic-agent://reference/edot-collector/components/elasticsearchexporter.md).
 
 :::{note}
-Currently, OpenTelemetry input packages only support sending data using the {{es}} output.
+:applies_to: {serverless: preview, stack: preview 9.5+}
+
+The [remote {{es}} output](/reference/fleet/remote-elasticsearch-output.md) is also supported as an exporter target.
 :::
 
 Only {{agents}} on version 9.2 or later can collect OTel data using OpenTelemetry input packages. OpenTelemetry input packages added to an agent policy do not affect enrolled agents on prior versions.

--- a/reference/fleet/remote-elasticsearch-output.md
+++ b/reference/fleet/remote-elasticsearch-output.md
@@ -19,6 +19,12 @@ Both the management cluster (where you configure {{fleet}}) and the remote clust
 
 A remote {{es}} cluster supports the same [output settings](/reference/fleet/es-output-settings.md) as your management {{es}} cluster.
 
+:::{note}
+:applies_to: {serverless: preview, stack: preview 9.5+}
+
+The remote {{es}} output can also serve as the exporter target for [OpenTelemetry input packages](/reference/fleet/otel-integrations.md) managed by {{fleet}}.
+:::
+
 ## Limitations [remote-output-limitations]
 
 These limitations apply to remote {{es}} output:


### PR DESCRIPTION
## Summary

This PR documents support for using a remote Elasticsearch output as the exporter target for OTel input packages in Fleet, available in Serverless and 9.5+.

Implementation PR: https://github.com/elastic/kibana/pull/270267
Resolves https://github.com/elastic/docs-content/issues/6881

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor / Claude Opus 4.7
