### PR TITLE
Mark PRW endpoint as GA in 9.5 and serverless

### DIFF
--- a/manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md
+++ b/manage-data/data-store/data-streams/tsds-ingest-prometheus-remote-write.md
@@ -1,8 +1,8 @@
 ---
 navigation_title: "Prometheus remote write endpoint"
 applies_to:
-  stack: preview
-  serverless: preview
+  stack: preview =9.4, ga 9.5+
+  serverless: ga
 products:
   - id: elasticsearch
 ---


### PR DESCRIPTION
This endpoint is preview since 9.4 (when it has been initially introduced) and GA in serverless and 9.5.

Related to https://github.com/elastic/elasticsearch/pull/151359