### PR TITLE
Minor fixes to page names and time range in av2 tutorial 

### DIFF
--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -293,7 +293,7 @@ Go to **Alerting v2 preview** using the navigation menu or the [global search fi
 2. Set the sandbox date range to the **Today** preset (from the **Commonly used** list) and run the query.
 
    :::{note}
-   Use **Today** rather than a relative preset like **Last 1 hour**. Because the sample data uses fixed times of day, a relative range only covers it once the current time has passed the data's last timestamp (`22:37` UTC, after you substitute today's date). **Today** covers the full calendar day, so it finds the data regardless of what time it is right now.
+   Use **Today** rather than a relative preset like **Last 1 hour**. Because the sample data uses fixed times of day, a relative range only includes data once the current time has passed the data's last timestamp (`22:37` UTC, after you substitute today's date). **Today** covers the full calendar day, so it finds the data regardless of what time it is right now.
    :::
 
 3. Confirm the query results. You should see one row for `service.name: checkout` with `p95_latency_ms` above 2000 and `severity: high` or `critical`.

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -80,7 +80,7 @@ Expand the drop-down below to copy the full bulk request, then run it in Dev Too
 The response should show `errors: false` for all documents.
 
 :::{note}
-The timestamps are fixed to `2026-07-02`, which is in the past. Before running this request, open it in a text editor and replace `2026-07-02` with today's date in `YYYY-MM-DD` format, keeping the time values unchanged. Once you load the data, complete the tutorial within 2 hours to see the full episode lifecycle.
+The timestamps are fixed to `2026-07-02`, which is in the past. Before running this request, open it in a text editor and replace `2026-07-02` with today's date in `YYYY-MM-DD` format, keeping the time values unchanged. If you want to see the episode recover on its own, without forcing it, complete the tutorial within 2 hours of loading the data.
 :::
 
 ::::{dropdown} Bulk request: 82 synthetic latency events (healthy → degraded → recovered)
@@ -350,13 +350,33 @@ Select **Next**.
 
 The sandbox showed that your query *can* find a breach. This step confirms the rule is actually running on schedule. The **Execution history** page gives you a real-time log of every rule run and its outcome.
 
-1. Open **Execution history** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
+:::::{stepper}
 
-2. On the **Rules** tab, select **Checkout Service Latency**.
+::::{step} Open Execution history
 
-3. Wait one schedule interval (5 minutes) after saving the rule, then check the table for a recent entry.
+Open **Execution history** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 
-4. Confirm the **Response** shows `success` and the **Timestamp** matches a recent time. If no entries appear, confirm at least one 5-minute interval has elapsed since you saved the rule.
+::::
+
+::::{step} Select the rule
+
+On the **Rules** tab, select **Checkout Service Latency**.
+
+::::
+
+::::{step} Wait for an execution
+
+Wait one schedule interval (5 minutes) after saving the rule, then check the table for a recent entry.
+
+::::
+
+::::{step} Confirm success
+
+Confirm the **Response** shows `success` and the **Timestamp** matches a recent time. If no entries appear, confirm at least one 5-minute interval has elapsed since you saved the rule.
+
+::::
+
+:::::
 
 ## Observe the episode lifecycle [observe-episode-lifecycle]
 
@@ -366,15 +386,56 @@ Because you set **Alert delay** to 2 consecutive breaches, the episode starts as
 
 :::{note}
 If your current UTC time hadn't yet passed `22:13` (the start of the degraded window, after you substitute today's date) when you loaded the sample data, no episode will appear here until real time reaches that point. The rule's lookback window only looks backward, so it needs the degraded window to be in the past before it can flag a breach. Once real time passes `22:13`, expect the episode to appear within about 10–15 minutes, after two consecutive evaluations confirm the breach.
+
+Note that you don't have to wait out the full lifecycle in real time. Once the episode is `active`, you can force it into recovery immediately instead of waiting for the lookback window to age out the degraded data naturally.  Refer to step 5 in the following section.
 :::
 
-1. Open **Alerting v2 preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then go to the **Alerts** page.
+:::::{stepper}
 
