### PR TITLE
Additional settings for Govcloud AWS customers

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
+++ b/deploy-manage/tools/snapshot-and-restore/cloud-on-k8s.md
@@ -268,6 +268,14 @@ Follow [the {{aws}} documentation](https://aws.amazon.com/premiumsupport/knowled
     1. {{es}} expects the service account token to be projected to exactly this path
     2. Replace with the actual `AWS_ROLE_ARN` for the IAM role you created in step 3
 
+      ::::{note}
+      If your cluster runs in an AWS GovCloud region, add the following environment variable to force the AWS SDK to use the correct regional STS endpoint. Without this,           authentication can fail with an `InvalidIdentityTokenException`.
+      ```yaml
+      - name: AWS_STS_REGIONAL_ENDPOINTS
+        value: "regional"
+      ```
+      ::::
+
 5. Create the snapshot repository as described in [Register the repository in {{es}}](#k8s-create-repository) but of type `s3`
 
     ```sh


### PR DESCRIPTION
The current documentation hits the commercial STS endpoint, but customers on Govcloud will need to hit the Govcloud STS and this setting helps with that.

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

