### PR TITLE
[Alerting V2][Serverless & 9.5][M2] Action policy and workflow changes from July 1, 2026

### DIFF
--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
@@ -71,7 +71,7 @@ For each enabled policy that is not snoozed, the dispatcher works through the fo
 Workflow invocations may not happen immediately after a rule evaluates.
 
 :::{tip}
-Severity changes can cause a policy to match an episode for the first time, which fires a notification even if the episode is not new. For example, if a policy is scoped to `severity: "critical"` and an episode escalates from `low` to `critical`, the policy fires because it has no prior notification record for that episode. However, a severity change alone does not re-trigger a policy that already matched the episode. Only a status change or the expiry of a time-based throttle can do that. For details and examples, refer to [Severity escalation and de-escalation](common-action-policy-scenarios.md#severity-escalation).
+Severity changes can cause a policy to match an episode for the first time, which fires a notification even if the episode is not new. For example, if a policy is scoped to `severity: "critical"` and an episode escalates from `low` to `critical`, the policy fires because it has no prior notification record for that episode. However, a severity change alone does not re-trigger a policy that already matched the episode. Only a status change or the expiry of a time-based throttle can do that. For details and examples, refer to [Manage severity escalation notifications](severity-escalation.md).
 :::
 
 ## Next steps

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
@@ -22,7 +22,7 @@ When you do need routing that is specific to one rule, create a per-rule policy 
 
 The three gates are suppression, match conditions, and frequency:
 
-* **Suppression** - Suppression checks whether the alert episode should be silenced. Episodes that are acknowledged, snoozed, or inside a maintenance window are stopped here and no workflow is invoked. For details on each mechanism and its scope, refer to [Reduce notification noise](reduce-notification-noise.md).
+* **Suppression** - Suppression determines whether to silence the alert episode. Episodes that are acknowledged, snoozed, or inside a maintenance window are stopped here and no workflow is invoked. For details on each mechanism and its scope, refer to [Reduce notification noise](reduce-notification-noise.md).
 * **Match conditions** - Match conditions filter which alert episodes the policy applies to. You define them using [KQL](../../../query-filter/languages/kql.md). An empty match condition applies to all alert episodes within the policy's scope.
 * **Frequency** - Frequency controls how often the policy can invoke its workflows for the same group of episodes, and how episodes batch before a workflow is invoked. Options are one notification per alert episode, one per notification group, or one digest for all matching episodes. If a workflow was already invoked within the cooldown period, the episode waits.
 
@@ -62,9 +62,9 @@ Per-rule policies are bound to a specific rule at creation. They apply only to a
 
 For each enabled policy that is not snoozed, the dispatcher works through the following steps:
 
-1. **Gating:** Is the alert episode acknowledged, snoozed, or deactivated? If so, skip. Refer to [Reduce notification noise](reduce-notification-noise.md) to learn more.
+1. **Gating:** Is the alert episode acknowledged, snoozed, or marked inactive? If so, skip. Refer to [Reduce notification noise](reduce-notification-noise.md) to learn more.
 2. **Matcher:** Does the alert episode match the policy's KQL? If not, skip this policy.
-3. **Grouping:** How should matching alert episodes batch into notification groups?
+3. **Grouping:** The dispatcher determines how matching alert episodes batch into notification groups.
 4. **Frequency:** Has a workflow already been invoked for this notification group recently? If so, wait.
 5. **Destinations:** Invoke the configured workflows.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -16,17 +16,17 @@ Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page is 
 
 Use these fields in the **Match conditions** expression to filter which alert episodes a policy applies to. Combine them with standard [KQL](../../../query-filter/languages/kql.md) operators, for example `severity: "critical" AND episode_status: "active"`.
 
-| Field | Type | Description | Accepted values | Example |
-|---|---|---|---|---|
-| `episode_id` | string | Unique identifier of the alert episode. | Any string | `episode_id: "ep-001"` |
-| `episode_status` | string | Current lifecycle status of the alert episode. | `inactive`, `pending`, `active`, `recovering` | `episode_status: "active"` |
-| `severity` | string | Current severity of the alert episode. Populated when the rule's {{esql}} query includes a `severity` column whose value matches a supported level (case-insensitive). Unrecognized values are silently ignored and the field is absent. Not set during recovery. Use to route high-severity episodes to dedicated workflows. | `info`, `low`, `medium`, `high`, `critical` | `severity: "critical" OR severity: "high"` |
-| `group_hash` | string | Stable hash identifying the alert series the alert episode belongs to. | Any string | `group_hash: "abc123"` |
-| `last_event_timestamp` | string | ISO 8601 timestamp of the most recent event recorded for the alert episode. | ISO 8601 timestamp | `last_event_timestamp > "2026-01-01"` |
-| `rule.id` | string | Unique identifier of the rule that generated the alert episode. | Any string | `rule.id: "rule-001"` |
-| `rule.name` | string | Display name of the rule. | Any string | `rule.name: "High CPU"` |
-| `rule.tags` | string[] | Tags attached to the rule. Use to match alert episodes from rules with a specific tag. | Any string | `rule.tags: "payment-service"` |
-| `data.*` | object | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. Use for rule-specific fields not covered by the standard episode fields above. | Depends on rule type | `data.host.name: "web-01"` |
+| Field | Description | Example |
+|---|---|---|
+| `episode_id` | Unique identifier of the alert episode. | `episode_id: "ep-001"` <br> Match a specific episode by ID. |
+| `episode_status` | Current lifecycle status of the alert episode. One of `inactive`, `pending`, `active`, or `recovering`. | `episode_status: "active"` <br> Match only active episodes. |
+| `severity` | Current severity level. One of `info`, `low`, `medium`, `high`, or `critical`. Populated when the rule's {{esql}} query includes a matching `severity` column (case-insensitive). Not set during recovery. Unrecognized values are ignored. | `severity: "critical" OR severity: "high"` <br> Route high-priority episodes to a dedicated workflow. |
+| `group_hash` | Stable hash identifying the alert series the episode belongs to. | `group_hash: "abc123"` <br> Match all episodes in a specific alert series. |
+| `last_event_timestamp` | ISO 8601 timestamp of the most recent event recorded for the episode. | `last_event_timestamp > "2026-01-01"` <br> Match episodes with activity after a specific date. |
+| `rule.id` | Unique identifier of the rule that generated the episode. | `rule.id: "rule-001"` <br> Match episodes from one specific rule. |
+| `rule.name` | Display name of the rule. | `rule.name: "High CPU"` <br> Match episodes from rules with this display name. |
+| `rule.tags` | Tags attached to the rule. | `rule.tags: "payment-service"` <br> Match episodes from all rules with this tag. |
+| `data.*` | Dynamic payload fields sent by the rule. Available fields depend on the rule type and configuration. Use for rule-specific fields not covered by the standard fields in this table. | `data.host.name: "web-01"` <br> Match episodes from a specific host in a host-based rule. |
 
 <!--[CONTENT NEEDED: 
 When rule authoring docs are created (issue #6689), link from this table row to the rule authoring page that explains how to include a `severity` column in the ES|QL query. The full severity contract (column name, case-insensitivity, silent-ignore behavior) belongs in the rule authoring reference, not here.]
@@ -83,7 +83,7 @@ Available frequency options when you set **Notify per** to **Digest**.
 
 ## Dispatch outcomes [dispatch-outcomes]
 
-After each dispatcher run, {{kib}} writes one event log entry per policy to the `.kibana-event-log-*` index. Three outcomes are recorded:
+After each dispatcher run, {{kib}} writes one event log entry per policy to the `.kibana-event-log-*` index. The dispatcher records three outcomes:
 
 | Outcome | What happened |
 |---|---|
@@ -93,7 +93,7 @@ After each dispatcher run, {{kib}} writes one event log entry per policy to the 
 
 Episodes that were acknowledged, snoozed, marked inactive, or covered by a maintenance window are suppressed before the dispatcher runs and produce no event log entry.
 
-`unmatched` is recorded in the event log but is not available as an outcome filter in the **Execution history** UI. To find `unmatched` records, open Discover, query `.kibana-event-log-*`, add a filter for `event.provider: "alerting_v2"`, and filter `event.action: "unmatched"`.
+`unmatched` appears in the event log but isn't available as an outcome filter in the **Execution history** UI. To find `unmatched` records, open Discover, query `.kibana-event-log-*`, add a filter for `event.provider: "alerting_v2"`, and filter `event.action: "unmatched"`.
 
 For more information about the execution history UI, refer to [Manage action policies](manage-action-policies.md#execution-history).
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -20,7 +20,7 @@ Use these fields in the **Match conditions** expression to filter which alert ep
 |---|---|---|---|---|
 | `episode_id` | string | Unique identifier of the alert episode. | Any string | `episode_id: "ep-001"` |
 | `episode_status` | string | Current lifecycle status of the alert episode. | `inactive`, `pending`, `active`, `recovering` | `episode_status: "active"` |
-| `severity` | string | Current severity of the alert episode. Populated when the rule's ES\|QL query includes a `severity` column whose value matches a supported level (case-insensitive). Unrecognized values are silently ignored and the field is absent. Not set during recovery. Use to route high-severity episodes to dedicated workflows. | `info`, `low`, `medium`, `high`, `critical` | `severity: "critical" OR severity: "high"` |
+| `severity` | string | Current severity of the alert episode. Populated when the rule's {{esql}} query includes a `severity` column whose value matches a supported level (case-insensitive). Unrecognized values are silently ignored and the field is absent. Not set during recovery. Use to route high-severity episodes to dedicated workflows. | `info`, `low`, `medium`, `high`, `critical` | `severity: "critical" OR severity: "high"` |
 | `group_hash` | string | Stable hash identifying the alert series the alert episode belongs to. | Any string | `group_hash: "abc123"` |
 | `last_event_timestamp` | string | ISO 8601 timestamp of the most recent event recorded for the alert episode. | ISO 8601 timestamp | `last_event_timestamp > "2026-01-01"` |
 | `rule.id` | string | Unique identifier of the rule that generated the alert episode. | Any string | `rule.id: "rule-001"` |

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
@@ -81,16 +81,21 @@ Available frequency options when you set **Notify per** to **Digest**.
 | At most once every… (default) | Caps digest delivery to at most one bundled summary within the chosen interval, regardless of how often the rule runs. | A rule running every 5 minutes with a 1h digest interval sends one bundled summary per hour containing all matching alert episodes from that period. |
 | Every evaluation | Fires on every rule run, bundling all matching alert episodes into one message. Can be noisy on frequent rule schedules. | A rule running every 30 minutes with 20 matching alert episodes produces one summary every 30 minutes containing all 20. |
 
-## Dispatch outcomes
+## Dispatch outcomes [dispatch-outcomes]
 
-The dispatcher records each run with one of the following outcomes. To investigate delivery issues, open Discover, query the `.alert-actions` index, and filter by the `action_type` field.
+After each dispatcher run, {{kib}} writes one event log entry per policy to the `.kibana-event-log-*` index. Three outcomes are recorded:
 
 | Outcome | What happened |
 |---|---|
 | `dispatched` | The dispatcher invoked a workflow for the alert episode. |
 | `throttled` | The alert episode matched a policy but was rate-limited by the frequency setting. No workflow ran. This is expected behavior, not an error. |
-| `suppressed` | Dispatch was blocked. The alert episode was acknowledged, snoozed, or deactivated, or the space is currently in a [maintenance window](../../alerts/maintenance-windows.md). |
 | `unmatched` | No action policy matched the alert episode. No workflow ran. |
+
+Episodes that were acknowledged, snoozed, marked inactive, or covered by a maintenance window are suppressed before the dispatcher runs and produce no event log entry.
+
+`unmatched` is recorded in the event log but is not available as an outcome filter in the **Execution history** UI. To find `unmatched` records, open Discover, query `.kibana-event-log-*`, add a filter for `event.provider: "alerting_v2"`, and filter `event.action: "unmatched"`.
+
+For more information about the execution history UI, refer to [Manage action policies](manage-action-policies.md#execution-history).
 
 ## Related pages
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
@@ -14,7 +14,7 @@ Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page cov
 
 ## Route alert episodes to different workflows by severity [routing-by-severity]
 
-When your rules produce alert episodes at different severity levels, you'll often want to route them to different workflows. For example, you might page an on-call team for critical episodes while sending lower-severity episodes to a Slack channel for async review.
+When your rules produce alert episodes at different severity levels, you often need to route them to different workflows. For example, you might page an on-call team for critical episodes while sending lower-severity episodes to a Slack channel for async review.
 
 To do this, create separate policies scoped to specific severity values using match conditions:
 
@@ -80,7 +80,7 @@ If an episode drops below a policy's severity threshold, the policy stops matchi
 
 ## Re-notify for persistently active episodes [controlling-re-notification]
 
-The `On status change` frequency option notifies once per status transition (for example, when an episode activates or resolves). This is efficient for reducing noise, but it means that a persistently active episode that only changes in severity won't re-trigger a notification.
+The `On status change` frequency option notifies once per status transition (for example, when an episode activates or resolves). This is efficient for reducing noise, but it means that a persistently active episode that only changes in severity does not re-trigger a notification.
 
 If you want re-notification for episodes that stay active without a status change, use a time-based throttle instead:
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
@@ -1,104 +1,23 @@
 ---
-navigation_title: Common scenarios
+navigation_title: Examples and common scenarios
 applies_to:
   stack: experimental 9.5+
   serverless: experimental
 products:
   - id: kibana
-description: "Common action policy scenarios for the experimental alerting system, including routing by severity, handling severity escalation, and controlling re-notification."
+description: "Common action policy scenarios for the experimental alerting system, including routing by severity, managing severity escalation, and controlling re-notification."
 ---
 
-# Common action policy scenarios [common-action-policy-scenarios]
+# Examples and common scenarios for action policies in the {{alerting-v2-system}} [common-action-policy-scenarios]
 
-Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page covers common situations you're likely to encounter when setting up action policies, and explains how to configure them to get the behavior you expect.
+This section covers common situations you encounter when setting up action policies in the {{alerting-v2-system}} and explains how to configure them to get the behavior you expect.
 
-## Route alert episodes to different workflows by severity [routing-by-severity]
-
-When your rules produce alert episodes at different severity levels, you often need to route them to different workflows. For example, you might page an on-call team for critical episodes while sending lower-severity episodes to a Slack channel for async review.
-
-To do this, create separate policies scoped to specific severity values using match conditions:
-
-| Field | Policy A | Policy B |
-|---|---|---|
-| **Policy type** | Global | Global |
-| **Match conditions** | `severity: "critical"` | `severity: "low" OR severity: "medium" OR severity: "high"` |
-| **Notify per** | Episode | Episode |
-| **Frequency** | On status change | On status change |
-| **Destinations** | PagerDuty workflow | Slack workflow |
-
-Each policy evaluates alert episodes independently:
-
-- An episode with `severity: "critical"` matches Policy A but not Policy B.
-- An episode with `severity: "high"` matches Policy B but not Policy A.
-- If an episode's severity changes mid-lifecycle, the policies that match it change accordingly. For example, if an episode escalates from `high` to `critical`, Policy A starts matching and Policy B stops matching. Policy A fires because it has no prior notification record for that episode.
-
-## Manage notifications across severity changes [severity-escalation]
-
-To manage notifications effectively when episode severity changes, you need to understand how policies match and re-match episodes as severity shifts. Whether a severity change fires a notification depends on whether the policy has matched the episode before and what frequency option is set.
-
-### Notify when an episode escalates into a new severity threshold
-
-Scope a policy to the severity level you want to be notified about. When an episode escalates into that severity level for the first time, the policy fires because it has no prior notification record for the episode.
-
-**Example:** Policy B is scoped to `severity: "critical"`. An episode starts at `low` severity, so Policy B does not match. When the episode escalates to `critical`, Policy B now matches and fires (regardless of the frequency setting) because it has never notified for this episode before.
-
-| Field | Value |
-|---|---|
-| **Policy type** | Global |
-| **Match conditions** | `severity: "critical"` |
-| **Notify per** | Episode |
-| **Frequency** | On status change |
-| **Destinations** | PagerDuty workflow |
-
-### Prevent duplicate notifications when severity changes within an existing match
-
-If a policy already matched an episode at a lower severity and the episode escalates, the policy does not automatically re-notify. With `On status change` frequency, a severity change alone does not count as a status change.
-
-**Example:** Policy A matches all episodes regardless of severity. It notified when the episode was `low`. The episode escalates to `critical`, but Policy A still matches and the status has not changed, only the severity has. The throttle blocks re-notification. To re-notify on escalation, use a time-based throttle or create separate policies per severity level as described in [Route alert episodes to different workflows by severity](#routing-by-severity).
-
-| Field | Value |
-|---|---|
-| **Policy type** | Global |
-| **Match conditions** | (None, matches all episodes) |
-| **Notify per** | Episode |
-| **Frequency** | On status change |
-| **Destinations** | Slack workflow |
-
-### Stop notifications when an episode de-escalates below a policy's threshold
-
-If an episode drops below a policy's severity threshold, the policy stops matching and sends no further notifications. If the episode later escalates back above the threshold, the policy fires again as if it were the first match.
-
-**Example:** Policy B is scoped to `severity: "critical"`. An episode de-escalates from `critical` to `high`. Policy B no longer matches and stops sending notifications. If the episode later escalates back to `critical`, Policy B fires again.
-
-| Field | Value |
-|---|---|
-| **Policy type** | Global |
-| **Match conditions** | `severity: "critical"` |
-| **Notify per** | Episode |
-| **Frequency** | On status change |
-| **Destinations** | PagerDuty workflow |
-
-## Re-notify for persistently active episodes [controlling-re-notification]
-
-The `On status change` frequency option notifies once per status transition (for example, when an episode activates or resolves). This is efficient for reducing noise, but it means that a persistently active episode that only changes in severity does not re-trigger a notification.
-
-If you want re-notification for episodes that stay active without a status change, use a time-based throttle instead:
-
-- **`At most once every…`:** Re-notifies after the configured interval regardless of whether severity or status changed. For example, `1h` sends a follow-up notification every hour while the episode remains active and matched.
-- **`On status change + repeat at interval`:** Notifies on status change and then repeats at the configured interval while the episode stays in the same status.
-
-**Example:** You want to be re-paged if a critical episode stays open for more than an hour. Set the policy frequency to `At most once every 1h`. The policy fires when the episode first matches and then again each hour until the episode resolves or no longer matches.
-
-| Field | Value |
-|---|---|
-| **Policy type** | Global |
-| **Match conditions** | `severity: "critical"` |
-| **Notify per** | Episode |
-| **Frequency** | At most once every 1 hour |
-| **Destinations** | PagerDuty workflow |
+- [Route alert episodes by severity](route-by-severity.md) describes how to direct critical and non-critical episodes to different workflows based on severity level.
+- [Manage severity escalation notifications](severity-escalation.md) explains how policies match and re-match episodes as severity shifts, and how to control which notifications fire.
+- [Re-notify for persistently active episodes](re-notification.md) covers how to configure policies to send follow-up notifications when an episode stays active without a status change.
 
 ## Related pages
 
-- [Action policy reference](action-policy-reference.md) to find descriptions of match condition fields, grouping modes, and frequency options.
+- [Action policy reference](action-policy-reference.md) for match condition fields, grouping modes, and frequency options.
 - [About action policies](about-action-policies.md) to understand how action policies evaluate and gate alert episodes.
-- [Create and configure an action policy](create-configure-action-policy.md) to learn how to set up policy type, match conditions, grouping, frequency, and workflow destinations.
+- [Create and configure an action policy](create-configure-action-policy.md) to set up policy type, match conditions, grouping, frequency, and workflow destinations.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
@@ -15,9 +15,3 @@ This section covers common situations you encounter when setting up action polic
 - [Route alert episodes by severity](route-by-severity.md) describes how to direct critical and non-critical episodes to different workflows based on severity level.
 - [Manage severity escalation notifications](severity-escalation.md) explains how policies match and re-match episodes as severity shifts, and how to control which notifications fire.
 - [Re-notify for persistently active episodes](re-notification.md) covers how to configure policies to send follow-up notifications when an episode stays active without a status change.
-
-## Related pages
-
-- [Action policy reference](action-policy-reference.md) for match condition fields, grouping modes, and frequency options.
-- [About action policies](about-action-policies.md) to understand how action policies evaluate and gate alert episodes.
-- [Create and configure an action policy](create-configure-action-policy.md) to set up policy type, match conditions, grouping, frequency, and workflow destinations.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -15,30 +15,27 @@ Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page cov
 
 Because policies are separate from rules, you can update notification behavior across many rules at once without touching detection logic, and you can route the same alert episodes differently depending on severity or source. You create and manage policies from the **Action policies** page, not from the rule form.
 
-For match conditions fields, grouping modes, frequency options, and dispatch outcomes, refer to [Action policy reference](action-policy-reference.md).
+## Select a policy type [policy-type]
 
-## Policy type [policy-type]
+Action policies only process alert episodes from rules running in Alert mode. Signals produced by rules running in Detect mode aren't eligible for action policy evaluation.
 
-Action policies only process alert episodes from rules running in Alert mode. Signals produced by rules running in Detect mode are not eligible for action policy evaluation.
+An action policy can be **global** (applies to any alert episode in the space) or **per-rule** (scoped to a single rule). For an explanation of how the two types differ and how they evaluate, refer to [About action policies](about-action-policies.md#policy-types).
 
-An action policy can be **global** (applies to any alert episode in the space) or **per-rule** (scoped to a single rule). For a full explanation of how the two types differ and how they evaluate, refer to [About action policies](about-action-policies.md#policy-types).
+You set the policy type at creation and can't change it later. If you need a different type, create a new policy.
 
-The policy type is set at creation and cannot be changed. If you need a different type, create a new policy.
+## Add tags to categorize the policy [policy-tags]
 
-## Tags [policy-tags]
+Tags are optional labels you assign to a policy to categorize it or filter it in the Action policies list. Policy tags describe the policy itself, not the alert episodes it matches. You can add, edit, or remove tags at any time without affecting routing behavior.
 
-Optional string labels you assign to a policy to categorize it or filter it on the Action policies list. Unlike rule tags, policy tags describe the policy itself rather than the alerts it matches. You can add, edit, or remove tags at any time without affecting routing behavior.
+## Filter which episodes the policy applies to [matcher]
 
-## Match conditions [matcher]
+Use an optional [KQL](../../../query-filter/languages/kql.md) expression to filter which alert episodes this policy applies to. Leaving it empty matches every episode in the policy's scope.
 
+Match conditions are the only way to scope a policy beyond its base type. There are no separate rule type or rule ID selector fields. Some common patterns include scoping to a severity level (`severity: "critical"`), to a specific rule (`rule.id: "my-rule-id"`), or to rules with a shared tag (`rule.tags: "payment-service"`).
 
-An optional [KQL](../../../query-filter/languages/kql.md) expression that filters which alert episodes this policy applies to. An empty match condition matches every alert episode covered by the policy's scope. For a global policy, that means all alert episodes in the space. For a per-rule policy, it means all alert episodes from the associated rule.
+For all available fields, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
 
-The match condition is the sole mechanism for scoping a policy beyond its base type. There are no separate rule type or rule ID selector fields. All scoping is done through this expression. For a global policy targeting a specific rule, use `rule.id: "my-rule-id"` or `rule.tags: "my-tag"` in the match condition.
-
-Use match conditions to route different alert episodes to different policies, for example, one policy for `severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
-
-## Notify per and frequency [reduce-noise-grouping]
+## Control how episodes batch and how often the policy notifies [reduce-noise-grouping]
 
 **Notify per** controls how alert episodes batch into notifications. **Frequency** controls how often the policy can notify for each batch.
 
@@ -63,7 +60,7 @@ To receive escalation notifications, either create separate policies scoped to s
 
 For detailed descriptions, frequency options, and examples for each mode, refer to [Notify per options](action-policy-reference.md#notification-grouping).
 
-## Destinations
+## Select workflows to invoke [policy-destinations]
 
 One or more [workflows](../../../workflows.md) to invoke when the policy matches. Use the search field to find and attach workflows.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -21,10 +21,7 @@ For match conditions fields, grouping modes, frequency options, and dispatch out
 
 Action policies only process alert episodes from rules running in Alert mode. Signals produced by rules running in Detect mode are not eligible for action policy evaluation.
 
-An action policy can be global or per-rule:
-
-- **Global** - Global policies apply to any alert episode in the space. Use a global policy when you want to route alert episodes from multiple rules. For example, a policy matching `rule.tags: "checkout"` applies to every rule with that tag.
-- **Per-rule** - Per-rule policies are scoped to a single rule. Use a per-rule policy when notification routing is specific to one rule and you don't want it to affect other rules in the space.
+An action policy can be **global** (applies to any alert episode in the space) or **per-rule** (scoped to a single rule). For a full explanation of how the two types differ and how they evaluate, refer to [About action policies](about-action-policies.md#policy-types).
 
 The policy type is set at creation and cannot be changed. If you need a different type, create a new policy.
 
@@ -41,8 +38,7 @@ The match condition is the sole mechanism for scoping a policy beyond its base t
 
 Use match conditions to route different alert episodes to different policies, for example, one policy for `severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
 
-## Grouping and frequency [reduce-noise-grouping]
-
+## Notify per and frequency [reduce-noise-grouping]
 
 **Notify per** controls how alert episodes batch into notifications. **Frequency** controls how often the policy can notify for each batch.
 
@@ -57,18 +53,15 @@ Use match conditions to route different alert episodes to different policies, fo
 
 :::
 
-For detailed descriptions, frequency options, and examples for each mode, refer to [Notify per options](action-policy-reference.md#notification-grouping).
-
-## Frequency [throttle]
-
-
-**Frequency** limits how often the policy can fire for a given notification group. The interval resets from the last time the policy fired, so successive notifications stay at least `interval` apart. Set a duration such as `1h` or `30m`. For available options by **Notify per** mode, refer to [Frequency](action-policy-reference.md#throttle-strategies).
+**Frequency** limits how often the policy fires for a given notification group. The interval resets from the last time the policy fired, so successive notifications stay at least `interval` apart. Set a duration such as `1h` or `30m`.
 
 :::{note}
-`On status change` only re-notifies when the alert episode's status changes, not when its severity changes. If an episode escalates from `low` to `critical` but the policy already matched it and the status hasn't changed, the throttle blocks re-notification. 
+`On status change` only re-notifies when the alert episode's status changes, not when its severity changes. If an episode escalates from `low` to `critical` but the policy already matched it and the status hasn't changed, the throttle blocks re-notification.
 
-To receive escalation notifications, either create separate policies scoped to specific severity levels, or use a time-based throttle such as `At most once every 1h` so the policy re-notifies after the interval regardless of severity or status changes. For examples, refer to [Controlling re-notification](common-action-policy-scenarios.md#controlling-re-notification).
+To receive escalation notifications, either create separate policies scoped to specific severity levels, or use a time-based throttle such as `At most once every 1h` so the policy re-notifies after the interval regardless of severity or status changes. For examples, refer to [Re-notify for persistently active episodes](re-notification.md).
 :::
+
+For detailed descriptions, frequency options, and examples for each mode, refer to [Notify per options](action-policy-reference.md#notification-grouping).
 
 ## Destinations
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
@@ -37,7 +37,7 @@ Optional string labels you assign to a policy to categorize it or filter it on t
 
 An optional [KQL](../../../query-filter/languages/kql.md) expression that filters which alert episodes this policy applies to. An empty match condition matches every alert episode covered by the policy's scope. For a global policy, that means all alert episodes in the space. For a per-rule policy, it means all alert episodes from the associated rule.
 
-The match condition is the sole mechanism for scoping a policy beyond its base type. There are no separate rule type or rule ID selector fields. All scoping is done through this expression. For a global policy that should target a specific rule, use `rule.id: "my-rule-id"` or `rule.tags: "my-tag"` in the match condition.
+The match condition is the sole mechanism for scoping a policy beyond its base type. There are no separate rule type or rule ID selector fields. All scoping is done through this expression. For a global policy targeting a specific rule, use `rule.id: "my-rule-id"` or `rule.tags: "my-tag"` in the match condition.
 
 Use match conditions to route different alert episodes to different policies, for example, one policy for `severity: "critical"` alert episodes routed to PagerDuty and another for lower-severity episodes routed to Slack. You can also scope by rule, such as `rule.tags: "payment-service"`, to apply a policy only to alert episodes from a set of related rules. For available fields and examples, refer to [Match conditions fields](action-policy-reference.md#matcher-fields).
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -29,6 +29,10 @@ After each dispatcher run, {{kib}} records the outcome in the `.alert-actions` i
 
 The **Execution history** view lets you search these records by policy name, rule name, or saved-object ID, and filter by outcome.
 
+:::{warning}
+The **Execution history** page paginates by log events, but each event renders one row per matched rule. A broad action policy with no rule or severity scoping can generate hundreds of rows from a single dispatcher run, pushing events from other policies off the first page. As a workaround, use match conditions to limit which rules a policy covers. This is currently a known limitation.
+:::
+
 To query raw dispatch records directly, open Discover and query the `.alert-actions` index. Filter by `action_type` to narrow by outcome, or by `policy_id` to filter by policy.
 
 ## Enable, disable, and snooze

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -24,7 +24,7 @@ After each dispatcher run, {{kib}} records the outcome in the `.alert-actions` i
 |---|---|
 | `dispatched` | The dispatcher invoked a workflow for the alert episode. |
 | `throttled` | The alert episode matched a policy but was rate-limited by the frequency setting. No workflow ran. |
-| `suppressed` | Dispatch was blocked. The alert episode was acknowledged, snoozed, or deactivated, or the space is currently in a [maintenance window](../../alerts/maintenance-windows.md). |
+| `suppressed` | Dispatch was blocked. The alert episode was acknowledged, snoozed, or marked inactive, or the space is currently in a [maintenance window](../../alerts/maintenance-windows.md). |
 | `unmatched` | No action policy matched the alert episode. No workflow ran. |
 
 The **Execution history** view lets you search these records by policy name, rule name, or saved-object ID, and filter by outcome.
@@ -36,12 +36,12 @@ To query raw dispatch records directly, open Discover and query the `.alert-acti
 You can disable a policy so it is not evaluated for new alert episodes. You can snooze a policy for a defined window so that it does not dispatch notifications during that period. Policies that are not enabled or are snoozed are skipped when the dispatcher evaluates policies.
 
 :::{note}
-Snoozing a policy differs from [snoozing an alert episode](reduce-notification-noise.md#snooze-scope). When you snooze a policy, the dispatch mechanism is paused and every series the policy would process is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy would have handled it. Use alert snooze when you want to quiet a specific recurring alert without affecting other series handled by the same policy.
+Snoozing a policy differs from [snoozing an alert episode](reduce-notification-noise.md#snooze-scope). When you snooze a policy, the dispatch mechanism is paused and every series the policy processes is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy handles it. Use alert snooze when you want to quiet a specific recurring alert without affecting other series handled by the same policy.
 :::
 
-### Maintenance windows [maintenance-windows]
+### {{maint-windows-cap}} [maintenance-windows]
 
-During a [maintenance window](../../alerts/maintenance-windows.md), action policies stop dispatching notifications automatically. No policy configuration is required. Rule evaluation continues and alert episodes are still recorded in `.rule-events`. Maintenance windows are configured separately, not on the action policy.
+During a [maintenance window](../../alerts/maintenance-windows.md), action policies stop dispatching notifications automatically. No policy configuration is required. Rule evaluation continues and alert episodes are still recorded in `.rule-events`. {{maint-windows-cap}} are configured separately, not on the action policy.
 
 ## Update API keys
 
@@ -51,7 +51,7 @@ You can rotate the API key used to run a policy's workflows without changing mat
 
 **Production considerations**
 
-When you update or delete an action policy, previous API keys used for execution are marked for invalidation and removed on a schedule managed by {{kib}}. Allow for a short delay before new keys are used for dispatch.
+When you update or delete an action policy, previous API keys used for execution are queued for removal on a schedule managed by {{kib}}. Allow for a short delay before new keys are used for dispatch.
 ::::
 
 ## Bulk actions
@@ -60,6 +60,6 @@ On the action policies list, select one or more policies to enable, disable, sno
 
 ## Related pages
 
-- [Reduce notification noise in {{alerting-v2-system}}](reduce-notification-noise.md) to silence individual alert episodes using acknowledge, snooze, or deactivate.
+- [Reduce notification noise in {{alerting-v2-system}}](reduce-notification-noise.md) to silence individual alert episodes by acknowledging, snoozing, or marking them inactive.
 - [Action policy reference in {{alerting-v2-system}}](action-policy-reference.md) to look up match condition fields, grouping modes, and frequency options.
 - [Create and configure an action policy](create-configure-action-policy.md) to set up or update the policies you manage here.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -12,45 +12,37 @@ description: "View policy details, enable, disable, snooze, review execution his
 
 Action policies are part of the {{alerting-v2-system}} in {{kib}}. This page covers how to view policy details, enable and disable policies, snooze them during planned outages, rotate their API keys, and review execution history.
 
-## View policy details
+## View and edit a policy
 
 From the **Action policies** list, you can open a policy to see its full configuration, including match conditions, grouping mode, frequency, and destinations. The list also shows the display name of the user who created the policy and the user who last updated it. You can also edit, clone, delete, enable, disable, snooze, or update its API key without leaving the list page.
 
-## Execution history
+## Review dispatch records and outcomes
 
-The **Execution history** page shows records from the last 24 hours. Each row represents one rule processed by a policy in a single dispatcher cycle and shows the policy name, rule name, outcome, episode count, action group count, and the workflows invoked (for `dispatched` records).
-
-After each dispatcher run, {{kib}} writes one event log entry per policy that ran. The UI denormalizes each entry into one row per rule reference, so a single dispatcher cycle produces as many rows as there are rules the policy evaluated.
+After each dispatcher run, {{kib}} writes one event log entry per policy to the `.kibana-event-log-*` index. {{kib}} retains records for 24 hours. Each entry covers one policy's full dispatcher cycle and includes the policy name, rule name, outcome, episode count, action group count, and any workflows invoked.
 
 | Outcome | What it means |
 |---|---|
 | `dispatched` | The dispatcher invoked a workflow for the alert episode. |
 | `throttled` | The alert episode matched a policy but was rate-limited by the frequency setting. No workflow ran. |
-| `unmatched` | No action policy matched the alert episode. No workflow ran. This outcome is recorded in the event log but is not available as a filter in the **Execution history** UI. Use Discover to find `unmatched` records. |
+| `unmatched` | No action policy matched the alert episode. No workflow ran. |
 
-Episodes that were acknowledged, snoozed, marked inactive, or covered by a [maintenance window](../../alerts/maintenance-windows.md) are suppressed before the dispatcher runs and do not produce an execution history record.
+The dispatcher drops episodes that are acknowledged, snoozed, marked inactive, or covered by a [maintenance window](../../alerts/maintenance-windows.md) before running and writes no record for them.
 
-Search records by policy name, rule name, or saved-object ID. Filter by outcome using the `dispatched` and `throttled` options in the UI.
+To query records directly or find records older than 24 hours, open Discover and query `.kibana-event-log-*` with `event.provider: "alerting_v2"`. Use `event.action` to filter by outcome (`dispatched`, `throttled`, or `unmatched`).
 
-:::{warning}
-The **Execution history** page paginates at 100 log events per page. Each log event covers one policy's full dispatcher cycle and is then expanded into one row per rule — a single event matching 50 rules fills one page slot but renders 50 rows. A broad policy with no rule or severity scoping can generate hundreds of rows from a single event, pushing records from other policies off the visible page. Use match conditions to scope a policy to specific rules or severity levels to reduce this.
-:::
+## Enable, disable, and snooze a policy
 
-Execution history records are retained for 24 hours. For older records, open Discover and query the `.kibana-event-log-*` index. Add a filter for `event.provider: "alerting_v2"` and use `event.action` to narrow by outcome (`dispatched`, `throttled`, or `unmatched`).
-
-## Enable, disable, and snooze
-
-You can disable a policy so it is not evaluated for new alert episodes. You can snooze a policy for a defined window so that it does not dispatch notifications during that period. Policies that are not enabled or are snoozed are skipped when the dispatcher evaluates policies.
+You can disable a policy so the dispatcher doesn't evaluate it for new alert episodes. You can snooze a policy for a defined window so it doesn't dispatch notifications during that period. The dispatcher skips policies that aren't enabled or are snoozed.
 
 :::{note}
-Snoozing a policy differs from [snoozing an alert episode](reduce-notification-noise.md#snooze-scope). When you snooze a policy, the dispatch mechanism is paused and every series the policy processes is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy handles it. Use alert snooze when you want to quiet a specific recurring alert without affecting other series handled by the same policy.
+Snoozing a policy differs from [snoozing an alert episode](reduce-notification-noise.md#snooze-scope). When you snooze a policy, the dispatcher pauses and silences every alert series the policy processes. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy handles it. Use alert snooze when you want to quiet a specific recurring alert without affecting other series handled by the same policy.
 :::
 
-### {{maint-windows-cap}} [maintenance-windows]
+### Pause dispatch during a maintenance window [maintenance-windows]
 
-During a [maintenance window](../../alerts/maintenance-windows.md), action policies stop dispatching notifications automatically. No policy configuration is required. Rule evaluation continues and alert episodes are still recorded in `.rule-events`. {{maint-windows-cap}} are configured separately, not on the action policy.
+During a [maintenance window](../../alerts/maintenance-windows.md), action policies stop dispatching notifications automatically. You don't need to configure the policy. Rule evaluation continues and alert episodes are still recorded in `.rule-events`. Configure {{maint-windows-cap}} separately, not on the action policy.
 
-## Update API keys
+## Rotate a policy's API key
 
 You can rotate the API key used to run a policy's workflows without changing matchers or destinations. Use the **Update API key** action on one policy or for multiple selected policies.
 
@@ -61,7 +53,7 @@ You can rotate the API key used to run a policy's workflows without changing mat
 When you update or delete an action policy, previous API keys used for execution are queued for removal on a schedule managed by {{kib}}. Allow for a short delay before new keys are used for dispatch.
 ::::
 
-## Bulk actions
+## Manage multiple policies at once
 
 On the action policies list, select one or more policies to enable, disable, snooze, and do more in bulk. **Select all** selects every policy on the current page of results. Clear the selection before changing filters if you need a different set.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md
@@ -18,22 +18,25 @@ From the **Action policies** list, you can open a policy to see its full configu
 
 ## Execution history
 
-After each dispatcher run, {{kib}} records the outcome in the `.alert-actions` index. These records let you audit whether workflows were invoked, skipped, or had no matching policy for each alert episode.
+The **Execution history** page shows records from the last 24 hours. Each row represents one rule processed by a policy in a single dispatcher cycle and shows the policy name, rule name, outcome, episode count, action group count, and the workflows invoked (for `dispatched` records).
+
+After each dispatcher run, {{kib}} writes one event log entry per policy that ran. The UI denormalizes each entry into one row per rule reference, so a single dispatcher cycle produces as many rows as there are rules the policy evaluated.
 
 | Outcome | What it means |
 |---|---|
 | `dispatched` | The dispatcher invoked a workflow for the alert episode. |
 | `throttled` | The alert episode matched a policy but was rate-limited by the frequency setting. No workflow ran. |
-| `suppressed` | Dispatch was blocked. The alert episode was acknowledged, snoozed, or marked inactive, or the space is currently in a [maintenance window](../../alerts/maintenance-windows.md). |
-| `unmatched` | No action policy matched the alert episode. No workflow ran. |
+| `unmatched` | No action policy matched the alert episode. No workflow ran. This outcome is recorded in the event log but is not available as a filter in the **Execution history** UI. Use Discover to find `unmatched` records. |
 
-The **Execution history** view lets you search these records by policy name, rule name, or saved-object ID, and filter by outcome.
+Episodes that were acknowledged, snoozed, marked inactive, or covered by a [maintenance window](../../alerts/maintenance-windows.md) are suppressed before the dispatcher runs and do not produce an execution history record.
+
+Search records by policy name, rule name, or saved-object ID. Filter by outcome using the `dispatched` and `throttled` options in the UI.
 
 :::{warning}
-The **Execution history** page paginates by log events, but each event renders one row per matched rule. A broad action policy with no rule or severity scoping can generate hundreds of rows from a single dispatcher run, pushing events from other policies off the first page. As a workaround, use match conditions to limit which rules a policy covers. This is currently a known limitation.
+The **Execution history** page paginates at 100 log events per page. Each log event covers one policy's full dispatcher cycle and is then expanded into one row per rule — a single event matching 50 rules fills one page slot but renders 50 rows. A broad policy with no rule or severity scoping can generate hundreds of rows from a single event, pushing records from other policies off the visible page. Use match conditions to scope a policy to specific rules or severity levels to reduce this.
 :::
 
-To query raw dispatch records directly, open Discover and query the `.alert-actions` index. Filter by `action_type` to narrow by outcome, or by `policy_id` to filter by policy.
+Execution history records are retained for 24 hours. For older records, open Discover and query the `.kibana-event-log-*` index. Add a filter for `event.provider: "alerting_v2"` and use `event.action` to narrow by outcome (`dispatched`, `throttled`, or `unmatched`).
 
 ## Enable, disable, and snooze
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/re-notification.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/re-notification.md
@@ -1,0 +1,34 @@
+---
+navigation_title: Re-notification
+applies_to:
+  stack: experimental 9.5+
+  serverless: experimental
+products:
+  - id: kibana
+description: "How to configure action policies to re-notify when an alert episode stays active without a status change in the experimental alerting system."
+---
+
+# Re-notify for persistently active episodes in the {{alerting-v2-system}} [controlling-re-notification]
+
+The `On status change` frequency option notifies once per status transition, for example when an episode activates or resolves. This is efficient for reducing noise from rules in the {{alerting-v2-system}}, but a persistently active episode that only changes in severity does not re-trigger a notification.
+
+To re-notify for episodes that stay active without a status change, use a time-based throttle.
+
+- **`At most once every…`** Re-notifies after the configured interval regardless of whether severity or status changed. Setting this to `1h` sends a follow-up notification every hour while the episode remains active and matched.
+- **`On status change + repeat at interval`** Notifies on status change and then repeats at the configured interval while the episode stays in the same status.
+
+In this example, you want to be re-paged if a critical episode stays open for more than an hour. Set the policy frequency to `At most once every 1h`. The policy fires when the episode first matches and then again each hour until the episode resolves or no longer matches.
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | `severity: "critical"` |
+| **Notify per** | Episode |
+| **Frequency** | At most once every 1 hour |
+| **Destinations** | PagerDuty workflow |
+
+## Related pages
+
+- [Manage severity escalation notifications](severity-escalation.md) for scenarios where a severity change determines whether a notification fires.
+- [Action policy reference](action-policy-reference.md) for descriptions of all frequency options.
+- [Create and configure an action policy](create-configure-action-policy.md) to set up the frequency settings described on this page.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/re-notification.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/re-notification.md
@@ -10,7 +10,7 @@ description: "How to configure action policies to re-notify when an alert episod
 
 # Re-notify for persistently active episodes in the {{alerting-v2-system}} [controlling-re-notification]
 
-The `On status change` frequency option notifies once per status transition, for example when an episode activates or resolves. This is efficient for reducing noise from rules in the {{alerting-v2-system}}, but a persistently active episode that only changes in severity does not re-trigger a notification.
+The `On status change` frequency option notifies once per status transition, for example when an episode activates or resolves. This is efficient for reducing noise from rules in the {{alerting-v2-system}}, but a persistently active episode that only changes in severity doesn't re-trigger a notification.
 
 To re-notify for episodes that stay active without a status change, use a time-based throttle.
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
@@ -35,7 +35,7 @@ For instructions on snoozing and unsnoozing single or multiple episodes, refer t
 -->
 
 :::{note}
-Snoozing an alert episode differs from [snoozing an action policy](manage-action-policies.md#enable-disable-and-snooze). When you snooze a policy, the dispatch mechanism is paused and every series the policy would process is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy would have handled it. Use policy snooze when you want to pause all notifications from a given policy, for example, during planned maintenance on a destination system.
+Snoozing an alert episode differs from [snoozing an action policy](manage-action-policies.md#enable-disable-and-snooze). When you snooze a policy, the dispatch mechanism is paused and every series the policy processes is silenced. When you snooze an alert episode, you target one specific series before policy matching runs, silencing it regardless of which policy handles it. Use policy snooze when you want to pause all notifications from a given policy, for example, during planned maintenance on a destination system.
 :::
 
 ## Related pages

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
@@ -8,9 +8,9 @@ products:
 description: "How to reduce notification noise in the experimental alerting system using acknowledge, snooze, and deactivate to silence alert episodes."
 ---
 
-# Reduce notification noise for the {{alerting-v2-system}} [reduce-notification-noise]
+# Reduce notification noise from the {{alerting-v2-system}} [reduce-notification-noise]
 
-Acknowledge, snooze, and deactivate are part of the {{alerting-v2-system}} in {{kib}}. Each one silences notifications for an alert episode at a different scope. When an alert episode is silenced, the dispatcher stops processing it before any action policy matching, grouping, or frequency evaluation runs.
+Several mechanisms within the {{alerting-v2-system}} can silence notifications for an alert episode. When an alert episode is silenced, the dispatcher stops processing it before any action policy matching, grouping, or frequency evaluation runs.
 
 This page covers when to use each silencing mechanism and how the scope of an alert episode snooze differs from the scope of a policy snooze. For an overview of where this fits in the full dispatch cycle, refer to [About action policies](about-action-policies.md).
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/reduce-notification-noise.md
@@ -23,8 +23,7 @@ Three mechanisms let you silence notifications, each at a different scope:
 | Acknowledge | Per alert episode | You're actively investigating a breach and want to silence notifications for it without closing the alert episode. Clear the acknowledgment when you're done to restore notifications. |
 | Snooze | Per series (group) | You want to quiet an entire alert series for a defined period, for example, during a known noisy window for a specific host. Snooze expires automatically at the end of the duration. |
 | Deactivate | Per alert episode | You want to manually close an alert episode that hasn't recovered automatically. Deactivating marks the alert episode as inactive and stops notifications for it. Unlike acknowledge, this closes the alert episode rather than silencing it while leaving it active. |
-
-Each mechanism is stored as a separate document in `.alert-actions`, so the full gating history for an episode is queryable in Discover.
+| [Maintenance window](../../alerts/maintenance-windows.md) | All policies in a space | You want to pause all action policy dispatching in a space for a planned maintenance period. All active policies stop dispatching; rule evaluation and episode recording continue. Maintenance windows are configured separately from action policies. |
 
 ### Snooze scope
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/route-by-severity.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/route-by-severity.md
@@ -1,0 +1,35 @@
+---
+navigation_title: Route by severity
+applies_to:
+  stack: experimental 9.5+
+  serverless: experimental
+products:
+  - id: kibana
+description: "How to route alert episodes to different workflows based on severity level in the experimental alerting system."
+---
+
+# Route alert episodes by severity in the {{alerting-v2-system}} [routing-by-severity]
+
+When your rules in the {{alerting-v2-system}} produce alert episodes at different severity levels, you can route them to different workflows by creating separate action policies that are scoped to specific severity values using match conditions.
+
+For example, you might page an on-call team for critical episodes while sending lower-severity episodes to a Slack channel for async review.
+
+| Field | Policy A | Policy B |
+|---|---|---|
+| **Policy type** | Global | Global |
+| **Match conditions** | `severity: "critical"` | `severity: "low" OR severity: "medium" OR severity: "high"` |
+| **Notify per** | Episode | Episode |
+| **Frequency** | On status change | On status change |
+| **Destinations** | PagerDuty workflow | Slack workflow |
+
+Each policy evaluates alert episodes independently.
+
+- An episode with `severity: "critical"` matches Policy A but not Policy B.
+- An episode with `severity: "high"` matches Policy B but not Policy A.
+- If an episode's severity changes mid-lifecycle, the policies that match it change accordingly. For example, if an episode escalates from `high` to `critical`, Policy A starts matching and Policy B stops matching. Policy A fires because it has no prior notification record for that episode.
+
+## Related pages
+
+- [Manage severity escalation notifications](severity-escalation.md) explains what happens when an episode that has already matched a policy changes severity.
+- [Action policy reference](action-policy-reference.md) for match condition fields, grouping modes, and frequency options.
+- [Create and configure an action policy](create-configure-action-policy.md) to set up a policy with match conditions.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/severity-escalation.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/severity-escalation.md
@@ -1,0 +1,61 @@
+---
+navigation_title: Severity escalation
+applies_to:
+  stack: experimental 9.5+
+  serverless: experimental
+products:
+  - id: kibana
+description: "How to manage notifications when alert episode severity changes in the experimental alerting system, including escalation, de-escalation, and duplicate notification prevention."
+---
+
+# Manage severity escalation notifications for the {{alerting-v2-system}} [severity-escalation]
+
+Not every severity change fires a notification. The outcome depends on whether the action policy has already matched the episode and which frequency option is configured.
+
+## Notify when an episode escalates into a new severity threshold
+
+Scope a policy to the severity level you want to be notified about. When an episode escalates into that severity level for the first time, the policy fires because it has no prior notification record for the episode.
+
+The following example uses a policy scoped to `severity: "critical"`. An episode starts at `low` severity, so the policy does not match. When the episode escalates to `critical`, the policy now matches and fires regardless of the frequency setting, because it has never notified for this episode before.
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | `severity: "critical"` |
+| **Notify per** | Episode |
+| **Frequency** | On status change |
+| **Destinations** | PagerDuty workflow |
+
+## Prevent duplicate notifications when severity changes within an existing match
+
+If a policy already matched an episode at a lower severity and the episode escalates, the policy does not automatically re-notify. With `On status change` frequency, a severity change alone does not count as a status change.
+
+In this example, Policy A matches all episodes regardless of severity. It notified when the episode was `low`. The episode escalates to `critical`, but Policy A still matches and the status has not changed, only the severity has. The throttle blocks re-notification. To re-notify on escalation, use a time-based throttle or create separate policies per severity level as described in [Route alert episodes by severity](route-by-severity.md).
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | (None, matches all episodes) |
+| **Notify per** | Episode |
+| **Frequency** | On status change |
+| **Destinations** | Slack workflow |
+
+## Stop notifications when an episode de-escalates below a policy's threshold
+
+If an episode drops below a policy's severity threshold, the policy stops matching and sends no further notifications. If the episode later escalates back above the threshold, the policy fires again as if it were the first match.
+
+In this example, Policy B is scoped to `severity: "critical"`. An episode de-escalates from `critical` to `high`. Policy B no longer matches and stops sending notifications. If the episode later escalates back to `critical`, Policy B fires again.
+
+| Field | Value |
+|---|---|
+| **Policy type** | Global |
+| **Match conditions** | `severity: "critical"` |
+| **Notify per** | Episode |
+| **Frequency** | On status change |
+| **Destinations** | PagerDuty workflow |
+
+## Related pages
+
+- [Route alert episodes by severity](route-by-severity.md) for configuration examples that use severity-scoped policies to separate routing destinations.
+- [Re-notify for persistently active episodes](re-notification.md) for time-based throttle options that re-notify when an episode stays active.
+- [Action policy reference](action-policy-reference.md) for match condition fields and frequency options.

--- a/explore-analyze/alerting/kibana-alerting-experimental/action-policies/severity-escalation.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/action-policies/severity-escalation.md
@@ -10,13 +10,13 @@ description: "How to manage notifications when alert episode severity changes in
 
 # Manage severity escalation notifications for the {{alerting-v2-system}} [severity-escalation]
 
-Not every severity change fires a notification. The outcome depends on whether the action policy has already matched the episode and which frequency option is configured.
+Not every severity change fires a notification. The outcome depends on whether the action policy has already matched the episode and which frequency option you've selected.
 
 ## Notify when an episode escalates into a new severity threshold
 
-Scope a policy to the severity level you want to be notified about. When an episode escalates into that severity level for the first time, the policy fires because it has no prior notification record for the episode.
+Scope a policy to the severity level you want notifications for. When an episode escalates into that severity level for the first time, the policy fires because it has no prior notification record for the episode.
 
-The following example uses a policy scoped to `severity: "critical"`. An episode starts at `low` severity, so the policy does not match. When the episode escalates to `critical`, the policy now matches and fires regardless of the frequency setting, because it has never notified for this episode before.
+The following example uses a policy scoped to `severity: "critical"`. An episode starts at `low` severity, so the policy doesn't match. When the episode escalates to `critical`, the policy now matches and fires regardless of the frequency setting, because it has never notified for this episode before.
 
 | Field | Value |
 |---|---|
@@ -28,9 +28,9 @@ The following example uses a policy scoped to `severity: "critical"`. An episode
 
 ## Prevent duplicate notifications when severity changes within an existing match
 
-If a policy already matched an episode at a lower severity and the episode escalates, the policy does not automatically re-notify. With `On status change` frequency, a severity change alone does not count as a status change.
+If a policy already matched an episode at a lower severity and the episode escalates, the policy doesn't automatically re-notify. With `On status change` frequency, a severity change alone doesn't count as a status change.
 
-In this example, Policy A matches all episodes regardless of severity. It notified when the episode was `low`. The episode escalates to `critical`, but Policy A still matches and the status has not changed, only the severity has. The throttle blocks re-notification. To re-notify on escalation, use a time-based throttle or create separate policies per severity level as described in [Route alert episodes by severity](route-by-severity.md).
+In this example, Policy A matches all episodes regardless of severity. It notified when the episode was `low`. The episode escalates to `critical`, but Policy A still matches and the status hasn't changed, only the severity has. The throttle blocks re-notification. To re-notify on escalation, use a time-based throttle or create separate policies per severity level as described in [Route alert episodes by severity](route-by-severity.md).
 
 | Field | Value |
 |---|---|
@@ -44,7 +44,7 @@ In this example, Policy A matches all episodes regardless of severity. It notifi
 
 If an episode drops below a policy's severity threshold, the policy stops matching and sends no further notifications. If the episode later escalates back above the threshold, the policy fires again as if it were the first match.
 
-In this example, Policy B is scoped to `severity: "critical"`. An episode de-escalates from `critical` to `high`. Policy B no longer matches and stops sending notifications. If the episode later escalates back to `critical`, Policy B fires again.
+In this example, Policy B targets only `severity: "critical"` episodes. An episode de-escalates from `critical` to `high`. Policy B no longer matches and stops sending notifications. If the episode later escalates back to `critical`, Policy B fires again.
 
 | Field | Value |
 |---|---|

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -23,9 +23,9 @@ To send a notification or trigger an action from a rule in the {{alerting-v2-sys
 
 1. [Build a workflow](../../workflows/get-started/build-your-first-workflow.md) that defines what to do, for example, send a message, call a webhook, open a case, or run any other automation.
 
-2. [Create an action policy](action-policies/create-configure-action-policy.md) that routes alert episodes to that workflow. The policy controls which alert episodes qualify, how they batch, and how often the workflow is invoked.
+2. [Create an action policy](action-policies/create-configure-action-policy.md) that routes alert episodes to that workflow. The policy controls which alert episodes qualify, how they batch, and how often it invokes the workflow.
 
-   For actions that should fire exactly once in response to a specific alert episode state change (such as opening a ticket when an episode is assigned) use an [alert episode lifecycle trigger](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven) instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a comparison of action policies and lifecycle triggers.
+   For actions that fire exactly once in response to a specific alert episode state change (such as opening a ticket when an episode is assigned) use an [alert episode lifecycle trigger](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven) instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a comparison of action policies and lifecycle triggers.
 
 ## Related pages
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -10,7 +10,7 @@ description: "How to set up notifications and actions for rules in the experimen
 
 # Notifications and actions for the {{alerting-v2-system}}
 
-Rules in the {{alerting-v2-system}} don't send notifications directly. Instead, they produce alert episodes, and you use workflows and action policies to decide what happens next.
+{{rules-ui}} in the {{alerting-v2-system}} don't send notifications directly. Instead, they produce alert episodes, and you use workflows and action policies to decide what happens next.
 
 - **Workflows** are the delivery layer. They define what happens when the system decides to act, such as sending a message, calling a webhook, or triggering an automation.
 - **Action policies** are the gating layer. They evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions, grouping, and frequency settings.

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -15,18 +15,24 @@ Rules in the {{alerting-v2-system}} don't send notifications directly. Instead, 
 - **Workflows** are the delivery layer. They define what happens when the system decides to act, such as sending a message, calling a webhook, or triggering an automation.
 - **Action policies** are the gating layer. They evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions, grouping, and frequency settings.
 
-## Get started
 
-To send notifications or run actions from an alerting v2 rule:
+## Send notifications or trigger an action
 
-1. [Build a workflow](../../workflows/get-started/build-your-first-workflow.md) that defines the action to take.
-2. [Create an action policy](action-policies/create-configure-action-policy.md) that routes alert episodes to that workflow.
+To send a notification or trigger an action from a rule in the {{alerting-v2-system}}:
 
-:::{tip}
-If you need an action to fire exactly once in response to a specific alert episode state change (such as opening a ticket when an episode is assigned) use an alert episode lifecycle trigger instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a comparison of both approaches.
-:::
+1. [Build a workflow](../../workflows/get-started/build-your-first-workflow.md) that defines what to do, for example, send a message, call a webhook, open a case, or run any other automation. 
 
-## In this section
+
+   :::{note}
+   :applies_to: {"stack": "ga 9.4+", "serverless": "ga"}
+   To use workflows, your role must have the appropriate privileges and your subscription must include workflows. Refer to the subscription page for [{{ecloud}}]({{subscriptions}}/cloud) and [{{stack}}/self-managed]({{subscriptions}}) for a breakdown of available features by tier.
+   :::
+
+2. [Create an action policy](action-policies/create-configure-action-policy.md) that routes alert episodes to that workflow. The policy controls which alert episodes qualify, how they batch, and how often the workflow is invoked.
+
+   For actions that should fire exactly once in response to a specific alert episode state change — such as opening a ticket when an episode is assigned — use an [alert episode lifecycle trigger](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven) instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a side-by-side comparison of action policies and lifecycle triggers.
+
+## Related pages
 
 - [Connect workflows](workflows-alerting.md) - How action policies and lifecycle triggers invoke workflows at runtime.
 - [About action policies](action-policies/about-action-policies.md) - How action policies evaluate and gate alert episodes.

--- a/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/notifications-actions.md
@@ -10,27 +10,22 @@ description: "How to set up notifications and actions for rules in the experimen
 
 # Notifications and actions for the {{alerting-v2-system}}
 
-{{rules-ui}} in the {{alerting-v2-system}} don't send notifications directly. Instead, they produce alert episodes, and you use workflows and action policies to decide what happens next.
+{{rules-ui}} in the {{alerting-v2-system}} don't send notifications directly. Instead, they produce alert episodes, and you use workflows and action policies to decide what happens next. For an explanation of how these two connect at runtime, refer to [Connect workflows](workflows-alerting.md).
 
-- **Workflows** are the delivery layer. They define what happens when the system decides to act, such as sending a message, calling a webhook, or triggering an automation.
-- **Action policies** are the gating layer. They evaluate active alert episodes on a continuous schedule and invoke workflows based on match conditions, grouping, and frequency settings.
-
+:::{note}
+:applies_to: {"stack": "ga 9.4+", "serverless": "ga"}
+To use workflows, your role must have the appropriate privileges and your subscription must include workflows. Refer to the subscription page for [{{ecloud}}]({{subscriptions}}/cloud) and [{{stack}}/self-managed]({{subscriptions}}) for a breakdown of available features by tier.
+:::
 
 ## Send notifications or trigger an action
 
 To send a notification or trigger an action from a rule in the {{alerting-v2-system}}:
 
-1. [Build a workflow](../../workflows/get-started/build-your-first-workflow.md) that defines what to do, for example, send a message, call a webhook, open a case, or run any other automation. 
-
-
-   :::{note}
-   :applies_to: {"stack": "ga 9.4+", "serverless": "ga"}
-   To use workflows, your role must have the appropriate privileges and your subscription must include workflows. Refer to the subscription page for [{{ecloud}}]({{subscriptions}}/cloud) and [{{stack}}/self-managed]({{subscriptions}}) for a breakdown of available features by tier.
-   :::
+1. [Build a workflow](../../workflows/get-started/build-your-first-workflow.md) that defines what to do, for example, send a message, call a webhook, open a case, or run any other automation.
 
 2. [Create an action policy](action-policies/create-configure-action-policy.md) that routes alert episodes to that workflow. The policy controls which alert episodes qualify, how they batch, and how often the workflow is invoked.
 
-   For actions that should fire exactly once in response to a specific alert episode state change — such as opening a ticket when an episode is assigned — use an [alert episode lifecycle trigger](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven) instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a side-by-side comparison of action policies and lifecycle triggers.
+   For actions that should fire exactly once in response to a specific alert episode state change (such as opening a ticket when an episode is assigned) use an [alert episode lifecycle trigger](../../workflows/triggers/event-driven-triggers.md#alert-episode-lifecycle-triggers-event-driven) instead of an action policy. Refer to [Connect workflows](workflows-alerting.md) for a comparison of action policies and lifecycle triggers.
 
 ## Related pages
 

--- a/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/workflows-alerting.md
@@ -23,18 +23,11 @@ The {{alerting-v2-system}} connects to workflows through two pathways.
 
 ### Action policies [action-policy-driven-workflows]
 
-Action policies evaluate alert episodes on a continuous schedule and invoke workflows when an episode meets the configured conditions. After a rule runs, the system routes alert episodes to workflows through the following steps.
+Action policies evaluate alert episodes on a continuous schedule and invoke workflows when an episode meets the configured conditions. After a rule runs, the system routes alert episodes to workflows through a suppression check, match conditions, grouping, and frequency gates. For the full step-by-step evaluation sequence, refer to [How action policies are evaluated](action-policies/about-action-policies.md#how-action-policies-evaluated).
 
 ```
 Rule → Alert episode → [Dispatcher] → Action policy → Workflow → Notification
 ```
-
-1. A rule evaluates data on a schedule and writes a rule event.
-2. In Alert mode, the rule event opens or updates an alert episode.
-3. The dispatcher runs on a short interval, independently of the rule schedule, and picks up active alert episodes.
-4. For each active alert episode, the dispatcher evaluates all enabled action policies. Each policy runs the episode through suppression, match conditions, grouping, and frequency gates.
-5. For policies where the episode clears all gates, the dispatcher invokes the configured workflows.
-6. Workflows deliver the notification or run the automation.
 
 ### Alert episode lifecycle triggers [alert-episode-lifecycle-triggers]
 

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -387,6 +387,10 @@ toc:
           - file: alerting/kibana-alerting-experimental/workflows-alerting.md
           - file: alerting/kibana-alerting-experimental/action-policies/about-action-policies.md
           - file: alerting/kibana-alerting-experimental/action-policies/common-action-policy-scenarios.md
+            children:
+              - file: alerting/kibana-alerting-experimental/action-policies/route-by-severity.md
+              - file: alerting/kibana-alerting-experimental/action-policies/severity-escalation.md
+              - file: alerting/kibana-alerting-experimental/action-policies/re-notification.md
           - file: alerting/kibana-alerting-experimental/action-policies/create-configure-action-policy.md
           - file: alerting/kibana-alerting-experimental/action-policies/action-policy-reference.md
           - file: alerting/kibana-alerting-experimental/action-policies/manage-action-policies.md

--- a/explore-analyze/workflows/triggers.md
+++ b/explore-analyze/workflows/triggers.md
@@ -105,7 +105,7 @@ Event-driven triggers run workflows when a platform event occurs:
 * **`workflows.failed`** fires when another workflow's execution fails {applies_to}`stack: preview 9.4+` {applies_to}`serverless: preview`.
 * **Cases triggers** fire when cases change {applies_to}`stack: preview 9.5+` {applies_to}`serverless: preview`. The family includes `cases.caseCreated`, `cases.caseUpdated`, `cases.caseStatusUpdated`, `cases.attachmentsAdded`, and `cases.commentsAdded`.
 * **Alert episode lifecycle triggers** (experimental, 9.5+) fire when an alert episode changes state in the {{alerting-v2-system}}, such as when it is activated, assigned, acknowledged, or snoozed.
-* **{{alerting-v2-system-cap}} rule lifecycle triggers** (experimental, 9.5+) fire when rules in the {{alerting-v2-system}} are created, updated, deleted, enabled, or disabled. The family includes `alerting.ruleCreated`, `alerting.ruleUpdated`, `alerting.ruleDeleted`, `alerting.ruleEnabled`, and `alerting.ruleDisabled`.
+* **{{alerting-v2-system-cap}} rule lifecycle triggers** fire when rules in the {{alerting-v2-system}} are created, updated, deleted, or have their status changed. The family includes `alerting.ruleCreated`, `alerting.ruleUpdated`, `alerting.ruleDeleted`, `alerting.ruleEnabled`, and `alerting.ruleDisabled`. {applies_to}`stack: experimental 9.5+` {applies_to}`serverless: experimental`.
 
 Use event-driven triggers for:
 

--- a/explore-analyze/workflows/triggers.md
+++ b/explore-analyze/workflows/triggers.md
@@ -104,12 +104,15 @@ Event-driven triggers run workflows when a platform event occurs:
 
 * **`workflows.failed`** fires when another workflow's execution fails {applies_to}`stack: preview 9.4+` {applies_to}`serverless: preview`.
 * **Cases triggers** fire when cases change {applies_to}`stack: preview 9.5+` {applies_to}`serverless: preview`. The family includes `cases.caseCreated`, `cases.caseUpdated`, `cases.caseStatusUpdated`, `cases.attachmentsAdded`, and `cases.commentsAdded`.
+* **Alert episode lifecycle triggers** (experimental, 9.5+) fire when an alert episode changes state in the {{alerting-v2-system}}, such as when it is activated, assigned, acknowledged, or snoozed.
+* **{{alerting-v2-system-cap}} rule lifecycle triggers** (experimental, 9.5+) fire when rules in the {{alerting-v2-system}} are created, updated, deleted, enabled, or disabled. The family includes `alerting.ruleCreated`, `alerting.ruleUpdated`, `alerting.ruleDeleted`, `alerting.ruleEnabled`, and `alerting.ruleDisabled`.
 
 Use event-driven triggers for:
 
 * Central error-handler workflows that react to failures across your automation
 * Reacting to case lifecycle changes (case opened, status changed, attachments or comments added)
 * Paging on-call, opening cases, or logging when a production workflow fails
+* Auditing rule management actions, syncing rule inventory with external systems, or notifying a channel when rules change in the {{alerting-v2-system}}
 
 Event-driven trigger example:
 
@@ -130,7 +133,9 @@ Each trigger type provides different data to the workflow context through the `e
 * **Event-driven**:
   * `workflows.failed` provides metadata about the failed workflow, its execution, and the step that failed.
   * Cases triggers provide `event.caseId`, `event.owner`, and event-specific fields (status changes carry `previousStatus` and `status`; attachment events carry IDs and type; comment events carry IDs).
-  
+  * Alert episode lifecycle triggers provide `event.episodeId`, `event.ruleId`, and `event.spaceId`.
+  * {{alerting-v2-system-cap}} rule lifecycle triggers provide `event.rule.ruleId` and `event.rule.spaceId`.
+
   Refer to [Event-driven triggers](/explore-analyze/workflows/triggers/event-driven-triggers.md) for the full payload shapes.
 
 Access trigger data in your workflow using template variables:

--- a/explore-analyze/workflows/triggers/event-driven-triggers.md
+++ b/explore-analyze/workflows/triggers/event-driven-triggers.md
@@ -397,7 +397,7 @@ serverless: experimental
 
 {{alerting-v2-system-cap}} rule lifecycle triggers fire when rules are created, updated, deleted, enabled, or disabled in the {{alerting-v2-system}}. Use them to automate responses to rule management actions — for example, auditing rule changes, syncing rule inventory with an external CMDB, or notifying a team channel when a new rule is added to a space.
 
-Rule lifecycle triggers are active by default and require no feature flag. They are part of the {{alerting-v2-system}} and fire independently of alert episodes.
+Rule lifecycle triggers are part of the {{alerting-v2-system}} and fire independently of alert episodes.
 
 ### Available triggers [alerting-rule-lifecycle-triggers-available]
 

--- a/explore-analyze/workflows/triggers/event-driven-triggers.md
+++ b/explore-analyze/workflows/triggers/event-driven-triggers.md
@@ -3,7 +3,7 @@ navigation_title: Event-driven triggers
 applies_to:
   stack: preview 9.4+
   serverless: preview
-description: Run a workflow in response to a platform event. Includes workflows.failed, the cases trigger family, and alert episode lifecycle triggers.
+description: Run a workflow in response to a platform event. Includes workflows.failed, the cases trigger family, alert episode lifecycle triggers, and {{alerting-v2-system}} rule lifecycle triggers.
 products:
   - id: kibana
   - id: cloud-serverless
@@ -15,11 +15,12 @@ products:
 
 # Event-driven triggers [workflows-event-driven-triggers]
 
-Event-driven triggers let workflows react to events elsewhere in {{kib}}. Three trigger families are available:
+Event-driven triggers let workflows react to events elsewhere in {{kib}}. Four trigger families are available:
 
 - **`workflows.failed`** — Fires when another workflow's execution fails. {applies_to}`stack: preview 9.4+` {applies_to}`serverless: preview`
 - **Cases triggers** — Fire when cases change (created, updated, status changed, attachments added, comments added). {applies_to}`stack: preview 9.5+` {applies_to}`serverless: preview`
-- **Alert episode lifecycle triggers** — Fire when an alert episode changes state in the experimental {{alerting-v2-system}}, such as when it is activated, assigned, acknowledged, or snoozed. {applies_to}`stack: experimental 9.5+` {applies_to}`serverless: experimental`
+- **Alert episode lifecycle triggers** — Fire when an alert episode changes state in the {{alerting-v2-system}}, such as when it is activated, assigned, acknowledged, or snoozed. {applies_to}`stack: experimental 9.5+` {applies_to}`serverless: experimental`
+- **{{alerting-v2-system-cap}} rule lifecycle triggers** — Fire when rules are created, updated, deleted, enabled, or disabled in the {{alerting-v2-system}}. {applies_to}`stack: experimental 9.5+` {applies_to}`serverless: experimental`
 
 :::{warning}
 The event-driven trigger system is in technical preview, including the triggers documented on this page. The schema and semantics can change in future releases.
@@ -386,6 +387,95 @@ Reference these fields with Liquid templating in workflow steps:
 ```
 
 Use these fields to write workflow conditions that scope the automation to specific rules or episodes. For example, use `event.ruleId: "my-rule-id"` to scope the workflow to alert episodes from a specific rule.
+
+## {{alerting-v2-system-cap}} rule lifecycle triggers [alerting-rule-lifecycle-triggers-event-driven]
+
+```{applies_to}
+stack: experimental 9.5+
+serverless: experimental
+```
+
+{{alerting-v2-system-cap}} rule lifecycle triggers fire when rules are created, updated, deleted, enabled, or disabled in the {{alerting-v2-system}}. Use them to automate responses to rule management actions — for example, auditing rule changes, syncing rule inventory with an external CMDB, or notifying a team channel when a new rule is added to a space.
+
+Rule lifecycle triggers are active by default and require no feature flag. They are part of the {{alerting-v2-system}} and fire independently of alert episodes.
+
+### Available triggers [alerting-rule-lifecycle-triggers-available]
+
+| Trigger ID | When it fires |
+|---|---|
+| `alerting.ruleCreated` | A rule is created. |
+| `alerting.ruleUpdated` | A rule's configuration is changed via a PATCH or PUT update. Enabling or disabling a rule through the dedicated enable/disable action does not emit this trigger — it emits `alerting.ruleEnabled` or `alerting.ruleDisabled` instead. |
+| `alerting.ruleDeleted` | A rule is deleted. |
+| `alerting.ruleEnabled` | A rule is enabled. |
+| `alerting.ruleDisabled` | A rule is disabled. |
+
+For bulk operations (bulk enable, bulk disable, bulk delete), one trigger event is emitted per affected rule. A PATCH update that makes no effective change emits nothing.
+
+### Schema [alerting-rule-lifecycle-triggers-schema]
+
+| Parameter | Location | Type | Required | Description |
+|---|---|---|---|---|
+| `type` | top level | string | Yes | One of: `alerting.ruleCreated`, `alerting.ruleUpdated`, `alerting.ruleDeleted`, `alerting.ruleEnabled`, `alerting.ruleDisabled`. |
+| `condition` | `on` | KQL string | No | Optional KQL predicate evaluated against the `event` payload. The trigger fires only when the condition matches. |
+
+```yaml
+triggers:
+  - type: alerting.ruleCreated
+  - type: alerting.ruleUpdated
+  - type: alerting.ruleDeleted
+  - type: alerting.ruleEnabled
+  - type: alerting.ruleDisabled
+```
+
+### Event payload [alerting-rule-lifecycle-triggers-event]
+
+All rule lifecycle triggers share the same minimal payload.
+
+| `event.*` field | Contains |
+|---|---|
+| `event.rule.ruleId` | Unique identifier of the rule that was created, updated, deleted, enabled, or disabled. |
+| `event.rule.spaceId` | ID of the {{kib}} space where the operation occurred. |
+
+Reference these fields with Liquid templating in workflow steps:
+
+```yaml
+- name: log_rule_event
+  type: console
+  with:
+    message: |
+      Rule {{ event.rule.ruleId }} changed in space {{ event.rule.spaceId }}.
+```
+
+Use `on.condition` to scope the trigger to a specific rule or space:
+
+```yaml
+triggers:
+  - type: alerting.ruleCreated
+    on:
+      condition: 'event.rule.spaceId: "production"'
+```
+
+### Example: Audit rule changes [alerting-rule-lifecycle-triggers-example]
+
+```yaml
+name: audit-rule-changes
+description: Log rule lifecycle events across all spaces.
+enabled: true
+
+triggers:
+  - type: alerting.ruleCreated
+  - type: alerting.ruleUpdated
+  - type: alerting.ruleDeleted
+  - type: alerting.ruleEnabled
+  - type: alerting.ruleDisabled
+
+steps:
+  - name: log_change
+    type: console
+    with:
+      message: |
+        Rule {{ event.rule.ruleId }} in space {{ event.rule.spaceId }} — trigger: {{ trigger.type }}
+```
 
 ## Prevent cascading handler loops
 

--- a/explore-analyze/workflows/triggers/event-driven-triggers.md
+++ b/explore-analyze/workflows/triggers/event-driven-triggers.md
@@ -166,7 +166,7 @@ Cases triggers fire when cases change. Use them to react to case lifecycle event
 **Shared payload.** Every cases trigger event includes:
 
 - `event.caseId` — The case ID, the alphanumeric identifier that is unique to each case.
-- `event.owner` — The solution that owns the case. It can be `securitySolution` for {{elastic-sec}} cases, `observability` for Observability cases, or `cases` for Stack cases.
+- `event.owner` — The solution that owns the case. It can be `securitySolution` for {{elastic-sec}} cases, `observability` for {{observability}} cases, or `cases` for Stack cases.
 
 Use `event.owner` in `on.condition` to filter by solution. For example, a workflow that only fires for {{elastic-sec}} cases:
 


### PR DESCRIPTION
## Summary

Updates docs for the experimental alerting system and Workflows across three areas: new rule lifecycle workflow triggers, execution history accuracy fixes, and structural/organizational improvements across the action policies doc set. Action policies pages also received Vale linter and style guide fixes throughout.

Following the tech preview principle of accuracy over comprehensiveness, additions focus on stable concepts — what these features help users understand, when to use them, and how they fit into the system.

---

## Content changes

### Experimental alerting system rule lifecycle triggers

Kibana PR #272376 (merged June 30, 2026) added five new event-driven trigger types that fire when rules are created, updated, deleted, enabled, or disabled in the experimental alerting system. These complement the existing alert episode lifecycle triggers and let teams automate rule auditing, CMDB syncing, and team notifications without needing a cron or external scheduler.

**`workflows/triggers/event-driven-triggers.md`** — Added a new section "{{alerting-v2-system-cap}} rule lifecycle triggers" documenting:

* The five available triggers (`alerting.ruleCreated`, `alerting.ruleUpdated`, `alerting.ruleDeleted`, `alerting.ruleEnabled`, `alerting.ruleDisabled`) in a reference table with "when it fires" descriptions, including the rule about bulk operations (one event per affected rule) and the distinction between `ruleUpdated` and `ruleEnabled`/`ruleDisabled`.
* Schema section with the `type` and `on.condition` parameters and a YAML example.
* Event payload section documenting `event.rule.ruleId` and `event.rule.spaceId`, with a Liquid templating reference example and a scoping example using `on.condition`.
* A full YAML example for an audit workflow that logs rule lifecycle events across all spaces.

Also updated the page intro (three → four trigger families) and added the new family to the intro list with `{applies_to}` tags.

**`workflows/triggers.md`** — Updated the event-driven triggers section to list the rule lifecycle trigger family, added rule lifecycle use cases to the event-driven use case list, and extended the trigger context table with `event.rule.ruleId` and `event.rule.spaceId`.

What was omitted: the internal rule management API shape, non-YAML configuration UI steps, and behavior for rule types that don't support the new trigger system.

---

### Execution history: factual corrections (closes #7179)

The execution history section in `manage-action-policies.md` contained several errors compared to the implementation in Kibana PRs #264825 and #266775.

**`action-policies/manage-action-policies.md`** — Full rewrite of the Execution history section:

* **Wrong data source fixed**: changed `.alert-actions` → `.kibana-event-log-*`. Execution history is written by `StoreExecutionHistoryStep` to the Kibana event log, not to `.alert-actions`.
* **Incorrect outcomes fixed**: removed `suppressed` from the outcomes table. Suppressed episodes (acknowledged, snoozed, marked inactive, or in a maintenance window) are dropped before `StoreExecutionHistoryStep` runs and produce no event log entry.
* **Wrong Discover query fields fixed**: replaced `action_type` and `policy_id` (neither exists in the event log) with `event.action` and `event.provider: "alerting_v2"`.
* **`unmatched` filter caveat added**: noted that `unmatched` is recorded in the event log but is not available as a filter option in the Execution history UI (only `dispatched` and `throttled` are selectable). Raw Discover is required to find `unmatched` records.
* **What each row shows added**: policy name, rule name, outcome, episode count, action group count, and workflows invoked.
* **24-hour retention window documented**: the Execution history page only shows records from the last 24 hours; older records require Discover.

**`action-policies/action-policy-reference.md`** — Aligned the Dispatch outcomes section with the same fixes: corrected the index reference, removed `suppressed`, fixed field names, added the `unmatched` filter caveat, and added a forward reference to `manage-action-policies.md` for UI details.

---

### Structural and organizational improvements

**`action-policies/common-action-policy-scenarios.md`** — Converted from a single page with three long sections into an index page that introduces the topic and links to three dedicated sub-pages. Each sub-page covers one scenario, includes its own `applies_to` frontmatter, and follows the how-to content type convention:

* **`route-by-severity.md`** — How to direct critical and non-critical episodes to different workflows based on severity level.
* **`severity-escalation.md`** — How policies match and re-match episodes as severity shifts, and how to control which notifications fire.
* **`re-notification.md`** — How to configure policies to send follow-up notifications when an episode stays active without a status change.

Updated `toc.yml` to nest the three sub-pages under `common-action-policy-scenarios.md` in the navigation.

**`action-policies/manage-action-policies.md`** — Section titles rewritten to be more descriptive and action-oriented:

* `## View policy details` → `## View and edit a policy`
* `## Execution history` → `## Review dispatch records and outcomes`
* `## Enable, disable, and snooze` → `## Enable, disable, and snooze a policy`
* `### {{maint-windows-cap}}` → `### Pause dispatch during a maintenance window`
* `## Update API keys` → `## Rotate a policy's API key`
* `## Bulk actions` → `## Manage multiple policies at once`

Also removed duplicate information and UI-specific references from the execution history section, leaving only what's needed to understand the data model and query records.

**`action-policies/create-configure-action-policy.md`** — Section titles rewritten to be action-oriented:

* `## Policy type` → `## Select a policy type`
* `## Tags` → `## Add tags to categorize the policy`
* `## Match conditions` → `## Filter which episodes the policy applies to`
* `## Notify per and frequency` → `## Control how episodes batch and how often the policy notifies`
* `## Destinations` → `## Select workflows to invoke`

Simplified the tags description and match conditions paragraphs for clarity and scannability. Simplified the "Match conditions fields" table from five columns (Field, Type, Description, Accepted values, Example) to three (Field, Description, Example), folding accepted values and type into the description and adding a plain-language explanation to each example.

**`notifications-actions.md`**

* Moved the workflow subscription prerequisite from inside step 1 of the numbered procedure into a dedicated "Before you begin" callout above the steps, following standard Elastic how-to pattern.
* Removed the duplicate workflow and action policy definitions (delivery layer / gating layer bullets) — these now live exclusively in `workflows-alerting.md`. Added a forward reference to that page in the opening paragraph instead.

**`workflows-alerting.md`**

* Removed the 6-step numbered dispatcher flow from the Action policies section. The same flow is already documented in `about-action-policies.md` under "How action policies are evaluated". Replaced with a one-sentence summary and a reference to the canonical location to eliminate the duplication.

**`action-policies/reduce-notification-noise.md`**

* Added maintenance windows as the fourth row in the silencing mechanisms table. Maintenance windows were referenced as a silencing mechanism in `about-action-policies.md`, `manage-action-policies.md`, and `action-policy-reference.md`, but were absent from the dedicated noise-reduction page.
* Removed a sentence claiming all silencing mechanisms are stored in `.alert-actions`. The claim was inaccurate (maintenance windows are not stored there) and the `.alert-actions` reference was already corrected elsewhere in the PR.

---

### Notifications and actions page improvements

**`notifications-actions.md`** (additional changes beyond the structural ones above):

* Renamed "## Send notifications or trigger an action" to make the heading describe what the section covers.
* Rewrote step 2 to include context about what action policies control (which episodes qualify, how they batch, how often the workflow runs).
* Promoted the tip about alert episode lifecycle triggers into the body of step 2 as a follow-on sentence, making it part of the natural decision flow. Updated the link to point directly to the alert episode lifecycle triggers section in `event-driven-triggers.md`.
* Renamed "## In this section" to "## Related pages".
* Applied the `{{rules-ui}}` substitution.

---

### Action policies pages: Vale linter and style guide fixes

**`about-action-policies.md`**

* "Suppression checks whether the alert episode should be silenced" → "Suppression determines whether to silence the alert episode" (indicative mood).
* "How should matching alert episodes batch into notification groups?" → "The dispatcher determines how matching alert episodes batch into notification groups" (indicative mood; question form removed).
* "deactivated" in the gating step → "marked inactive" (ableist terminology).

**`action-policy-reference.md`**

* `ES\|QL` → `{{esql}}` (substitution variable).
* "Three outcomes are recorded" → "The dispatcher records three outcomes" (passive → active).
* "`unmatched` is recorded…but is not available" → "`unmatched` appears…but isn't available" (passive + contraction).
* "not covered by the standard fields above" → "not covered by the standard fields in this table" (directional language removed).

**`common-action-policy-scenarios.md`**

* "you'll often want to route" → "you often need to route" (future tense).
* "won't re-trigger" → "does not re-trigger" (future tense).

**`create-configure-action-policy.md`**

* "For a global policy that should target a specific rule" → "For a global policy targeting a specific rule" (indicative mood).
* "are not eligible" → "aren't eligible" (contraction).
* "The policy type is set at creation and cannot be changed" → "You set the policy type at creation and can't change it later" (passive → active + contraction).
* `## Choose a policy type` / `## Choose workflows to invoke` → `## Select a policy type` / `## Select workflows to invoke` (device-neutral language).

**`manage-action-policies.md`**

* `Maintenance windows` heading and body reference → `{{maint-windows-cap}}` (substitution variable, ×2).
* "every series the policy would process" → "every series the policy processes"; "regardless of which policy would have handled it" → "regardless of which policy handles it" (conditional/subjunctive tense).
* "marked for invalidation and removed" → "queued for removal" (ableist terminology: `invalidation`).
* "deactivated" in the execution outcome table → "marked inactive" (ableist terminology).
* "using acknowledge, snooze, or deactivate" in related pages → "by acknowledging, snoozing, or marking them inactive" (ableist terminology).
* "Records are retained for 24 hours" → "{{kib}} retains records for 24 hours" (passive → active).
* "Episodes that were acknowledged…are suppressed before the dispatcher runs" → "The dispatcher drops episodes that are acknowledged…" (passive → active).
* "it is not evaluated" / "does not dispatch" / "Policies that are not enabled or are snoozed are skipped" → active voice + contractions throughout.
* "the dispatch mechanism is paused and every series…is silenced" → "the dispatcher pauses and silences every alert series…" (passive → active).
* "No policy configuration is required" → "You don't need to configure the policy" (passive → active).

**`notifications-actions.md`**

* "For actions that should fire exactly once" → "For actions that fire exactly once" (subjunctive mood removed).
* "how often the workflow is invoked" → "how often it invokes the workflow" (passive → active).

**`reduce-notification-noise.md`**

* "every series the policy would process" → "every series the policy processes"; "regardless of which policy would have handled it" → "regardless of which policy handles it" (conditional/subjunctive tense).

**`severity-escalation.md`**

* "which frequency option is configured" → "which frequency option you've selected" (passive → active).
* "the severity level you want to be notified about" → "the severity level you want notifications for" (passive → active).
* `does not` → `doesn't` throughout (contractions).
* "has not changed" → "hasn't changed" (contraction).
* "Policy B is scoped to…" → "Policy B targets only…" (passive → active).

**`re-notification.md`**

* "does not re-trigger" → "doesn't re-trigger" (contraction).

---

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
* Yes — Cursor + Claude
* No