-2. If you have other rules in this cluster, filter by **Rule** to show only episodes for **Checkout Service Latency**. After the first two evaluations (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
+::::{step} Open the Alerts page
 
-3. Select the episode to open its details page. Use the metric trend to see how P95 latency compared to the threshold over the episode's lifetime, and confirm the grouping value (`checkout`) that triggered it.
+Open **Alerting v2 preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then go to the **Alerts** page.
 
-4. Wait for the rule's lookback window to advance past the degraded data. Once no breaching rows fall within the 2-hour window, the episode status changes to `inactive` automatically. No manual action is required. This is default recovery in action.
+::::
+
+::::{step} Find the episode
+
+If you have other rules in this cluster, filter by **Rule** to show only episodes for **Checkout Service Latency**. After the first two evaluations (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
+
+::::
+
+::::{step} Inspect the episode details
+
+Select the episode to open its details page. Use the metric trend to see how P95 latency compared to the threshold over the episode's lifetime, and confirm the grouping value (`checkout`) that triggered it.
+
+::::
+
+::::{step} Wait for automatic recovery
+
+Wait for the rule's lookback window to advance past the degraded data. Once no breaching rows fall within the 2-hour window, the episode status changes to `inactive` automatically. No manual action is required. This is default recovery in action.
+
+Because the lookback window is 2 hours, this can take a while. The degraded data doesn't age out until roughly 2 hours after you loaded it. If you don't want to wait, follow the instructions in the next step to force the same outcome immediately.
+
+::::
+
+::::{step} (Optional) Force recovery immediately
+
+Run the following in **Dev Tools** to delete the degraded documents:
+
+```json
+POST checkout-service-logs/_delete_by_query
+{
+  "query": {
+    "range": { "latency_ms": { "gt": 2000 } }
+  }
+}
+```
+
+With the breaching documents gone, the next scheduled run (within 5 minutes) finds no rows over the threshold. The rule writes a new rule event, and the episode moves to `inactive`, the same recovery path you'd otherwise wait up to 2 hours to see.
+
+::::
+
+:::::
 
 ## Key concepts demonstrated [create-rule-key-concepts]
 
@@ -383,4 +444,4 @@ This tutorial put four core concepts into practice:
 - **Rules** - The query you wrote runs every 5 minutes and computes P95 latency over a 2-hour lookback window. Each run checks whether the result exceeds 2000 ms. The schedule and lookback you configured determined how often the rule checked and how much history it analyzed each time.
 - **Severity tiers** - The `CASE()` expression you wrote classified each breach as `high` or `critical` based on the P95 value. Those labels are stored in `.rule-events` and visible in the episode detail view.
 - **Episode lifecycle** - Setting **Alert delay** to **Breaches: 2** meant the episode didn't open on the first breach. You watched it start as `pending` on the Alerts page, then move to `active` after a second consecutive breaching evaluation confirmed the condition wasn't transient.
-- **Automatic recovery** - Because you kept the default recovery settings, the episode closed on its own once the degraded data aged out of the lookback window. The rule detected the absence of a breach and moved the episode to `inactive`. 
+- **Automatic recovery** - Because you kept the default recovery settings, the episode closed once a scheduled run found no breaching rows, whether that happened naturally as the degraded data aged out of the lookback window, or immediately after you deleted the degraded documents. Either way, the rule detected the absence of a breach and moved the episode to `inactive`.

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -317,7 +317,7 @@ The query you applied from the sandbox auto-fills **Mode**, **Time field**, and 
 - Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial.
 
 :::{note}
-Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation); it can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the sample data's last timestamp (`22:37`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. See the note in **Observe the episode lifecycle** for what to expect.
+Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation). It can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the sample data's last timestamp (`22:37`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. You can go ahead and finish configuring and saving the rule. Refer to the note in **Observe the episode lifecycle** for when the episode will actually appear.
 :::
 
 Select **Next**.
@@ -368,9 +368,7 @@ The sandbox showed that your query *can* find a breach. This step confirms the r
 
 With the rule running, you can watch the full alert lifecycle play out on the Alerts page and in the episode detail view. The episode opens once the breach persists across consecutive evaluations, stays active while the degraded data is in the lookback window, and closes automatically when no breaching data remains.
 
-:::{note}
 Because you set **Alert delay** to 2 consecutive breaches, the episode starts as `pending` and only moves to `active` once the breach persists across a second evaluation. This prevents transient spikes from opening an episode right away.
-:::
 
 :::{note}
 If your current UTC time hadn't yet passed `22:37` when you loaded the sample data, no episode will appear here until real time catches up to that point. The rule's lookback window only looks backward, so it needs the degraded window to be in the past before it can flag a breach.

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -316,9 +316,9 @@ The query you applied from the sandbox auto-fills **Mode**, **Time field**, and 
 - Set **Schedule** to every `5` minutes.
 - Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial.
 
-:::{note}
-Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation). It can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the sample data's last timestamp (`22:37`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. You can go ahead and finish configuring and saving the rule. Refer to the note in **Observe the episode lifecycle** for when the episode will actually appear.
-:::
+   :::{note}
+   Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation). It can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the sample data's last timestamp (`22:37`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. You can go ahead and finish configuring and saving the rule. Refer to the note in **Observe the episode lifecycle** for when the episode will actually appear.
+   :::
 
 Select **Next**.
 
@@ -342,7 +342,7 @@ Select **Next**.
 1. On the **Details & Artifacts** step, enter the following:
 
    - **Name**: Checkout Service Latency
-   - **Description**: `Detects when P95 latency for the checkout service exceeds 2 seconds. Groups by service name and assigns severity: critical at 4 seconds, high at 2 seconds.`
+   - **Description**: Detects when P95 latency for the checkout service exceeds 2 seconds. Groups by service name and assigns severity: critical at 4 seconds, high at 2 seconds.
 
    Select **Next**.
 
