### PR TITLE
ECH no backups of found-snapshots

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
+++ b/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
@@ -37,6 +37,7 @@ When working with snapshot repositories in {{ech}}, keep the following in mind:
 - Clusters should only register a particular snapshot repository bucket once. If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. On other clusters, register the repository as read-only.
 - This prevents multiple clusters from writing to the repository at the same time and corrupting the repository’s contents. It also prevents {{es}} from caching the repository’s contents, which means that changes made by other clusters will become visible straight away.
 - When upgrading {{es}} to a newer version, you can continue to use the same repository you were using before the upgrade. If the repository is accessed by multiple clusters, they should all have the same version. Once a repository has been modified by a particular version of {{es}}, it may not work correctly when accessed by older versions. However, you will be able to recover from a failed upgrade by restoring a snapshot taken before the upgrade into a cluster running the pre-upgrade version, even if you have taken more snapshots during or after the upgrade.
+- Elastic does not enable cloud host level backups of the `found-snapshots` repositories. All changes made are permanent and cannot be reset to earlier time periods. You should enable a [custom repository](#ess-repo-types) for increased resiliency as needed.
 
 ## {{ech}} snapshot repository types [ess-repo-types]
 

--- a/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
+++ b/deploy-manage/tools/snapshot-and-restore/elastic-cloud-hosted.md
@@ -37,7 +37,7 @@ When working with snapshot repositories in {{ech}}, keep the following in mind:
 - Clusters should only register a particular snapshot repository bucket once. If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. On other clusters, register the repository as read-only.
 - This prevents multiple clusters from writing to the repository at the same time and corrupting the repository’s contents. It also prevents {{es}} from caching the repository’s contents, which means that changes made by other clusters will become visible straight away.
 - When upgrading {{es}} to a newer version, you can continue to use the same repository you were using before the upgrade. If the repository is accessed by multiple clusters, they should all have the same version. Once a repository has been modified by a particular version of {{es}}, it may not work correctly when accessed by older versions. However, you will be able to recover from a failed upgrade by restoring a snapshot taken before the upgrade into a cluster running the pre-upgrade version, even if you have taken more snapshots during or after the upgrade.
-- Elastic does not enable cloud host level backups of the `found-snapshots` repositories. All changes made are permanent and cannot be reset to earlier time periods. You should enable a [custom repository](#ess-repo-types) for increased resiliency as needed.
+- Elastic does not enable host-level backups of the cloud repository's file directory. Snapshot repository modifications are permanent and cannot be recovered. To expand redundancy, [configure a custom repository](#ess-repo-types).
 
 ## {{ech}} snapshot repository types [ess-repo-types]
 


### PR DESCRIPTION

## Summary
Speaking towards an infrequent high severity question, this delineates that for our built-in ECH `found-snapshots`, Elastic does not by default enable that some cloud hosts allow you to do backups of the data directory. And we don't do that (as would increase billing). So if users delete their (searchable) snapshots, that is a permanent deletion in our eyes and also was self-inflicted. Users can compensate for this by having backup redundancies. 

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [X] No  
