### PR TITLE
Fix typo in logstash container name

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/configuration-logstash.md
+++ b/deploy-manage/deploy/cloud-on-k8s/configuration-logstash.md
@@ -576,7 +576,7 @@ spec:
   podTemplate:
     spec:
       containers:
-      - name: logtash
+      - name: logstash
         env:
         - name: LS_JAVA_OPTS
           value: "-Xmx2g -Xms2g"


### PR DESCRIPTION
change the word "logtash" to "logstash".

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->
The page https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/configuration-logstash have error word.
<img width="967" height="732" alt="image" src="https://github.com/user-attachments/assets/53280b1d-82e0-4440-81a8-e789fde0416e" />

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