@@ -358,7 +358,7 @@ The sandbox showed that your query *can* find a breach. This step confirms the r
 
 1. Open **Execution history** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 
-2. Select the **Rules** tab and use the **Rule** filter to select **Checkout Service Latency**.
+2. On the **Rules** tab, select **Checkout Service Latency**.
 
 3. Wait one schedule interval (5 minutes) after saving the rule, then check the table for a recent entry.
 
@@ -366,7 +366,7 @@ The sandbox showed that your query *can* find a breach. This step confirms the r
 
 ## Observe the episode lifecycle [observe-episode-lifecycle]
 
-With the rule running, you can watch the full alert lifecycle play out on the Alerts page and in the episode detail view. The episode opens once the breach persists across consecutive evaluations, stays active while the degraded data is in the lookback window, and closes automatically when no breaching data remains.
+With the rule running, you can watch the full alert lifecycle play out on the **Alerts** page and in the episode detail view. The episode opens once the breach persists across consecutive evaluations, stays active while the degraded data is in the lookback window, and closes automatically when no breaching data remains.
 
 Because you set **Alert delay** to 2 consecutive breaches, the episode starts as `pending` and only moves to `active` once the breach persists across a second evaluation. This prevents transient spikes from opening an episode right away.
 

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -71,185 +71,187 @@ Confirm the response shows `"acknowledged": true` before proceeding.
 
 ::::{step} Load the sample data
 
-Expand the drop-down below to copy the full bulk request, then run it in Dev Tools. It populates the index with synthetic latency data for a `checkout` service covering three phases:
+Expand the drop-down below to copy the full bulk request, then run it in Dev Tools. It populates the index with synthetic latency data for a `checkout` service covering three phases, all within a single hour:
 
-- **Healthy** (`21:57`–`22:12`): P95 well under 2 seconds
-- **Degraded** (`22:13`–`22:27`): P95 well over 2 seconds across 3 consecutive 5-minute windows
-- **Recovered** (`22:28`–`22:37`): P95 returns to healthy levels
+- **Healthy** (`:00`–`:15`): P95 well under 2 seconds
+- **Degraded** (`:16`–`:30`): P95 well over 2 seconds across 3 consecutive 5-minute windows
+- **Recovered** (`:31`–`:40`): P95 returns to healthy levels
 
 The response should show `errors: false` for all documents.
 
 :::{note}
