### PR TITLE
Updates EIS pricing link

### DIFF
--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -216,7 +216,7 @@ You can now use `semantic_text` with the new ELSER endpoint on EIS. To learn how
 
 ## Pricing [pricing]
 
-All models on EIS incur a charge per million tokens. Certain LLM providers charge different prices depending on the prompt size. The pricing details are available on our [Pricing page](https://www.elastic.co/pricing/serverless-search).
+All models on EIS incur a charge per million tokens. Certain LLM providers charge different prices depending on the prompt size. The pricing details are available on our [Pricing page](https://cloud.elastic.co/cloud-pricing-table?productType=serverless).
 
 This pricing model differs from the existing [Machine Learning Nodes](https://www.elastic.co/docs/explore-analyze/machine-learning/data-frame-analytics/ml-trained-models), which is billed through VCUs consumed.
 


### PR DESCRIPTION
This PR updates the [EIS pricing](https://www.elastic.co/docs/explore-analyze/elastic-inference/eis#pricing) link to point to the serverless pricing table in Elastic Cloud (https://cloud.elastic.co/cloud-pricing-table?productType=serverless) instead of the previous serverless search pricing page.

