### PR TITLE
Add custom CTAs for Kubernetes and AWS monitoring pages

### DIFF
--- a/docset.yml
+++ b/docset.yml
@@ -7,7 +7,7 @@ features:
 cta:
   monitor-kubernetes:
     button:
-      label: Monitor Kubernetes free
+      label: Get started free
       url: https://cloud.elastic.co/serverless-registration?onboarding_token=monitor-kubernetes
     benefits:
       - "14-day free trial"
@@ -15,7 +15,7 @@ cta:
       - "No setup required"
   monitor-aws:
     button:
-      label: Monitor AWS free
+      label: Get started free
       url: https://cloud.elastic.co/serverless-registration?onboarding_token=monitor-aws
     benefits:
       - "14-day free trial"

--- a/docset.yml
+++ b/docset.yml
@@ -4,6 +4,24 @@ max_toc_depth: 2
 features:
   primary-nav: true
 
+cta:
+  monitor-kubernetes:
+    button:
+      label: Monitor Kubernetes free
+      url: https://cloud.elastic.co/serverless-registration?onboarding_token=monitor-kubernetes
+    benefits:
+      - "14-day free trial"
+      - "All features included"
+      - "No setup required"
+  monitor-aws:
+    button:
+      label: Monitor AWS free
+      url: https://cloud.elastic.co/serverless-registration?onboarding_token=monitor-aws
+    benefits:
+      - "14-day free trial"
+      - "All features included"
+      - "No setup required"
+
 exclude:
   - 'README.md'
   - 'changelog/**'

--- a/solutions/observability/cloud/amazon-web-services-aws-monitoring.md
+++ b/solutions/observability/cloud/amazon-web-services-aws-monitoring.md
@@ -7,6 +7,8 @@ applies_to:
   serverless: ga
 products:
   - id: observability
+cta:
+  id: monitor-aws
 ---
 
 

--- a/solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-agent.md
+++ b/solutions/observability/cloud/monitor-amazon-web-services-aws-with-elastic-agent.md
@@ -7,6 +7,8 @@ applies_to:
   serverless: ga
 products:
   - id: observability
+cta:
+  id: monitor-aws
 ---
 
 

--- a/solutions/observability/get-started/quickstart-monitor-kubernetes-cluster-with-elastic-agent.md
+++ b/solutions/observability/get-started/quickstart-monitor-kubernetes-cluster-with-elastic-agent.md
@@ -9,6 +9,8 @@ applies_to:
 products:
   - id: cloud-serverless
   - id: observability
+cta:
+  id: monitor-kubernetes
 ---
 
 # Quickstart: Monitor your Kubernetes cluster with {{agent}} [monitor-k8s-logs-metrics-with-elastic-agent]

--- a/solutions/observability/infra-and-hosts/tutorial-observe-kubernetes-deployments.md
+++ b/solutions/observability/infra-and-hosts/tutorial-observe-kubernetes-deployments.md
@@ -5,6 +5,8 @@ applies_to:
   stack: ga
 products:
   - id: observability
+cta:
+  id: monitor-kubernetes
 ---
 
 # Tutorial: Observe your Kubernetes deployments [monitor-kubernetes]


### PR DESCRIPTION
## What
Adds two custom right-gutter CTA templates and applies them to the Kubernetes and AWS monitoring pages so the CTA deep links into the Serverless onboarding flow instead of the default trial registration.

Implements elastic/docs-eng-team#635. Follows the same mechanism as elastic/docs-content#7183, and uses the deep-link targets from the earlier text-based implementation in elastic/docs-content#7135.