-The timestamps are fixed to `2026-07-02`, which is in the past. Before running this request, open it in a text editor and replace `2026-07-02` with today's date in `YYYY-MM-DD` format, keeping the time values unchanged. If you want to see the episode recover on its own, without forcing it, complete the tutorial within 2 hours of loading the data.
+The timestamps are fixed to `2026-07-02T21`. Before running this request, replace `2026-07-02T21` with today's date and the current UTC hour in `YYYY-MM-DDTHH` format (for example, `2026-07-14T09`), keeping the minutes and seconds unchanged.
+
+The rule can only see data that's already in the past, so each phase won't appear until real time reaches its minute mark.
 :::
 
 ::::{dropdown} Bulk request: 82 synthetic latency events (healthy → degraded → recovered)
 ```json
 POST checkout-service-logs/_bulk
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T21:57:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":468}
+{"@timestamp":"2026-07-02T21:00:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":468}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T21:57:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":336}
+{"@timestamp":"2026-07-02T21:00:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":336}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T21:58:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":367}
+{"@timestamp":"2026-07-02T21:01:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":367}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T21:58:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":372}
+{"@timestamp":"2026-07-02T21:01:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":372}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T21:59:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":497}
+{"@timestamp":"2026-07-02T21:02:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":497}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T21:59:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":305}
+{"@timestamp":"2026-07-02T21:02:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":305}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:00:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":384}
+{"@timestamp":"2026-07-02T21:03:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":384}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:00:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":406}
+{"@timestamp":"2026-07-02T21:03:31.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":406}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:01:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":427}
+{"@timestamp":"2026-07-02T21:04:01.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":427}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:01:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":461}
+{"@timestamp":"2026-07-02T21:04:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":461}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:02:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":448}
+{"@timestamp":"2026-07-02T21:05:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":448}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:02:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":527}
+{"@timestamp":"2026-07-02T21:05:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":527}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:03:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":272}
+{"@timestamp":"2026-07-02T21:06:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":272}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:03:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":477}
+{"@timestamp":"2026-07-02T21:06:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":477}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:04:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":355}
+{"@timestamp":"2026-07-02T21:07:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":355}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:04:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":466}
+{"@timestamp":"2026-07-02T21:07:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":466}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:05:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":528}
+{"@timestamp":"2026-07-02T21:08:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":528}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:05:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":280}
+{"@timestamp":"2026-07-02T21:08:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":280}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:06:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":278}
+{"@timestamp":"2026-07-02T21:09:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":278}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:06:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":252}
+{"@timestamp":"2026-07-02T21:09:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":252}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:07:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":443}
+{"@timestamp":"2026-07-02T21:10:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":443}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:07:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":447}
+{"@timestamp":"2026-07-02T21:10:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":447}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:08:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":504}
+{"@timestamp":"2026-07-02T21:11:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":504}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:08:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":260}
+{"@timestamp":"2026-07-02T21:11:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":260}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:09:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":353}
+{"@timestamp":"2026-07-02T21:12:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":353}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:09:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":508}
+{"@timestamp":"2026-07-02T21:12:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":508}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:10:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":381}
+{"@timestamp":"2026-07-02T21:13:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":381}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:10:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":315}
+{"@timestamp":"2026-07-02T21:13:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":315}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:11:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":284}
+{"@timestamp":"2026-07-02T21:14:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":284}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:11:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":261}
+{"@timestamp":"2026-07-02T21:14:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":261}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:12:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":371}
+{"@timestamp":"2026-07-02T21:15:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":371}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:12:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":329}
+{"@timestamp":"2026-07-02T21:15:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":329}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:13:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2704}
+{"@timestamp":"2026-07-02T21:16:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2704}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:13:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2909}
+{"@timestamp":"2026-07-02T21:16:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2909}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:14:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2898}
+{"@timestamp":"2026-07-02T21:17:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2898}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:14:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3094}
+{"@timestamp":"2026-07-02T21:17:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3094}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:15:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3701}
+{"@timestamp":"2026-07-02T21:18:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3701}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:15:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3977}
+{"@timestamp":"2026-07-02T21:18:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3977}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:16:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2368}
+{"@timestamp":"2026-07-02T21:19:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2368}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:16:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3954}
+{"@timestamp":"2026-07-02T21:19:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3954}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:17:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2610}
+{"@timestamp":"2026-07-02T21:20:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2610}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:17:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2491}
+{"@timestamp":"2026-07-02T21:20:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2491}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:18:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3751}
+{"@timestamp":"2026-07-02T21:21:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3751}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:18:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3909}
+{"@timestamp":"2026-07-02T21:21:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3909}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:19:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3903}
+{"@timestamp":"2026-07-02T21:22:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3903}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:19:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3905}
+{"@timestamp":"2026-07-02T21:22:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3905}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:20:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2292}
+{"@timestamp":"2026-07-02T21:23:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2292}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:20:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4429}
+{"@timestamp":"2026-07-02T21:23:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4429}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:21:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4147}
+{"@timestamp":"2026-07-02T21:24:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4147}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:21:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2462}
+{"@timestamp":"2026-07-02T21:24:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2462}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:22:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2733}
+{"@timestamp":"2026-07-02T21:25:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2733}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:22:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2869}
+{"@timestamp":"2026-07-02T21:25:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2869}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:23:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4323}
+{"@timestamp":"2026-07-02T21:26:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4323}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:23:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3802}
+{"@timestamp":"2026-07-02T21:26:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3802}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:24:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3105}
+{"@timestamp":"2026-07-02T21:27:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3105}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:24:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2335}
+{"@timestamp":"2026-07-02T21:27:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2335}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:25:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3649}
+{"@timestamp":"2026-07-02T21:28:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3649}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:25:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4320}
+{"@timestamp":"2026-07-02T21:28:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":4320}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:26:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2671}
+{"@timestamp":"2026-07-02T21:29:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2671}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:26:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3438}
+{"@timestamp":"2026-07-02T21:29:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3438}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:27:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2251}
+{"@timestamp":"2026-07-02T21:30:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":2251}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:27:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3235}
+{"@timestamp":"2026-07-02T21:30:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":3235}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:28:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":525}
+{"@timestamp":"2026-07-02T21:31:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":525}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:28:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":458}
+{"@timestamp":"2026-07-02T21:31:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":458}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:29:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":448}
+{"@timestamp":"2026-07-02T21:32:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":448}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:29:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":453}
+{"@timestamp":"2026-07-02T21:32:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":453}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:30:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":435}
+{"@timestamp":"2026-07-02T21:33:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":435}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:30:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":463}
+{"@timestamp":"2026-07-02T21:33:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":463}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:31:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":319}
+{"@timestamp":"2026-07-02T21:34:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":319}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:31:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":421}
+{"@timestamp":"2026-07-02T21:34:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":421}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:32:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":353}
+{"@timestamp":"2026-07-02T21:35:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":353}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:32:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":378}
+{"@timestamp":"2026-07-02T21:35:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":378}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:33:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":369}
+{"@timestamp":"2026-07-02T21:36:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":369}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:33:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":490}
+{"@timestamp":"2026-07-02T21:36:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":490}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:34:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":284}
+{"@timestamp":"2026-07-02T21:37:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":284}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:34:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":359}
+{"@timestamp":"2026-07-02T21:37:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":359}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:35:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":468}
+{"@timestamp":"2026-07-02T21:38:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":468}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:35:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":292}
+{"@timestamp":"2026-07-02T21:38:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":292}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:36:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":427}
+{"@timestamp":"2026-07-02T21:39:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":427}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:36:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":423}
+{"@timestamp":"2026-07-02T21:39:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":423}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:37:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":259}
+{"@timestamp":"2026-07-02T21:40:02.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":259}
 {"index":{"_index":"checkout-service-logs"}}
-{"@timestamp":"2026-07-02T22:37:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":309}
+{"@timestamp":"2026-07-02T21:40:32.000Z","service.name":"checkout","transaction.name":"POST /checkout","latency_ms":309}
 ```
 ::::
 
