### PR TITLE
[Alerting V2][Serverless & 9.5][M2] Prep overview page for incoming content 

### DIFF
--- a/explore-analyze/alerting/alerts.md
+++ b/explore-analyze/alerting/alerts.md
@@ -16,9 +16,15 @@ description: "Overview of Kibana alerting: rules, alerts, actions, connectors, a
 # {{kib}} alerting [alerts]
 
 {{kib}} alerting is the built-in alerting system in {{kib}}. It lets you define rules that check your data on a schedule, create alerts when conditions are met, and trigger actions through connectors (email, Slack, webhooks, and more). It is available on all deployments.
-<!-- TODO: Uncomment when PR #6521 (experimental overview) is merged:
+
+:::{note}
+:applies_to: {"stack": "experimental 9.5+", "serverless": "experimental"}
 For the {{alerting-v2}} built on {{esql}}, refer to [{{alerting-v2-cap}}](kibana-alerting-experimental.md).
--->
+:::
+
+::::{note}
+In this doc, *alert* refers to a tracked occurrence of a rule condition. If you're using the {{alerting-v2-system}}, the equivalent concept is called an *alert episode*. The two terms describe similar ideas in different systems and are not interchangeable.
+::::
 
 ## {{rules-ui}} [rules]
 

--- a/explore-analyze/alerting/choose-an-alerting-system.md
+++ b/explore-analyze/alerting/choose-an-alerting-system.md
@@ -36,3 +36,16 @@ Elastic has three alerting systems. You only need one. Pick the one that fits ho
 | **Noise reduction** | Snooze per rule, maintenance windows | Per-episode acknowledge or deactivate, per-series snooze, maintenance windows, match condition routing in action policies | Action conditions and throttling |
 | **Available on {{serverless-full}}** | Yes | Yes, {applies_to}`serverless: experimental` | No |
 | **Available on {{stack}}** | Yes | Yes, {applies_to}`stack: experimental 9.5+` | Yes |
