### PR TITLE
Add Multi-organization membership GA release note (Serverless, July 7, 2026)

### DIFF
--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md
@@ -2,4 +2,6 @@
 
 ### Features and enhancements [elastic-2026-07-07-features-enhancements]
 
-* **Multi-organization membership is now generally available.** Your {{ecloud}} account can now belong to more than one organization at the same time. Instead of maintaining separate logins, email aliases, or duplicate accounts, you sign in once and switch between organizations from the Cloud Console, with your roles, permissions, and resources scoped to each organization. Each organization keeps its own security settings, including SSO enforcement. Refer to [Manage multiple organizations](/deploy-manage/cloud-organization/manage-multiple-organizations.md).
+* **Multi-organization membership is now generally available.** Your {{ecloud}} account can now belong to multiple organizations at once. Instead of maintaining separate logins, email aliases, or duplicate accounts, you sign in once and switch between organizations from the Cloud Console.
+
+Each organization keeps its own scoped roles, permissions, resources, and security settings, including SSO enforcement. Refer to [Manage multiple organizations](/deploy-manage/cloud-organization/manage-multiple-organizations.md).

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md
@@ -1,0 +1,5 @@
+## July 7, 2026 [elastic-release-notes-2026-07-07]
+
+### Features and enhancements [elastic-2026-07-07-features-enhancements]
+
+* **Multi-organization membership is now generally available.** Your {{ecloud}} account can now belong to more than one organization at the same time. Instead of maintaining separate logins, email aliases, or duplicate accounts, you sign in once and switch between organizations from the Cloud Console, with your roles, permissions, and resources scoped to each organization. Each organization keeps its own security settings, including SSO enforcement. Refer to [Manage multiple organizations](/deploy-manage/cloud-organization/manage-multiple-organizations.md).

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md
@@ -4,4 +4,4 @@
 
 * **Multi-organization membership is now generally available.** Your {{ecloud}} account can now belong to multiple organizations at once. Instead of maintaining separate logins, email aliases, or duplicate accounts, you sign in once and switch between organizations from the Cloud Console.
 
-Each organization keeps its own scoped roles, permissions, resources, and security settings, including SSO enforcement. Refer to [Manage multiple organizations](/deploy-manage/cloud-organization/manage-multiple-organizations.md).
+  Each organization keeps its own scoped roles, permissions, resources, and security settings, including SSO enforcement. Refer to [Manage multiple organizations](/deploy-manage/cloud-organization/manage-multiple-organizations.md).

--- a/release-notes/elastic-cloud-serverless/index.md
+++ b/release-notes/elastic-cloud-serverless/index.md
@@ -12,6 +12,8 @@ Review the changes, fixes, and more to {{serverless-full}}.
 <!-- :::{changelog} /releases
 ::: -->
 
+:::{include} _snippets/2026-07-07/index.md
+:::
 :::{include} _snippets/2026-07-02/index.md
 :::
 :::{include} _snippets/2026-06-30/index.md


### PR DESCRIPTION
## Summary
- Adds a July 7, 2026 release-note entry announcing the GA of **multi-organization membership** to the {{serverless-full}} changelog.
- New snippet: `release-notes/elastic-cloud-serverless/_snippets/2026-07-07/index.md`, included at the top of `release-notes/elastic-cloud-serverless/index.md`.

Multi-org membership applies to all of Elastic Cloud; a companion entry is being added to the Elastic Cloud Hosted release notes (elastic/cloud#156925).

## Notes
- No PR link on the entry (control-plane feature, no single public kibana/es PR). Happy to add one if preferred.

Made with [Cursor](https://cursor.com)