@@ -271,7 +273,7 @@ Go to **Alerting v2 preview** using the navigation menu or the [global search fi
 
 ::::{step} Write and test the detection query
 
-1. Paste the following {{esql}} query into the **Query sandbox**. It computes the 95th percentile latency per service, assigns a severity label based on the result, and filters to show only services where P95 exceeds 2 seconds. Each pipe (`|`) passes the output of one step to the next.
+1. Paste the following {{esql}} query into the **Query sandbox**. It finds the slowest 5% of requests for each service (P95 latency), labels how severe that is, and keeps only the services where that value is above 2 seconds. You don't need to add a time filter yourself: the sandbox and the rule both apply one automatically based on the date range or schedule you choose.
 
    ```esql
    FROM checkout-service-logs
@@ -281,22 +283,14 @@ Go to **Alerting v2 preview** using the navigation menu or the [global search fi
        p95_latency_ms >= 2000, "high",
        "low"
      )
-   | WHERE p95_latency_ms > 2000 
+   | WHERE p95_latency_ms > 2000
    ```
 
-   :::{note}
-   You don't need to add a `WHERE @timestamp` clause to this query. Both the query sandbox and the rule executor automatically inject the time-window filter based on the date range you select in the sandbox or the rule's schedule and lookback once it's running.
-   :::
-
-2. Set the sandbox date range to the **Today** preset (from the **Commonly used** list) and run the query.
-
-   :::{note}
-   Use **Today** rather than a relative preset like **Last 1 hour**. Because the sample data uses fixed times of day, a relative range only includes data once the current time has passed the data's last timestamp (`22:37` UTC, after you substitute today's date). **Today** covers the full calendar day, so it finds the data regardless of what time it is right now.
-   :::
+2. Set the sandbox date range to the **Today** preset (from the **Commonly used** list) and run the query. **Today** covers the full calendar day, so it finds the sample data no matter what time it is right now.
 
 3. Confirm the query results. You should see one row for `service.name: checkout` with `p95_latency_ms` above 2000 and `severity: high` or `critical`.
 
-   You can also use the sandbox to preview what recovery looks like. If you narrow the range to a healthy window (before `22:13` or after `22:28`), the row disappears. No rows means no breach, and when a scheduled evaluation returns the same, the episode closes. You'll configure this behavior in the **Recovery Condition** step.
+   You can also preview recovery by setting a custom sandbox range that falls outside `:16`–`:30` past the hour, the degraded window. The query then returns no rows, the same result a non-breaching evaluation produces once the rule is running. You'll configure that recovery behavior in the **Recovery Condition** step.
 
 4. Select **Apply changes** to populate the rule form, then select **Next**.
 
@@ -312,7 +306,7 @@ The query you applied from the sandbox auto-fills **Mode**, **Time field**, and 
 
 - Set **Alert delay** to **Breaches: 2**. The breach must persist across 2 consecutive evaluations before the episode moves to `active`.
 - Set **Schedule** to every `5` minutes.
-- Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial. Unlike the sandbox, this is always a relative range, it can't use an absolute range like **Today**. Go ahead and finish configuring and saving the rule; see **Observe the episode lifecycle** for when the episode will actually appear.
+- Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial. Unlike the sandbox, this is always a relative range; it can't use an absolute range like **Today**. Go ahead and finish configuring and saving the rule; see **Observe the episode lifecycle** for when the episode will actually appear.
 
 Select **Next**.
 
@@ -372,7 +366,7 @@ Wait one schedule interval (5 minutes) after saving the rule, then check the tab
 
 ::::{step} Confirm success
 
-Confirm the **Response** shows `success` and the **Timestamp** matches a recent time. If no entries appear, confirm at least one 5-minute interval has elapsed since you saved the rule.
+Confirm the **Response** column shows `success` and the **Timestamp** matches a recent time. If no entries appear, confirm at least one 5-minute interval has elapsed since you saved the rule.
 
 ::::
 
@@ -380,14 +374,10 @@ Confirm the **Response** shows `success` and the **Timestamp** matches a recent 
 
 ## Observe the episode lifecycle [observe-episode-lifecycle]
 
-With the rule running, you can watch the full alert lifecycle play out on the **Alerts** page and in the episode detail view. The episode opens once the breach persists across consecutive evaluations, stays active while the degraded data is in the lookback window, and closes automatically when no breaching data remains.
+With the rule running, you can watch the full alert lifecycle play out on the **Alerts** page and in the episode's details page. Because you set **Alert delay** to 2 consecutive breaches, the episode starts as `pending` and only moves to `active` once a second consecutive evaluation confirms the breach, preventing transient spikes from opening an episode right away. It stays active while the degraded data is in the lookback window, and closes automatically once no breaching data remains.
 
