### PR TITLE
[Alerting V2][Serverless & 9.5][M2] Add requirements section and execution history docs to rules pages

### DIFF
--- a/explore-analyze/alerting/kibana-alerting-experimental/rules/create-rules-action-policies-agent-builder.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/rules/create-rules-action-policies-agent-builder.md
@@ -14,6 +14,25 @@ Rule and action policy authoring in {{agent-builder}} is part of the {{alerting-
 
 Instead of filling out the rule form manually, you describe what you want to monitor and the agent uses its rule management skill and tools to resolve the data source and build a fully configured rule proposal for you.
 
+## Requirements [create-ai-agent-requirements]
+
+Before you start, make sure you have the following:
+
+- **The required subscription**: {{agent-builder}} requires the appropriate {{stack}} [subscription](https://www.elastic.co/pricing) or {{serverless-short}} [project feature tier](/deploy-manage/deploy/elastic-cloud/project-settings.md#project-features-add-ons). Without it, the "Create with AI Agent" option is hidden in the {{alerting-v2-system}} UI.
+- **The `agentBuilder:experimentalFeatures` advanced setting turned on**: Go to the **Advanced Settings** menu using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), and turn on `agentBuilder:experimentalFeatures`.
+- **The required privileges**: Your [role](/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-role-management.md) must include the following:
+
+  | To... | Required privilege |
+  |---|---|
+  | Access and use {{agent-builder}} | **Agent Builder: Read** (under **Analytics**) |
+  | Save the rule | **Rules: All** (under **Alerting**) |
+  | Save the action policy | **Action Policies: All** (under **Alerting**) |
+  | Select or create the workflow destination | **Workflows: Read** to select an existing workflow; **Workflows: All** to create one (under **Analytics > Workflows**) |
+
+<!-- TODO: Uncomment when PR #6522 (get-started/configure-access) is merged:
+  For the full privilege reference, refer to [Configure access to the {{alerting-v2-system}}](/explore-analyze/alerting/kibana-alerting-experimental/get-started/configure-access.md).
+-->
+
 ## Propose and save a rule [ai-agent-rule-proposal]
 
 To use this capability, open an agent in [{{agent-builder}}](/explore-analyze/ai-features/elastic-agent-builder.md) that has the rule management skill configured. The rule management skill gives the agent domain expertise in {{alerting-v2-system}} rule authoring, including knowledge of ES\|QL query patterns, threshold configuration, grouping, and the alerting v2 data model. When you describe a monitoring requirement, the agent uses its tools to resolve the relevant data source and builds a rule proposal.

--- a/explore-analyze/alerting/kibana-alerting-experimental/rules/view-manage-rules.md
+++ b/explore-analyze/alerting/kibana-alerting-experimental/rules/view-manage-rules.md
@@ -5,12 +5,12 @@ applies_to:
   serverless: experimental
 products:
   - id: kibana
-description: "Search, filter, sort, and bulk-manage rules from the rules list in Kibana's experimental alerting system. Inline editing and a summary flyout let you update settings without a full page reload."
+description: "Search, filter, and bulk-manage rules in Kibana's experimental alerting system. Use inline editing, the rule summary flyout, and the Execution History page to manage rules and monitor rule health."
 ---
 
 # View and manage rules in the {{alerting-v2-system}} [manage-rules]
 
-Rule management is part of the {{alerting-v2-system}} in {{kib}}. This page covers how to find and filter rules in the rules list, quick-edit settings without leaving the list, use the rule summary flyout, and navigate the rule details page including the alert activity timeline.
+Rule management is part of the {{alerting-v2-system}} in {{kib}}. This page covers how to find and filter rules in the rules list, quick-edit settings without leaving the list, use the rule summary flyout, navigate the rule details page including the alert activity timeline, and monitor rule health at scale from the Execution History page.
 
 ## Find and filter rules [find-filter-rules]
 
@@ -39,6 +39,24 @@ The rule details page is organized into tabs that let you review a rule's config
 - **Runbook**: If the rule has an investigation guide, it appears here.
 
 Use **Edit** to modify the rule, or the actions menu to enable, disable, clone, or delete it.
+
+## Monitor rule execution health [execution-history]
+
+The Execution History page shows a cross-rule view of rule execution history, giving you a paginated, filterable log of every rule run across all rules in the space. Use this page to spot patterns that aren't visible when looking at individual rules, for example, a cluster of failures at the same timestamp pointing to a shared dependency issue.
+
+The page has two tabs: **Rules** (default), which shows per-rule execution records, and **Policies**, which shows action policy dispatch records and outcomes.
+
+The **Rules** tab displays a table of rule execution records with the following columns:
+
+| Column | Description |
+|---|---|
+| **Timestamp** | When the rule execution ran. |
+| **Rule** | The rule that ran. Selecting the rule name opens the rule summary flyout so you can inspect the rule without leaving the page. |
+| **Duration** | How long the execution took. |
+| **Response** | The outcome of the run: `success` or `failure`. |
+| **Message** | An optional message included with the execution result, typically an error description for failed runs. |
+
+Use the **Outcome** filter to narrow results by execution outcome: **All**, **Success**, or **Failure**. Filtering is applied server-side. Results are capped at 10,000 records.
 
 ## Disable or snooze a rule [disable-snooze-rule]
 


### PR DESCRIPTION
## Summary

Adds two missing documentation gaps to the experimental alerting rules section, addressing issues [#7227](https://github.com/elastic/docs-content/issues/7227) and [#7240](https://github.com/elastic/docs-content/issues/7240). Both pages are in the in-progress PR [#6523](https://github.com/elastic/docs-content/pull/6523).

---

## Content changes

### `rules/create-rules-action-policies-agent-builder.md`

Addresses [#7227](https://github.com/elastic/docs-content/issues/7227):

Added a **Requirements** section before "Propose and save a rule" covering the three conditions that must be met for the "Create with AI Agent" entry points to appear in the {{alerting-v2-system}} UI:

- **The required subscription**: Agent Builder requires the appropriate Stack subscription or Serverless project feature tier. Without it, the entry points are hidden.
- **The `agentBuilder:experimentalFeatures` advanced setting turned on**: The alerting v2-specific UI gate, enabled in Advanced Settings. Added following the Kibana PR [#274165](https://github.com/elastic/kibana/pull/274165) which introduced this as a hard gate on all four "Create with AI Agent" entry points (rules list split-button, empty state, and both create-rule flyouts).
- **The required privileges**: A table covering the four privilege requirements — `Agent Builder: Read` to access the agent, `Rules: All` to save a rule, `Action Policies: All` to save an action policy, and `Workflows: Read` or `Workflows: All` to select or create a workflow destination. A cross-reference link to `configure-access.md` is included but commented out pending PR [#6522](https://github.com/elastic/docs-content/pull/6522).

Requirements section is modeled on the `create-your-first-rule.md` pattern from PR [#6522](https://github.com/elastic/docs-content/pull/6522).

---

### `rules/view-manage-rules.md`

Addresses [#7240](https://github.com/elastic/docs-content/issues/7240):

Added a **Monitor rule execution health** section documenting the Execution History page and its Rules tab, introduced in Kibana PR [#275066](https://github.com/elastic/kibana/pull/275066).

- Describes the Execution History page as a cross-rule view for monitoring rule health at scale.
- Documents the two-tab layout: **Rules** (default) and **Policies**.
- Documents the **Rules** tab columns: Timestamp, Rule (links to rule summary flyout), Duration, Response, and Message.
- Documents the server-side **Outcome** filter (All / Success / Failure) and the 10,000-record result cap.

Updated the page description and opening paragraph to reflect the new coverage.


## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?

- [x] Yes — Cursor + Claude
- [ ] No