+
+<!--
+TODO: Once PRs #6523, #6525, and #6527 are merged, add cross-links to the experimental system cells in the comparison table above. The cells currently describe the system but don't link anywhere. Suggested targets:
+
+| Row                        | Link target                                                                 |
+|----------------------------|-----------------------------------------------------------------------------|
+| Alert data (experimental)  | kibana-alerting-experimental/alerts/query-alerts-and-signals-in-discover.md (PR #6527) |
+| Notifications (experimental) | kibana-alerting-experimental/notifications-actions.md or action-policies/about-action-policies.md (PR #6525) |
+| Noise reduction (experimental) | kibana-alerting-experimental/action-policies/reduce-notification-noise.md (PR #6525) |
+| Rule definition (experimental) | kibana-alerting-experimental/rules/configure-rule-query.md (PR #6523) |
+
+Also add links to the experimental system rows in the "Select by use case" table once the relevant pages are available.
+-->

--- a/explore-analyze/alerting/kibana-alerting-experimental.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental.md
@@ -53,10 +53,10 @@ Refer to [Notifications and actions](kibana-alerting-experimental/notifications-
 
 ### Workflows
 
-A workflow is what actually sends the message or runs the automation, for example, posting to Slack or sending an email. Action policies hand off to workflows for delivery. Without a workflow attached, no notification is sent.
+A workflow is what actually sends the message or runs the automation, for example, posting to Slack, sending an email, calling a webhook. The {{alerting-v2-system}} invokes workflows either through action policies (on a schedule, with conditions) or in direct response to a state change on an alert episode.
 
 <!-- TODO: When PR #6525 (workflows/notifications) merges, uncomment the link below and trim this sub-section to 1–2 anchor sentences + the link.
-Refer to [Workflows for the {{alerting-v2-system}}](kibana-alerting-experimental/workflows-alerting.md) to learn more.
+Refer to [Connect workflows](kibana-alerting-experimental/workflows-alerting.md) to learn more.
 -->
 
 ## How the pieces fit together [how-pieces-fit-together]

--- a/explore-analyze/alerting/kibana-alerting-experimental.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental.md
@@ -10,9 +10,11 @@ description: The experimental Kibana alerting system uses ES|QL rules to detect 
 
 # {{alerting-v2-system-cap}} overview [alerting-overview]
 
-The {{alerting-v2-system}} in {{kib}} is marked **Experimental** in the UI and is subject to change before general availability. It includes rules, alert episodes, action policies, workflows, and connectors. For the existing {{kib}} alerting system, refer to [{{kib}} alerting](alerts.md).
+The {{alerting-v2-system}} in {{kib}} watches your {{es}} data continuously, so your team doesn't have to. You define the conditions that matter, such as when to open an issue, who should know, and how often to notify them. The system handles the rest.
 
-The {{alerting-v2-system}} watches your {{es}} data continuously, so your team doesn't have to. You define the conditions that matter, such as when to open an issue, who should know, and how often to notify them. The system handles the rest.
+::::{note}
+In the generally available {{kib}} alerting system, the term *alert* refers to a tracked occurrence of a rule condition. In the {{alerting-v2-system}}, the equivalent concept is called an *alert episode*. The two terms describe similar ideas in different systems and are not interchangeable.
+::::
 
 ## The core idea [kibana-alerting-v2-overview]
 
@@ -29,30 +31,35 @@ A rule defines what to watch for in your data and how often to check. Every rule
 - **Alert**: Opens an alert episode when the rule finds a match, keeps it open until the condition clears, and can notify your team or trigger automated actions when the state changes. Use this when you want the system to track an issue and tell someone about it.
 - **Signal**: Records each match as a data point with no ongoing tracking and no notifications. Use this when you want to capture activity for later querying and investigation.
 
-<!-- TODO: Uncomment when PR #6523 (rules) is merged:
+<!-- TODO: When PR #6523 (rules) merges, uncomment the link below and trim this sub-section to 1–2 anchor sentences + the link.
 Refer to [Rules](kibana-alerting-experimental/rules.md) to learn more.
 -->
 
 ### Alert episodes
+
 In Alert mode, the rule opens one alert episode per problem and keeps it open until the condition clears. The alert episode moves through states (pending, active, recovering, inactive) giving you one lifecycle to triage rather than a separate item per rule check. You manage alert episodes on the **Alerts** page.
-<!-- TODO: Uncomment when PR #6524 (alerts) is merged:
+
+<!-- TODO: When PR #6527 (alerts) merges, uncomment the link below and trim this sub-section to 1–2 anchor sentences + the link.
 Refer to [Alert episodes](kibana-alerting-experimental/alerts.md) to learn more.
 -->
 
 ### Action policies
+
 An action policy is the gating layer between an alert episode and a workflow. It decides whether and when to invoke a workflow by evaluating suppression, match conditions, and frequency. You can set conditions to filter which alert episodes it applies to, for example, only critical severity alert episodes from a specific service. Global action policies apply to alert episodes from any rule in the space. Per-rule action policies scope to a single rule for more targeted routing.
-<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
+
+<!-- TODO: When PR #6525 (workflows/notifications) merges, uncomment the link below and trim this sub-section to 1–2 anchor sentences + the link.
 Refer to [Notifications and actions](kibana-alerting-experimental/notifications-actions.md) to learn more.
 -->
 
 ### Workflows
+
 A workflow is what actually sends the message or runs the automation, for example, posting to Slack or sending an email. Action policies hand off to workflows for delivery. Without a workflow attached, no notification is sent.
-<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
+
+<!-- TODO: When PR #6525 (workflows/notifications) merges, uncomment the link below and trim this sub-section to 1–2 anchor sentences + the link.
 Refer to [Workflows for the {{alerting-v2-system}}](kibana-alerting-experimental/workflows-alerting.md) to learn more.
 -->
 
 ## How the pieces fit together [how-pieces-fit-together]
-
 
 What happens after a rule finds something depends entirely on the rule's mode.
 
@@ -68,26 +75,19 @@ Rule runs → the rule's conditions are met → writes a rule event
       → [dispatcher] → action policy → workflow → notification
 ```
 
-1. The rule evaluates {{esql}} on a schedule and writes a rule event to `.rule-events`.
-2. The rule event opens or updates an alert episode, which is tracked until the condition resolves.
-3. The dispatcher runs on a short interval, independently of the rule schedule, and picks up active alert episodes.
-4. For each active alert episode, the dispatcher evaluates all enabled action policies. Each policy runs the episode through a sequence of gates: suppression, match conditions, and frequency.
-5. For policies where the episode clears all gates, the dispatcher invokes the configured workflows.
-6. Workflows deliver the notification or run the automation (email, chat, webhook, and so on).
+The rule evaluates {{esql}} on a schedule and writes a rule event to `.rule-events`. When a match occurs, the dispatcher picks up the active alert episode, evaluates all enabled action policies against it, and invokes any workflows that pass suppression, match conditions, and frequency gates. When the condition clears, the episode recovers and recovery notifications fire through the same pipeline.
 
-#### Example: Rule runs in Alert mode
-
-An SRE team creates a rule in Alert mode that checks checkout service latency every five minutes. When p95 exceeds 2 seconds for more than one consecutive check, the rule opens an alert episode. An action policy with a `rule.tags: "checkout"` matcher picks it up, skips low-severity alert episodes, and sends a Slack message through an on-call workflow.
-
-The on-call engineer gets one message, investigates, fixes a slow query, and latency drops. The alert episode recovers automatically. No dashboard watching required.
+::::{dropdown} Example: Rule runs in Alert mode
+An SRE team creates a rule in Alert mode that checks checkout service latency every five minutes. When p95 exceeds 2 seconds for more than one consecutive check, the rule opens an alert episode. An action policy with a `rule.tags: "checkout"` matcher skips low-severity episodes and sends a Slack message through an on-call workflow. The engineer investigates, fixes a slow query, and the alert episode recovers automatically.
 
 :::{image} ../images/rule-alert-mode-diagram.png
 :alt: Diagram of Alert mode flow. A rule runs ES|QL on a schedule. When it finds a match, it writes a rule event tied to an ongoing alert episode. The alert episode moves through pending, active, recovering, and inactive states. An action policy matches eligible alert episodes and routes them to a workflow, which delivers a notification.
 :::
+::::
 
 ### Signal mode
 
-Use Signal mode when you want to record matches for querying and analysis without alerting anyone. The rule writes a signal and stops. An alert episode is not opened, and notifications are not sent.
+Use Signal mode when you want to record matches for querying and analysis without alerting anyone. The rule writes a signal and stops — no alert episode is opened and no notifications are sent.
 
 ```
 Rule runs → the rule's conditions are met → writes a signal
@@ -95,84 +95,22 @@ Rule runs → the rule's conditions are met → writes a signal
   → no alert episode, no action policy, no notification
 ```
 
-1. The rule evaluates {{esql}} on a schedule and writes a rule event (signal) to `.rule-events`.
-2. The signal is available for querying in Discover, dashboards, and ES|QL.
-3. No alert episode is opened. No action policy is evaluated. No notification is sent.
+The rule evaluates {{esql}} on a schedule and writes a rule event (signal) to `.rule-events`. The signal is immediately available for querying in Discover, dashboards, and {{esql}}.
 
-#### Example: Rule runs in Signal mode
-
-A security team wants to track when a rarely-used admin API endpoint is called. Individual calls are not inherently suspicious, so they do not want a notification every time the rule fires. The pattern only becomes meaningful in context. They create a rule in Signal mode that checks for requests to the endpoint every hour.
-
-The rule writes a signal each time it finds a match. No alert episodes are opened and no notifications go out.
+::::{dropdown} Example: Rule runs in Signal mode
+A security team tracks when a rarely-used admin API endpoint is called. Individual calls aren't inherently suspicious, so they create a Signal mode rule that records each match without triggering notifications. When an on-call alert fires later for unusual privilege escalation, the team queries `.rule-events` in Discover and finds the admin endpoint was called three times in the hour before — context that would have been invisible without the signals already in the index.
 
 :::{image} ../images/rule-detect-mode-diagram.png
 :alt: Diagram of Signal mode flow. A rule runs ES|QL on a schedule. When it finds a match, it writes a signal to .rule-events. The signal is available for querying in Discover, dashboards, and ES|QL.
 :::
-
-Later, an on-call alert fires for unusual privilege escalation on the same host. During the investigation, the team queries `.rule-events` in Discover and finds that the admin API endpoint was called three times in the hour before the escalation. The Signal mode rule events did not surface the incident. The Alert mode rule did. But without the signals already in the index, the admin API activity would have been invisible during the post-incident review.
-
-
-## {{alerting-v2-system-cap}} glossary [key-concepts-glossary]
-
-These terms appear throughout the {{alerting-v2-system}} docs. If a term is unclear while reading, check its definition here before going further.
-
-**Action policy**
-:   The gating layer between an alert episode and a workflow. You configure suppression rules, match conditions to filter which alert episodes it applies to, frequency settings to control batching and cooldown, and which workflow should send the message. Global action policies apply to alert episodes from any rule in the space. Per-rule action policies scope to a single rule.
-<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
-    To learn more, refer to [Notifications and actions](kibana-alerting-experimental/notifications-actions.md).
--->
-
-**Alert episode**
-:   The complete record of one problem tracked in Alert mode, from when it was first detected to when it recovered. An alert episode moves through states (pending, active, recovering, inactive) as the situation changes. This is what you see and act on on the **Alerts** page.
-
-**Breach**
-:   A single moment when a rule's query finds a match. One breach doesn't necessarily trigger a notification. You can configure a rule to require several consecutive breaches before it confirms the problem is real.
-
-**Dispatcher**
-:   The background process in {{kib}} that runs the notification pipeline. On a short interval (around 5 seconds), it evaluates each enabled action policy against active alert episodes and sends notifications. The dispatcher runs on its own cadence, separate from the rule schedule.
-<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
-    To learn more, refer to [Reduce notification noise](kibana-alerting-experimental/action-policies/reduce-notification-noise.md).
--->
-
-**{{esql}}**
-:   The query language every rule uses to search your data. To learn more, refer to the [{{esql}} reference](elasticsearch://reference/query-languages/esql.md).
-
-**Notification**
-:   The message or action delivered when an alert episode matches an action policy and a workflow sends it. Examples include a Slack message, an email, or a webhook call.
-<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
-    To learn more, refer to [How action policies are evaluated](kibana-alerting-experimental/notifications-actions.md#how-action-policies-evaluated).
--->
-
-**Rule**
-:   The definition of what to watch for in your data, how often to check, and what counts as a problem. Rules run on a schedule. In Signal mode they produce signals. In Alert mode they track ongoing alert episodes.
-<!-- TODO: Uncomment when PR #6523 (rules) is merged:
-    To learn more, refer to [Rules](kibana-alerting-experimental/rules.md).
--->
-
-**Rule event**
-:   A record written to `.rule-events` every time a rule runs and its query finds a match. Every rule produces rule events. In Signal mode the record is a signal. In Alert mode it belongs to an alert episode.
-
-**Severity**
-:   A label you can attach to alert episodes to indicate how serious they are. Severity is available as a filter in action policies, so you can route critical alert episodes differently from low-priority ones.
-<!-- TODO: Uncomment when PR #6523 (rules) is merged:
-    To learn more, refer to [Author rules](kibana-alerting-experimental/rules/author-rules.md#severity-levels).
--->
-
-**Signal**
-:   A rule event recorded when a rule runs in Signal mode. Signals are stored and queryable, but they don't open alert episodes or trigger notifications.
-
-**Threshold**
-:   The condition a rule uses to decide when something is worth alerting on. This includes both the query that detects the problem and settings that control how many times the condition must be met before an alert episode opens or closes.
-<!-- TODO: Uncomment when PR #6523 (rules) is merged:
-    To learn more, refer to [Conditions and thresholds](kibana-alerting-experimental/rules/author-rules.md#conditions-and-thresholds).
--->
-
-**Workflow**
-:   The automation that sends a message or runs an action when an action policy decides a notification should go out. Examples include posting to Slack, sending an email, or calling a webhook.
-<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
-    To learn more, refer to [Workflows for the {{alerting-v2-system}}](kibana-alerting-experimental/workflows-alerting.md).
--->
+::::
 
 ## Next steps
+
+<!-- TODO: When PRs #6523, #6525, and #6527 merge, replace the paragraph below with these three forward-facing tracks and remove the choose-an-alerting-system link (it points here, not forward):
+- **Rules**: Refer to [Rules](kibana-alerting-experimental/rules.md) to learn how to create and configure detection rules.
+- **Alerts**: Refer to [Alerts](kibana-alerting-experimental/alerts.md) to learn how alert episodes work and how to triage them.
+- **Notifications**: Refer to [Notifications and actions](kibana-alerting-experimental/notifications-actions.md) to learn how action policies and workflows route notifications.
+-->
 
 To understand how the {{alerting-v2-system}} fits into {{kib}}'s alerting options, refer to [Alerting](../alerting.md) or [Choose an alerting system](choose-an-alerting-system.md).

--- a/explore-analyze/alerting/kibana-alerting-experimental.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental.md
@@ -78,7 +78,13 @@ Rule runs → the rule's conditions are met → writes a rule event
 The rule evaluates {{esql}} on a schedule and writes a rule event to `.rule-events`. When a match occurs, the dispatcher picks up the active alert episode, evaluates all enabled action policies against it, and invokes any workflows that pass suppression, match conditions, and frequency gates. When the condition clears, the episode recovers and recovery notifications fire through the same pipeline.
 
 ::::{dropdown} Example: Rule runs in Alert mode
-An SRE team creates a rule in Alert mode that checks checkout service latency every five minutes. When p95 exceeds 2 seconds for more than one consecutive check, the rule opens an alert episode. An action policy with a `rule.tags: "checkout"` matcher skips low-severity episodes and sends a Slack message through an on-call workflow. The engineer investigates, fixes a slow query, and the alert episode recovers automatically.
+An SRE team wants to know when checkout service latency degrades, and notify the on-call team when it does. The team creates an Alert mode rule:
+
+1. The rule runs an {{esql}} query every five minutes, checking p95 checkout service latency.
+2. When p95 exceeds 2 seconds for more than one consecutive check, the rule opens an alert episode.
+3. An action policy with a `rule.tags: "checkout"` matcher skips low-severity episodes and sends a Slack message through an on-call workflow.
+
+The engineer investigates, fixes a slow query, and the alert episode recovers automatically.
 
 :::{image} ../images/rule-alert-mode-diagram.png
 :alt: Diagram of Alert mode flow. A rule runs ES|QL on a schedule. When it finds a match, it writes a rule event tied to an ongoing alert episode. The alert episode moves through pending, active, recovering, and inactive states. An action policy matches eligible alert episodes and routes them to a workflow, which delivers a notification.
@@ -98,7 +104,13 @@ Rule runs → the rule's conditions are met → writes a signal
 The rule evaluates {{esql}} on a schedule and writes a rule event (signal) to `.rule-events`. The signal is immediately available for querying in Discover, dashboards, and {{esql}}.
 
 ::::{dropdown} Example: Rule runs in Signal mode
-A security team tracks when a rarely-used admin API endpoint is called. Individual calls aren't inherently suspicious, so they create a Signal mode rule that records each match without triggering notifications. When an on-call alert fires later for unusual privilege escalation, the team queries `.rule-events` in Discover and finds the admin endpoint was called three times in the hour before — context that would have been invisible without the signals already in the index.
+A security team wants to track calls to a rarely-used admin API endpoint, but individual calls aren't suspicious enough to page anyone. To start collecting data without generating noise, the team creates a Signal mode rule:
+
+1. The rule runs an {{esql}} query on a schedule, checking for calls to the admin API endpoint.
+2. Each time the condition is met, the rule writes a signal to `.rule-events`.
+3. The signals accumulate silently and are immediately queryable in Discover.
+
+After running the Signal mode rule for a few weeks, the team has enough data to understand normal call patterns and identify what volume looks anomalous. With that baseline established, the team is ready to create an Alert mode rule that opens an alert episode and notifies the on-call team when the call rate crosses a meaningful threshold.
 
 :::{image} ../images/rule-detect-mode-diagram.png
 :alt: Diagram of Signal mode flow. A rule runs ES|QL on a schedule. When it finds a match, it writes a signal to .rule-events. The signal is available for querying in Discover, dashboards, and ES|QL.

--- a/explore-analyze/alerting/kibana-alerting-experimental/glossary.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/glossary.md
@@ -1,0 +1,70 @@
+---
+applies_to:
+  stack: experimental 9.5+
+  serverless: experimental
+products:
+  - id: kibana
+  - id: cloud-serverless
+description: Definitions of key terms used throughout the experimental Kibana alerting system documentation.
+---
+
+# {{alerting-v2-system-cap}} glossary [alerting-v2-glossary]
+
+These terms appear throughout the {{alerting-v2-system}} docs. If a term is unclear while reading, check its definition here before going further.
+
+**Action policy**
+:   The gating layer between an alert episode and a workflow, configuring suppression, match conditions, and frequency to control which episodes trigger notifications and how often.
+<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
+    To learn more, refer to [Notifications and actions](notifications-actions.md).
+-->
+
+**Alert episode**
+:   The complete record of one problem tracked in Alert mode, from first detection to recovery, moving through states (pending, active, recovering, inactive).
+
+**Breach**
+:   A single moment when a rule's query finds a match; you can require several consecutive breaches before an alert episode opens.
+
+**Dispatcher**
+:   The background process that evaluates action policies against active alert episodes on a short interval (around 5 seconds), independent of the rule schedule.
+<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
+    To learn more, refer to [Reduce notification noise](action-policies/reduce-notification-noise.md).
+-->
+
+**{{esql}}**
+:   The query language every rule uses to search your data. To learn more, refer to the [{{esql}} reference](elasticsearch://reference/query-languages/esql.md).
+
+**Notification**
+:   The message or action delivered when an alert episode matches an action policy and a workflow sends it, such as a Slack message, an email, or a webhook call.
+<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
+    To learn more, refer to [How action policies are evaluated](notifications-actions.md#how-action-policies-evaluated).
+-->
+
+**Rule**
+:   The definition of what to watch for in your data, how often to check, and what counts as a match; runs on a schedule and produces signals (Signal mode) or tracks alert episodes (Alert mode).
+<!-- TODO: Uncomment when PR #6523 (rules) is merged:
+    To learn more, refer to [Rules](rules.md).
+-->
+
+**Rule event**
+:   A record written to `.rule-events` every time a rule runs and its query finds a match; in Signal mode it is a signal, in Alert mode it belongs to an alert episode.
+
+**Severity**
+:   A label attached to alert episodes to indicate urgency; available as a filter in action policies so critical episodes can be routed differently from low-priority ones.
+<!-- TODO: Uncomment when PR #6523 (rules) is merged:
+    To learn more, refer to [Configure rule severity](rules/configure-rule-severity.md).
+-->
+
+**Signal**
+:   A rule event recorded in Signal mode; stored and queryable in Discover but doesn't open an alert episode or trigger notifications.
+
+**Threshold**
+:   The condition a rule uses to decide when something is worth alerting on, including how many times the condition must be met before an alert episode opens or closes.
+<!-- TODO: Uncomment when PR #6523 (rules) is merged:
+    To learn more, refer to [Activation and recovery thresholds](rules/configure-rule-thresholds.md).
+-->
+
+**Workflow**
+:   The automation that sends a message or runs an action when an action policy decides a notification should go out, such as posting to Slack, sending an email, or calling a webhook.
+<!-- TODO: Uncomment when PR #6525 (workflows/notifications) is merged:
+    To learn more, refer to [Connect workflows](workflows-alerting.md).
+-->

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -384,6 +384,8 @@ toc:
     children:
       - file: alerting/choose-an-alerting-system.md
       - file: alerting/kibana-alerting-experimental.md
+        children:
+          - file: alerting/kibana-alerting-experimental/glossary.md
       - file: alerting/alerts.md
         children:
           - file: alerting/alerts/alerting-getting-started.md


### PR DESCRIPTION
## Summary

Preps the experimental alerting system overview page and related pages for incoming content from PRs #6523 (rules), #6525 (notifications and action policies), and #6527 (alerts). Changes follow the principle of reducing duplication and orienting the overview page toward routing readers forward rather than documenting the full system end-to-end.

## Changes

### `kibana-alerting-experimental.md`

**Glossary extracted to a dedicated page.** The glossary section (60+ lines) has been moved to `kibana-alerting-experimental/glossary.md` and replaced with a two-line cross-reference. Keeping it on the overview caused the page to function as both a conceptual introduction and a reference, which made it harder to scan. The dedicated page allows the overview to stay focused.

**"How the pieces fit together" section trimmed.** The six-step numbered list in Alert mode and the three-step numbered list in Signal mode have been replaced with 2–3 prose sentences each. The same content is documented in `about-action-policies.md` (PR #6525); keeping a full numbered flow on the overview created duplicate maintenance surface. The diagrams and worked examples are retained.

**Examples made collapsible.** The Alert mode and Signal mode worked examples are now wrapped in `::::{dropdown}` directives. This keeps the examples available for readers who want them without making them a required part of the overview flow.

**Terminology note added.** A callout clarifies that *alert* (classic Kibana alerting) and *alert episode* (experimental system) describe similar ideas in different systems and are not interchangeable. This addresses terminology friction for readers who use both systems.

**"Four building blocks" sub-sections annotated for post-merge trimming.** Each sub-section has a TODO comment identifying what to cut and which child page to link to once the corresponding PR merges. The content is unchanged for now since the child pages don't yet exist on main.

**"Next steps" section prepped for post-merge replacement.** A TODO comment in Next Steps contains the three forward-facing tracks (Rules, Alerts, Notifications) ready to swap in once PRs #6523, #6525, and #6527 merge. Currently the section still points to the parent alerting page and the choose-an-alerting-system page.

### `kibana-alerting-experimental/glossary.md` (new)

New page containing all glossary terms with 1-sentence definitions. TODO comments are in place for each term's "To learn more" cross-link, pointing to the correct child pages in the incoming PRs. Link paths are relative to the glossary's location in the subdirectory.

### `alerts.md`

**Terminology note added.** A callout mirrors the one on the overview page, telling readers that what this doc calls *alerts* are called *alert episodes* in the experimental system. Placed after the existing experimental system cross-reference callout.

### `choose-an-alerting-system.md`

**TODO comment added after the comparison table.** Documents which comparison table cells should gain cross-links to child pages once PRs #6523, #6525, and #6527 merge, with the specific target file for each row.

### `toc.yml`

Added `glossary.md` as a child of `kibana-alerting-experimental.md`.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes — Cursor + Claude
- [ ] No