### PR TITLE
Add Security known issues for version-specific agent policies

### DIFF
--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -23,6 +23,28 @@ Known issues are significant defects or limitations that may impact your impleme
 
 % :::
 
+:::{dropdown} Endpoints do not appear on the Assets > Endpoints page
+**Applies to: {{stack}} 9.4.0, 9.4.1, 9.4.2, 9.4.3**
+
+**Impact**<br>
+Certain {{agent}} integration packages and inputs can trigger the creation of a version-specific {{agent}} policy. When a version-specific policy includes the {{elastic-defend}} integration, the corresponding endpoints are not visible on the **Assets** > **Endpoints** and **Assets** > **Endpoints** > **Policies** pages.
+
+For more information, refer to [#276295](https://github.com/elastic/kibana/issues/276295).
+
+**Workaround**<br>
+There is currently no workaround available. A fix will be included in a future 9.4.x release.
+:::
+
+:::{dropdown} Osquery cannot target agents on version-specific policies
+**Applies to: {{stack}} 9.4.0, 9.4.1, 9.4.2, 9.4.3**
+
+**Impact**<br>
+Certain {{agent}} integration packages and inputs can trigger the creation of a version-specific {{agent}} policy. When a version-specific policy includes the Osquery integration, the corresponding agents do not appear in the Osquery agent or policy selector, so they cannot be targeted. Live queries against an affected policy fail with a `No agents found for selection` error, and agent grouping and counts in the selector are inaccurate.
+
+**Workaround**<br>
+There is currently no workaround available. A fix will be included in a future 9.4.x release.
+:::
+
 :::{dropdown} Problem Child and DGA integrations fail to install
 **Applies to: {{stack}} 9.3.6**
 


### PR DESCRIPTION
## Summary

Adds two known issues to the Elastic Security known issues page, both caused by [version-specific agent policies](https://www.elastic.co/docs/reference/fleet/version-specific-agent-policies) (9.4+) appending a `#<major.minor>` suffix to the `policy_id`, which breaks lookups that match on the bare `policy_id`:

- **Elastic Defend / Endpoint**: affected endpoints are not visible on the **Assets > Endpoints** and **Assets > Endpoints > Policies** pages.
- **Osquery**: affected agents do not appear in the Osquery agent or policy selector, live queries fail with `No agents found for selection`, and grouping/counts are inaccurate.

Applies to {{stack}} 9.4.0–9.4.3. No workaround is currently available; a fix is expected in a future 9.4.x release.


### Related issues
- Public (Endpoint): elastic/kibana#276295
- Internal tracking (Endpoint): elastic/security-team#18004
- Internal tracking (Osquery): elastic/security-team#18185
- Root cause PR (feature flag): elastic/kibana#258796

## Test plan
- [ ] Preview build renders both dropdown entries correctly
- [ ] Confirm version range (9.4.0–9.4.3) with the Defend/Osquery teams
- [ ] Confirm the Osquery known issue matches the eventual public tracking issue

Made with [Cursor](https://cursor.com)