### PR TITLE
Add platform.alerting and platform.sig_events to protected namespaces

### DIFF
--- a/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
+++ b/explore-analyze/ai-features/agent-builder/tools/custom-tools.md
@@ -133,8 +133,10 @@ The set of protected prefixes has expanded across {{stack}} versions. The versio
 - `attachments.*` {applies_to}`stack: ga 9.4+`
 - `filestore.*` {applies_to}`stack: ga 9.4+`
 - `observability.*` {applies_to}`stack: ga 9.3+`
+- `platform.alerting.*` {applies_to}`stack: ga 9.5+`
 - `platform.core.*` {applies_to}`stack: ga 9.2+`
 - `platform.dashboard.*` {applies_to}`stack: ga 9.3+`
+- `platform.sig_events.*` {applies_to}`stack: ga 9.5+`
 - `platform.streams.*` {applies_to}`stack: ga 9.4+`
 - `platform.workflows.*` {applies_to}`stack: ga 9.4+`
 - `search.*` {applies_to}`stack: ga 9.4+`


### PR DESCRIPTION
The [Protected namespaces](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/tools/custom-tools#protected-namespaces) list on `custom-tools.md` was missing two prefixes that are present in the Kibana [`protectedNamespaces`](https://github.com/elastic/kibana/blob/main/x-pack/platform/packages/shared/agent-builder/agent-builder-common/base/namespaces.ts) array: `platform.alerting.*` and `platform.sig_events.*`.

## Changes

- Adds both prefixes to the list, in alphabetical order.
- Tags both `ga 9.5+`. The version is derived from git history of `namespaces.ts`: both prefixes were added to the `protectedNamespaces` array after the 9.5 branch cut (`platform.alerting` on 2026-05-04, `platform.sig_events` on 2026-06-29). The same method reproduces the existing `platform.streams.* ga 9.4+` entry (added 2026-03-19, between the 9.4.0 and 9.5.0 version bumps), which confirms the calibration.

Follow-up to https://github.com/elastic/docs-content/pull/7262.

Built and previewed locally with docs-builder (0 errors / 0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)