### PR TITLE
Serverless release notes: breaking changes for Dashboards and Visualizations APIs (asCode GA schemas)

### DIFF
--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
@@ -7,7 +7,7 @@
 
   **Impact:** API requests that configure duration formats with the previous verbose unit names (for example, `minutes`, `humanize`, or `asMilliseconds`) are rejected.
 
-  **Action:** Update the duration `from` and `to` values in your visualization and dashboard panel API payloads to the new short-hand units.
+  **Action:** Update the duration `from` and `to` values in your visualization and dashboard panel API payloads to the new short-hand units. Refer to the [Dashboard API reference](https://dashboardsapispec.kibana.dev/index.html) for the updated schemas.
 ::::
 
 ::::{dropdown} Dashboard API search endpoint uses a new response schema and enforces a page size limit
@@ -17,5 +17,5 @@
 
   **Impact:** Requests that set `per_page` above 1000 are rejected. Clients that read `dashboards`, `page`, or `total` from the top level of the response no longer receive those fields.
 
-  **Action:** Update Dashboard API search clients to read results from `data` and pagination from `meta`, and keep `per_page` at or below 1000.
+  **Action:** Update Dashboard API search clients to read results from `data` and pagination from `meta`, and keep `per_page` at or below 1000. Refer to the [Dashboard API reference](https://dashboardsapispec.kibana.dev/index.html) for the updated schemas.
 ::::

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
@@ -7,15 +7,15 @@
 
   **Impact:** API requests that configure duration formats with the previous verbose unit names (for example, `minutes`, `humanize`, or `asMilliseconds`) are rejected.
 
-  **Action:** Update the duration `from` and `to` values in your visualization and dashboard panel API payloads to the new short-hand units. Refer to the [Dashboard API reference](https://dashboardsapispec.kibana.dev/index.html) for the updated schemas.
+  **Action:** Update the duration `from` and `to` values in your visualization and dashboard panel API payloads to the new short-hand units. Refer to the [Dashboards API reference](https://dashboardsapispec.kibana.dev/index.html) for the updated schemas.
 ::::
 
-::::{dropdown} Dashboard API search endpoint uses a new response schema and enforces a page size limit
+::::{dropdown} Dashboards API search endpoint uses a new response schema and enforces a page size limit
   For more information, check [#268951]({{kib-pull}}268951).
 
-  The response envelope for the Dashboard API search endpoint changed from `{ dashboards, page, total }` to `{ data, meta }`, where the pagination fields (`page`, `per_page`, and `total`) move under `meta`. The endpoint also enforces a maximum `per_page` of 1000.
+  The response envelope for the Dashboards API search endpoint changed from `{ dashboards, page, total }` to `{ data, meta }`, where the pagination fields (`page`, `per_page`, and `total`) move under `meta`. The endpoint also enforces a maximum `per_page` of 1000.
 
   **Impact:** Requests that set `per_page` above 1000 are rejected. Clients that read `dashboards`, `page`, or `total` from the top level of the response no longer receive those fields.
 
-  **Action:** Update Dashboard API search clients to read results from `data` and pagination from `meta`, and keep `per_page` at or below 1000. Refer to the [Dashboard API reference](https://dashboardsapispec.kibana.dev/index.html) for the updated schemas.
+  **Action:** Update Dashboards API search clients to read results from `data` and pagination from `meta`, and keep `per_page` at or below 1000. Refer to the [Dashboards API reference](https://dashboardsapispec.kibana.dev/index.html) for the updated schemas.
 ::::

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
@@ -13,7 +13,7 @@
 ::::{dropdown} Dashboard API search endpoint uses a new response schema and enforces a page size limit
   For more information, check [#268951]({{kib-pull}}268951).
 
-  The Dashboard API search endpoint now returns the generally available response schema. The response envelope changed from `{ dashboards, page, total }` to `{ data, meta }`, where the pagination fields move under `meta` (`page`, `per_page`, and `total`). The endpoint also enforces a maximum `per_page` of 1000.
+  The response envelope for the Dashboard API search endpoint changed from `{ dashboards, page, total }` to `{ data, meta }`, where the pagination fields (`page`, `per_page`, and `total`) move under `meta`. The endpoint also enforces a maximum `per_page` of 1000.
 
   **Impact:** Requests that set `per_page` above 1000 are rejected. Clients that read `dashboards`, `page`, or `total` from the top level of the response no longer receive those fields.
 

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/breaking-changes.md
@@ -1,0 +1,21 @@
+## July 13, 2026 [elastic-2026-07-13-breaking-changes]
+
+::::{dropdown} Dashboards and Visualizations APIs use short-hand duration units
+  For more information, check [#274792]({{kib-pull}}274792).
+
+  The `duration` format used in visualization configuration now uses short-hand unit values aligned with {{esql}} conventions for its `from` and `to` options. This affects the `api/visualizations` and `api/dashboards` APIs, for both by-value and by-reference panels. For example, `minutes` becomes `min`, `humanize` becomes `auto-approximate`, and `humanizePrecise` becomes `auto`.
+
+  **Impact:** API requests that configure duration formats with the previous verbose unit names (for example, `minutes`, `humanize`, or `asMilliseconds`) are rejected.
+
+  **Action:** Update the duration `from` and `to` values in your visualization and dashboard panel API payloads to the new short-hand units.
+::::
+
+::::{dropdown} Dashboard API search endpoint uses a new response schema and enforces a page size limit
+  For more information, check [#268951]({{kib-pull}}268951).
+
+  The Dashboard API search endpoint now returns the generally available response schema. The response envelope changed from `{ dashboards, page, total }` to `{ data, meta }`, where the pagination fields move under `meta` (`page`, `per_page`, and `total`). The endpoint also enforces a maximum `per_page` of 1000.
+
+  **Impact:** Requests that set `per_page` above 1000 are rejected. Clients that read `dashboards`, `page`, or `total` from the top level of the response no longer receive those fields.
+
+  **Action:** Update Dashboard API search clients to read results from `data` and pagination from `meta`, and keep `per_page` at or below 1000.
+::::

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/index.md
@@ -1,0 +1,3 @@
+## July 13, 2026 [elastic-release-notes-2026-07-13]
+
+This release includes breaking changes to the Dashboards and Visualizations APIs. Refer to [Breaking changes](/release-notes/elastic-cloud-serverless/breaking-changes.md#elastic-2026-07-13-breaking-changes) for details and the actions you might need to take.

--- a/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/index.md
+++ b/release-notes/elastic-cloud-serverless/_snippets/2026-07-13/index.md
@@ -1,3 +1,3 @@
 ## July 13, 2026 [elastic-release-notes-2026-07-13]
 
-This release includes breaking changes to the Dashboards and Visualizations APIs. Refer to [Breaking changes](/release-notes/elastic-cloud-serverless/breaking-changes.md#elastic-2026-07-13-breaking-changes) for details and the actions you might need to take.
+**The Dashboards and Visualizations APIs are now generally available.** This introduces breaking changes to their request and response schemas. Refer to [Breaking changes](/release-notes/elastic-cloud-serverless/breaking-changes.md#elastic-2026-07-13-breaking-changes) for details and the actions you might need to take.

--- a/release-notes/elastic-cloud-serverless/breaking-changes.md
+++ b/release-notes/elastic-cloud-serverless/breaking-changes.md
@@ -10,6 +10,9 @@ products:
 :type: breaking-change
 ::: -->
 
+:::{include} _snippets/2026-07-13/breaking-changes.md
+:::
+
 :::{include} _snippets/2026-06-30/breaking-changes.md
 :::
 

--- a/release-notes/elastic-cloud-serverless/index.md
+++ b/release-notes/elastic-cloud-serverless/index.md
@@ -12,6 +12,8 @@ Review the changes, fixes, and more to {{serverless-full}}.
 <!-- :::{changelog} /releases
 ::: -->
 
+:::{include} _snippets/2026-07-13/index.md
+:::
 :::{include} _snippets/2026-07-07/index.md
 :::
 :::{include} _snippets/2026-07-02/index.md


### PR DESCRIPTION
## Summary

Documents the two breaking changes that take effect for {{serverless-full}} when the `asCode.useGASchemas` feature flag is enabled for serverless (Dashboards and Visualizations APIs). Timed to the serverless flag flip, not the original Kibana merge dates.

Dated `2026-07-13` — adjust if the flip lands on a different day.

- Adds `_snippets/2026-07-13/breaking-changes.md` with two dropdown entries:
  - Short-hand duration units in visualization configuration ([elastic/kibana#274792](https://github.com/elastic/kibana/pull/274792)) — affects `api/visualizations` and `api/dashboards` (by-value and by-reference panels).
  - New Dashboards API search response schema (`{ data, meta }`) with a 1000 `per_page` limit ([elastic/kibana#268951](https://github.com/elastic/kibana/pull/268951)).
- Adds `_snippets/2026-07-13/index.md` — a one-line pointer from the main changelog to the breaking changes page.
- Wires both snippets into `breaking-changes.md` and `index.md`.
- Both entries link to the [Dashboards API reference](https://dashboardsapispec.kibana.dev/index.html), where the updated specs publish the same day.

## Verification

Verified against `elastic/kibana` at `main` (commit `d9a9d72`):

- **Duration units** (`duration_units.ts`): `from` enum `ps, ns, us, ms, s, min, h, d, w, mo, y`; `to` enum `auto, auto-approximate, ms, s, min, h, d, w, mo, y`. Legacy free-form values (`minutes`, `humanize`, `humanizePrecise`, `asMilliseconds`, …) are rejected under the GA schema. Examples in the note (`minutes`→`min`, `humanize`→`auto-approximate`, `humanizePrecise`→`auto`) confirmed.
- **Dashboards search** (`schemas.ts`, `pagination.ts`, `constants.ts`): GA response `{ data (maxSize 1000), meta: { page, per_page, total } }`; legacy `{ dashboards, page, total }`. `PAGINATION_MAX_SIZE = 1000` confirmed.

Vale: 0 errors, 0 warnings on the new snippets.

## Test plan

- [ ] Confirm the publish date matches the actual serverless flag-flip date; rename the `2026-07-13` snippet folder and anchors if it differs.
- [ ] Preview render: both dropdowns appear on the breaking changes page and the main changelog pointer links to `#elastic-2026-07-13-breaking-changes`.

## Screenshots to add or update

None.