### PR TITLE
[Security] Fix lifecycle state for threat hunting leads skill

### DIFF
--- a/solutions/security/ai/agent-builder/skills-use-cases.md
+++ b/solutions/security/ai/agent-builder/skills-use-cases.md
@@ -74,9 +74,9 @@ The `manage-watchlists` skill only covers watchlist changes. To also profile ent
 ## Threat hunting leads
 
 ```{applies_to}
-stack: ga 9.5+
+stack: preview 9.5+
 serverless:
-  security: ga
+  security: preview
 ```
 
 **Enable:** `entity-analytics-leads`


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Fixes lifecycle state for threat hunting leads skill since the feature is still in preview.
 
Related to https://github.com/elastic/docs-content/pull/7333.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