-Because you set **Alert delay** to 2 consecutive breaches, the episode starts as `pending` and only moves to `active` once the breach persists across a second evaluation. This prevents transient spikes from opening an episode right away.
-
-:::{note}
-If your current UTC time hadn't yet passed `22:13` (the start of the degraded window, after you substitute today's date) when you loaded the sample data, no episode will appear here until real time reaches that point. The rule's lookback window only looks backward, so it needs the degraded window to be in the past before it can flag a breach. Once real time passes `22:13`, expect the episode to appear within about 10–15 minutes, after two consecutive evaluations confirm the breach.
-
-Note that you don't have to wait out the full lifecycle in real time. Once the episode is `active`, you can force it into recovery immediately instead of waiting for the lookback window to age out the degraded data naturally.  Refer to step 5 in the following section.
+:::{tip}
+If you want to see the episode recover on its own, without forcing it, complete this section within 2 hours of loading the sample data.
 :::
 
 :::::{stepper}
@@ -400,7 +390,13 @@ Open **Alerting v2 preview** using the navigation menu or the [global search fie
 
 ::::{step} Find the episode
 
-If you have other rules in this cluster, filter by **Rule** to show only episodes for **Checkout Service Latency**. After the first two evaluations (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
+If you have other rules in this cluster, filter by **Rule** to show only episodes for **Checkout Service Latency**.
+
+:::{note}
+The episode won't appear until the current UTC time passes 16 minutes past that hour, which is the start of the degraded window.
+:::
+
+After the first two evaluations following that point (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
 
 ::::
 
@@ -431,7 +427,7 @@ POST checkout-service-logs/_delete_by_query
 }
 ```
 
-With the breaching documents gone, the next scheduled run (within 5 minutes) finds no rows over the threshold. The rule writes a new rule event, and the episode moves to `inactive`, the same recovery path you'd otherwise wait up to 2 hours to see.
+Within 5 minutes, the next scheduled run should find no data over the threshold and move the episode to `inactive`. Go to the **Alerts** page and open the episode's details page again to confirm.
 
 ::::
 
@@ -442,6 +438,6 @@ With the breaching documents gone, the next scheduled run (within 5 minutes) fin
 This tutorial put four core concepts into practice:
 
 - **Rules** - The query you wrote runs every 5 minutes and computes P95 latency over a 2-hour lookback window. Each run checks whether the result exceeds 2000 ms. The schedule and lookback you configured determined how often the rule checked and how much history it analyzed each time.
-- **Severity tiers** - The `CASE()` expression you wrote classified each breach as `high` or `critical` based on the P95 value. Those labels are stored in `.rule-events` and visible in the episode detail view.
+- **Severity tiers** - The `CASE()` expression you wrote classified each breach as `high` or `critical` based on the P95 value. Those labels are stored in `.rule-events` and visible in the episode's details page.
 - **Episode lifecycle** - Setting **Alert delay** to **Breaches: 2** meant the episode didn't open on the first breach. You watched it start as `pending` on the Alerts page, then move to `active` after a second consecutive breaching evaluation confirmed the condition wasn't transient.
 - **Automatic recovery** - Because you kept the default recovery settings, the episode closed once a scheduled run found no breaching rows, whether that happened naturally as the degraded data aged out of the lookback window, or immediately after you deleted the degraded documents. Either way, the rule detected the absence of a breach and moved the episode to `inactive`.

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -19,7 +19,7 @@ Here's what you'll do:
 2. **Write a detection query** - Use the query sandbox to build and preview an {{esql}} query that computes P95 latency and flags breaches. The sandbox lets you verify the logic before the rule ever runs.
 3. **Configure the rule** - Set the alert condition, schedule, lookback window, and recovery behavior. You'll see how each setting shapes the alert lifecycle.
 4. **Confirm the rule is running** - Check the **Execution history** page to see that the rule is evaluating on schedule and its runs are succeeding.
-5. **Watch the episode open and recover** - Open the alert episode's details page to watch the episode move from `pending` to `active` as the breach persists, then close automatically when the degraded data ages out of the lookback window.
+5. **Watch the episode open and recover** - Open the alert episode's details page to watch the episode move from `pending` to `active` as the breach persists, then close automatically when the degraded data ages out of the lookback window, or immediately if you force recovery.
 
 ## Requirements [create-rule-requirements]
 

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -81,8 +81,6 @@ The response should show `errors: false` for all documents.
 
 :::{note}
 The timestamps are fixed to `2026-07-02`, which is in the past. Before running this request, open it in a text editor and replace `2026-07-02` with today's date in `YYYY-MM-DD` format, keeping the time values unchanged. Once you load the data, complete the tutorial within 2 hours to see the full episode lifecycle.
-
-Because the times of day are fixed (`21:57`–`22:37` UTC), the data only looks "recent" once the current UTC time has passed `22:37`. If you load the data before then, the documents are technically timestamped in the future. This doesn't affect the query sandbox in the next section, which uses an absolute time range, but it does affect the rule's lookback window (which is always relative to now) once the rule is running. See the note in **Observe the episode lifecycle** for what this means for the rest of the tutorial.
 :::
 
 ::::{dropdown} Bulk request: 82 synthetic latency events (healthy → degraded → recovered)
@@ -314,11 +312,7 @@ The query you applied from the sandbox auto-fills **Mode**, **Time field**, and 
 
 - Set **Alert delay** to **Breaches: 2**. The breach must persist across 2 consecutive evaluations before the episode moves to `active`.
 - Set **Schedule** to every `5` minutes.
-- Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial.
-
-   :::{note}
-   Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation). It can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the start of the degraded window (`22:13`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. You can go ahead and finish configuring and saving the rule. Refer to the note in **Observe the episode lifecycle** for when the episode will actually appear.
-   :::
+- Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial. Unlike the sandbox, this is always a relative range, it can't use an absolute range like **Today**. Go ahead and finish configuring and saving the rule; see **Observe the episode lifecycle** for when the episode will actually appear.
 
 Select **Next**.
 

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -81,9 +81,11 @@ The response should show `errors: false` for all documents.
 
 :::{note}
 The timestamps are fixed to `2026-07-02`, which is in the past. Before running this request, open it in a text editor and replace `2026-07-02` with today's date in `YYYY-MM-DD` format, keeping the time values unchanged. Once you load the data, complete the tutorial within 2 hours to see the full episode lifecycle.
+
+Because the times of day are fixed (`21:57`–`22:37` UTC), the data only looks "recent" once the current UTC time has passed `22:37`. If you load the data before then, the documents are technically timestamped in the future. This doesn't affect the query sandbox in the next section, which uses an absolute time range, but it does affect the rule's lookback window (which is always relative to now) once the rule is running. See the note in **Observe the episode lifecycle** for what this means for the rest of the tutorial.
 :::
 
-::::{dropdown} Bulk request: 80 synthetic latency events (healthy → degraded → recovered)
+::::{dropdown} Bulk request: 82 synthetic latency events (healthy → degraded → recovered)
 ```json
 POST checkout-service-logs/_bulk
 {"index":{"_index":"checkout-service-logs"}}
@@ -265,7 +267,7 @@ You'll build a rule that detects when P95 latency for a service exceeds 2 second
 
 ::::{step} Open the rule editor
 
-Go to **Alerting V2 Preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md). From the rules list, select the option to create a new rule. When the rule creation panel opens, select **Create ES|QL rule** to open the rule authoring flyout.
+Go to **Alerting v2 preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md). From the **Rules** page, select the option to create an {{esql}} rule.
 
 ::::
 
