### PR TITLE
docs: fix human-in-the-loop workflow YAML

### DIFF
--- a/explore-analyze/workflows/authoring-techniques/human-in-the-loop.md
+++ b/explore-analyze/workflows/authoring-techniques/human-in-the-loop.md
@@ -44,6 +44,8 @@ steps:
     type: cases.createCase
     with:
       title: "Potential compromise: {{ event.alerts[0].host.name }}"
+      description: "Potential host compromise detected by alert workflow"
+      owner: securitySolution
       severity: high
       tags: ["auto-triage"]
 
@@ -101,7 +103,7 @@ steps:
     with:
       case_id: "{{ steps.open_case.output.case.id }}"
       comment: |
-        **Decision:** {{ steps.review.output.approved ? "isolated" : "no action" }}
+        **Decision:** {% if steps.review.output.approved %}isolated{% else %}no action{% endif %}
         **Notes:** {{ steps.review.output.notes }}
 ```
 


### PR DESCRIPTION
## Summary
- Fix the human-in-the-loop workflow example so the YAML and Liquid syntax are valid.
- Add required case creation fields for the sample security workflow.