### PR TITLE
Move up reinstall requirement on ECE uninstall doc

### DIFF
--- a/deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
+++ b/deploy-manage/uninstall/uninstall-elastic-cloud-enterprise.md
@@ -17,6 +17,8 @@ You might need to remove {{ece}} for one of the following reasons:
 * The installation process does not complete successfully and you can't troubleshoot the issue.
 * You are de-provisioning a host and want to remove the installed {{ece}} software.
 
+If you plan to reinstall {{ece}} on the host, make sure you [delete the host](../maintenance/ece/delete-ece-hosts.md) from the Cloud UI first. Reinstallation can fail if the host is still associated with your old {{ece}} installation.
+
 ::::{important}
 If the {{ece}} host you are uninstalling has the allocator role and is running instances from orchestrated deployments, all containers will be deleted, causing the instances to appear unhealthy on the Deployments page. To avoid disruptions, it is recommended to [vacate the host](/deploy-manage/maintenance/ece/move-nodes-instances-from-allocators.md) before uninstalling {{ece}}.
 ::::
@@ -34,8 +36,6 @@ You can remove {{ece}} by removing all containers on the host:
   ```sh
   sudo podman rm -f frc-runners-runner frc-allocators-allocator $(sudo podman ps -a -q); sudo rm -rf /mnt/data/elastic && sudo podman ps -a
   ```
-
-If you plan to reinstall {{ece}} on the host, make sure you [delete the host](../maintenance/ece/delete-ece-hosts.md) from the Cloud UI first. Reinstallation can fail if the host is still associated with your old {{ece}} installation.
 
 ::::{warning}
 During installation, the system generates secrets that are placed into the `/mnt/data/elastic/bootstrap-state/bootstrap-secrets.json` secrets file, unless you passed in a different path with the `--host-storage-path` parameter. Keep the information in the `bootstrap-secrets.json` file secure by removing it from its default location and placing it into a secure storage location.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
If a user is uninstalling ECE to reinstall it later, they must delete the host from Cloud UI first. This PR moves this bit of info higher up on the page before the uninstall command so that eventual reinstalls don't fail.

Closes: https://github.com/elastic/docs-content/issues/7145

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

