### PR TITLE
docs: reorder visualize TOC and align Lens/ES|QL nav titles with product

### DIFF
--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -298,8 +298,6 @@ toc:
           - file: dashboards/create-dashboard-of-panels-with-ecommerce-data.md
   - file: visualize.md
     children:
-      - file: visualize/visualize-library.md
-      - file: visualize/manage-panels.md
       - file: visualize/lens.md
         children:
           - file: visualize/charts/area-charts.md
@@ -368,6 +366,8 @@ toc:
           - file: visualize/legacy-editors/aggregation-based.md
           - file: visualize/legacy-editors/tsvb.md
           - file: visualize/legacy-editors/timelion.md
+      - file: visualize/visualize-library.md
+      - file: visualize/manage-panels.md
   - file: find-and-organize.md
     children:
       - file: find-and-organize/data-views.md

--- a/explore-analyze/visualize/esorql.md
+++ b/explore-analyze/visualize/esorql.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: Visualization (query)
+navigation_title: Visualizations (ES|QL query)
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/esql-visualizations.html
 applies_to:

--- a/explore-analyze/visualize/esorql.md
+++ b/explore-analyze/visualize/esorql.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: ES|QL
+navigation_title: Visualization (query)
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/esql-visualizations.html
 applies_to:

--- a/explore-analyze/visualize/esorql.md
+++ b/explore-analyze/visualize/esorql.md
@@ -9,7 +9,7 @@ products:
   - id: kibana
 ---
 
-# ES|QL visualizations [esql-visualizations]
+# Lens visualizations using ES|QL queries [esql-visualizations]
 
 Creating visualizations using an {{esql}} query is particularly useful when you need to:
 

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -9,7 +9,7 @@ products:
   - id: kibana
 ---
 
-# Lens [lens]
+# Lens visualizations [lens]
 
 **Lens** is {{kib}}'s visualization editor for building charts, tables, maps, and metrics. It supports two modes for creating visualizations:
 

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: Lens
+navigation_title: Visualization
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/lens.html
 applies_to:

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: Visualization
+navigation_title: Visualizations
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/lens.html
 applies_to:


### PR DESCRIPTION
## Summary

Requested by the PM. Two navigation changes in the **Panels and visualizations** section:

- **`explore-analyze/toc.yml`**: Move the **Visualize Library** and **Manage panels** pages from the top of the section to the end, after all panel types (below **Legacy editors**).
- **`explore-analyze/visualize/lens.md`**: Change `navigation_title` from `Lens` to `Visualizations`, and rename the H1 from **Lens** to **Lens visualizations**.
- **`explore-analyze/visualize/esorql.md`**: Change `navigation_title` from `ES|QL` to `Visualizations (ES|QL query)`, and rename the H1 from **ES|QL visualizations** to **Lens visualizations using ES|QL queries**.

Navigation titles are plural to match the sibling entries (for example **Custom visualizations**, **Bar charts**, **Tables**), and the query entry keeps **ES|QL** visible so readers can tell the two apart at a glance. The two H1s are parallel — **Lens visualizations** and **Lens visualizations using ES|QL queries** — which also reflects that ES|QL visualizations are Lens's query mode. The `[lens]` and `[esql-visualizations]` anchors are preserved, so existing links keep working.

No page content, file paths, or URLs change, so no redirects are needed.

## Verification

Product renaming confirmed at HEAD in `elastic/kibana` (`origin/main`): the **Add panel** flyout now labels the two editors **Visualization** (`xpack.lens.visTypeAlias.title` in `x-pack/platform/plugins/shared/lens/public/vis_type_alias.ts`) and **Visualization (query)** (`add_esql_panel_action.tsx`). The docs navigation titles follow the plural TOC convention rather than the exact singular product strings, and the query entry names ES|QL explicitly for orientation.

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.