### PR TITLE
Rename 'Managed integrations content' page to 'Managed content’ page in Fleet docs

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -952,3 +952,9 @@ redirects:
       'index-and-resource-limits': 'elasticsearch-differences-serverless-index-size'
       'elasticsearch-differences-custom-plugins-and-bundles': 'elasticsearch-differences-custom-plugins-and-bundles'
       'elasticsearch-differences-serverless-settings-availability': 'elasticsearch-differences-serverless-settings-availability'
+
+  # Fleet: renamed "Managed integrations content" to "Managed content" and moved the page
+  'reference/fleet/managed-integrations-content.md':
+    to: 'reference/fleet/managed-content.md'
+    anchors:
+      'managed-integrations-content': 'managed-content'

--- a/redirects.yml
+++ b/redirects.yml
@@ -957,4 +957,4 @@ redirects:
   'reference/fleet/managed-integrations-content.md':
     to: 'reference/fleet/managed-content.md'
     anchors:
-      'managed-integrations-content': 'managed-content'
+      'managed-integrations-content':

--- a/reference/fleet/managed-content.md
+++ b/reference/fleet/managed-content.md
@@ -1,5 +1,5 @@
 ---
-navigation_title: Managed integrations content
+navigation_title: Managed content
 mapped_pages:
   - https://www.elastic.co/guide/en/fleet/current/managed-integrations-content.html
 applies_to:
@@ -10,7 +10,7 @@ products:
   - id: elastic-agent
 ---
 
-# Managed integrations content [managed-integrations-content]
+# Managed content [managed-content]
 
 
 Most integration content installed by {{fleet}} isn't editable. This content is tagged with a **Managed** badge in the {{kib}} UI. Managed content itself cannot be edited or deleted, however managed visualizations, dashboards, and saved searches can be cloned.

--- a/reference/fleet/toc.yml
+++ b/reference/fleet/toc.yml
@@ -146,7 +146,7 @@ toc:
       - file: integration-level-outputs.md
       - file: upgrade-integration.md
       - file: roll-back-integration.md
-      - file: managed-integrations-content.md
+      - file: managed-content.md
       - file: integrations-assets-best-practices.md
       - file: otel-integrations.md
       - file: deprecated-integrations.md


### PR DESCRIPTION
## Summary

This PR renames the [Managed integrations content](https://www.elastic.co/docs/reference/fleet/managed-integrations-content) page to "Managed content” to avoid confusion with the Managed integrations (GA in 9.5), and adds a redirect.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor / Claude Opus 4.8

