### PR TITLE
Add OAuth clients docs URL stub

### DIFF
--- a/deploy-manage/app-connections/oauth-clients.md
+++ b/deploy-manage/app-connections/oauth-clients.md
@@ -1,0 +1,14 @@
+---
+navigation_title: OAuth clients
+description: Register and manage OAuth clients for application connections.
+applies_to:
+  serverless: preview
+products:
+  - id: cloud-serverless
+  - id: kibana
+---
+
+<!-- Temporary hidden stub for https://github.com/elastic/kibana/pull/277286.
+Replace this page with the full content from https://github.com/elastic/docs-content/pull/7104. -->
+
+# Manage OAuth clients [oauth-clients]

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -650,6 +650,7 @@ toc:
       - file: api-keys/serverless-project-api-keys.md
       - file: api-keys/elastic-cloud-api-keys.md
       - file: api-keys/elastic-cloud-enterprise-api-keys.md
+      - hidden: app-connections/oauth-clients.md
   - file: manage-connectors.md
   - file: remote-clusters.md
     children:


### PR DESCRIPTION
## Summary

Adds a temporary hidden stub for /deploy-manage/app-connections/oauth-clients so elastic/kibana#277286 can link to a live docs URL before the full OAuth/application connections docs in #7104 merge.

## Changes

- Adds a hidden TOC entry for deploy-manage/app-connections/oauth-clients.md.
- Adds a minimal page with front matter and the oauth-clients anchor only.

## Follow-up

Replace this stub with the full content from #7104 when that PR is ready.