### PR TITLE
Add CTA for Azure Marketplace in documentation

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
@@ -9,6 +9,7 @@ navigation_title: Azure Native Service
 products:
   - id: cloud-hosted
   - id: cloud-serverless
+cta: azure-mp
 ---
 
 # {{ecloud}} Azure Native Service [ec-azure-marketplace-native]


### PR DESCRIPTION
## DRAFT: missing the important half of the changes

## Summary
First attempt at updating a CTA to have a trial go to MP
Obviously this is missing the definition of the CTA itself per https://github.com/elastic/docs-eng-team/issues/635#issuecomment-4850797276, but I don't know where the dockset.yml resides.

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