@@ -288,7 +290,11 @@ Go to **Alerting V2 Preview** using the navigation menu or the [global search fi
    You don't need to add a `WHERE @timestamp` clause to this query. Both the query sandbox and the rule executor automatically inject the time-window filter based on the date range you select in the sandbox or the rule's schedule and lookback once it's running.
    :::
 
-2. Set the sandbox date range to **Last 1 hour** and run the query. This preset gives comfortable coverage of the full dataset without pulling in data from a previous run.
+2. Set the sandbox date range to the **Today** preset (from the **Commonly used** list) and run the query.
+
+   :::{note}
+   Use **Today** rather than a relative preset like **Last 1 hour**. Because the sample data uses fixed times of day, a relative range only covers it once the current time has passed the data's last timestamp (`22:37` UTC, after you substitute today's date). **Today** covers the full calendar day, so it finds the data regardless of what time it is right now.
+   :::
 
 3. Confirm the query results. You should see one row for `service.name: checkout` with `p95_latency_ms` above 2000 and `severity: high` or `critical`.
 
@@ -309,6 +315,10 @@ The query you applied from the sandbox auto-fills **Mode**, **Time field**, and 
 - Set **Alert delay** to **Breaches: 2**. The breach must persist across 2 consecutive evaluations before the episode moves to `active`.
 - Set **Schedule** to every `5` minutes.
 - Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial.
+
+:::{note}
+Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation); it can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the sample data's last timestamp (`22:37`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. See the note in **Observe the episode lifecycle** for what to expect.
+:::
 
 Select **Next**.
 
@@ -362,7 +372,11 @@ With the rule running, you can watch the full alert lifecycle play out on the Al
 Because you set **Alert delay** to 2 consecutive breaches, the episode starts as `pending` and only moves to `active` once the breach persists across a second evaluation. This prevents transient spikes from opening an episode right away.
 :::
 
