### PR TITLE
Fix `elastic-api-version` header value in the Fleet docs

### DIFF
--- a/reference/fleet/migrate-elastic-agent.md
+++ b/reference/fleet/migrate-elastic-agent.md
@@ -153,7 +153,7 @@ To reset the {{ecloud}} {{agent}} policy:
         -u username:password \
         --header 'Content-Type: application/json' \
         --header 'kbn-xsrf: as' \
-        --header 'elastic-api-version: 1'
+        --header 'elastic-api-version: 2023-10-31'
         ```
 
     * If you’re using a {{kib}} version below 8.11, run:

--- a/troubleshoot/ingest/fleet/common-problems.md
+++ b/troubleshoot/ingest/fleet/common-problems.md
@@ -1028,7 +1028,7 @@ In {{ecloud}}, after [upgrading](/reference/fleet/upgrade-integration.md) {{flee
       --url <kibana_url>/internal/fleet/reset_preconfigured_agent_policies/policy-elastic-agent-on-cloud \
       --header 'content-type: application/json' \
       --header 'kbn-xsrf: xyz' \
-      --header 'elastic-api-version: 1'
+      --header 'elastic-api-version: 2023-10-31'
     ```
 
 2. Force unenroll the agent stuck in `Updating`:


### PR DESCRIPTION
## Summary

This PR fixes a factual error in a curl command in the Fleet docs. Passing `1` as the `elastic-api-version` header returns a 400 Bad Request, so users following the migration guide were blocked. The `elastic-api-version` header’s only valid value is `2023-10-31`.

Resolves https://github.com/elastic/docs-content/issues/7152

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No