-1. Open **Alerting V2 Preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then go to the **Alerts** page.
+:::{note}
+If your current UTC time hadn't yet passed `22:37` when you loaded the sample data, no episode will appear here until real time catches up to that point. The rule's lookback window only looks backward, so it needs the degraded window to be in the past before it can flag a breach.
+:::
+
+1. Open **Alerting v2 preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then go to the **Alerts** page.
 
 2. Filter by **Rule** to show only episodes for **Checkout Service Latency**. After the first two evaluations (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
 

--- a/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
+++ b/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule.md
@@ -317,7 +317,7 @@ The query you applied from the sandbox auto-fills **Mode**, **Time field**, and 
 - Set **Lookback Window** to the last `2` hours. This ensures the rule can reach the pre-loaded sample data regardless of when you complete the tutorial.
 
    :::{note}
-   Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation). It can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the sample data's last timestamp (`22:37`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. You can go ahead and finish configuring and saving the rule. Refer to the note in **Observe the episode lifecycle** for when the episode will actually appear.
+   Unlike the sandbox, the rule's **Lookback Window** is always a relative range (the last 2 hours as of each evaluation). It can't use an absolute range like **Today**. If the current UTC time hasn't yet passed the start of the degraded window (`22:13`, after you substitute today's date), the rule won't see the degraded data until real time catches up. This doesn't block you from continuing the tutorial. You can go ahead and finish configuring and saving the rule. Refer to the note in **Observe the episode lifecycle** for when the episode will actually appear.
    :::
 
 Select **Next**.
@@ -371,12 +371,12 @@ With the rule running, you can watch the full alert lifecycle play out on the **
 Because you set **Alert delay** to 2 consecutive breaches, the episode starts as `pending` and only moves to `active` once the breach persists across a second evaluation. This prevents transient spikes from opening an episode right away.
 
 :::{note}
-If your current UTC time hadn't yet passed `22:37` when you loaded the sample data, no episode will appear here until real time catches up to that point. The rule's lookback window only looks backward, so it needs the degraded window to be in the past before it can flag a breach.
+If your current UTC time hadn't yet passed `22:13` (the start of the degraded window, after you substitute today's date) when you loaded the sample data, no episode will appear here until real time reaches that point. The rule's lookback window only looks backward, so it needs the degraded window to be in the past before it can flag a breach. Once real time passes `22:13`, expect the episode to appear within about 10–15 minutes, after two consecutive evaluations confirm the breach.
 :::
 
 1. Open **Alerting v2 preview** using the navigation menu or the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md), then go to the **Alerts** page.
 
-2. Filter by **Rule** to show only episodes for **Checkout Service Latency**. After the first two evaluations (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
+2. If you have other rules in this cluster, filter by **Rule** to show only episodes for **Checkout Service Latency**. After the first two evaluations (about 10 minutes), you'll see an episode appear and move from `pending` to `active`.
 
 3. Select the episode to open its details page. Use the metric trend to see how P95 latency compared to the threshold over the episode's lifetime, and confirm the grouping value (`checkout`) that triggered it.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

The tutorial's sample data used fixed absolute timestamps for a specific day, which caused two problems: the query sandbox's relative **Last 1 hour** preset returned zero results once real time passed the data's last timestamp, and the fixed two-hour clock window didn't adapt to whatever hour the reader actually started the tutorial in. This PR reworks the sample data and every dependent step to be hour-relative instead of date/time-fixed, and cleans up structure, wording, and terminology throughout the page.

- **Sample data**: Timestamps are now anchored to a single substituted hour (`YYYY-MM-DDTHH`) instead of a fixed date, with the three phases expressed as minute-of-hour ranges (`:00`–`:15` healthy, `:16`–`:30` degraded, `:31`–`:40` recovered) instead of absolute clock times. The bulk request now has 82 events.
- **Query sandbox step**: Switched from the relative **Last 1 hour** preset to the absolute **Today** preset, which always covers the sample data regardless of current time. Simplified the query explanation (P95 latency described in plain language) and merged the `WHERE @timestamp` guidance into the main instruction instead of a separate note.
- **Configure the alert condition step**: Clarified inline that the rule's Lookback Window is always a relative range (unlike the sandbox) and can't use an absolute range like **Today** — but that this doesn't block the reader from finishing and saving the rule.
- **Confirm the rule is evaluating** and **Observe the episode lifecycle**: Converted numbered lists into the `stepper` component for clearer step-by-step navigation.
- **Observe the episode lifecycle**: Added a new **(Optional) Force recovery immediately** step so readers can force the episode to `inactive` via Dev Tools instead of waiting up to 2 hours for the lookback window to age out the degraded data naturally. Added a tip noting the 2-hour window needed for natural recovery, and clarified exactly when the episode will appear relative to the substituted hour.
- **Terminology and copy consistency**: Standardized on "episode's details page" (previously also called "detail view" in some places) and on "Alerting v2 preview" capitalization; softened "filter by Rule" instructions to be conditional since a first-rule tutorial reader typically has nothing else to filter out; fixed minor grammar issues (comma splices) and a leftover "tab"/"table" wording error.

## Preview

[Create a rule and observe the alert lifecycle](https://docs-v3-preview.elastic.dev/elastic/docs-content/pull/7370/explore-analyze/alerting/experimental-alerting-system/get-started/create-your-first-rule)

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes - Cursor + Claude
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->
