### PR TITLE
docs: Explain remembered space behavior (#6937)

### DIFF
--- a/cloud-account/index.md
+++ b/cloud-account/index.md
@@ -49,4 +49,4 @@ Organizations are groupings of {{ecloud}} resources and associated settings. As 
 
 ## Customize your interface
 
-Some account features also let you set personal preferences and customize the interface, such as [using dark mode](dark-mode.md) in your projects and deployments.
+Some account features also let you set personal preferences and customize the interface, such as [using dark mode](dark-mode.md) and [whether Kibana remembers your last space](/deploy-manage/choose-and-switch-spaces.md#remember-last-selected-space) in your projects and deployments.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -24,7 +24,7 @@ From the global header, select your current space, then select the space you wan
 
 ## Understand what happens when you log in
 
-{applies_to}`ech: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` {applies_to}`serverless: ga` If you can access more than one space, {{kib}} asks you to select a space when you log in.
+{applies_to}`ech: ga` {applies_to}`serverless: ga` If you can access more than one space, {{kib}} asks you to select a space when you log in.
 
 {applies_to}`self: ga` On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
 

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -34,7 +34,9 @@ From the global header, select your current space, then select the space you wan
 ## Change whether Kibana remembers your space
 ```{applies_to}
 deployment:
-  self: ga 9.5+
+  self: ga
+  ece: ga
+  eck: ga
 ```
 
 This personal preference controls whether {{kib}} returns you to your last space or shows the space selector when you log in and can access multiple spaces.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -24,12 +24,12 @@ From the global header, select your current space, then select the space you wan
 
 ## Understand what happens when you log in
 
-What {{kib}} opens when you log in depends on your version and whether it has remembered a space:
+{applies_to}`ech: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` {applies_to}`serverless: ga` If you can access more than one space, {{kib}} asks you to select a space when you log in.
 
-- {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space.
-- {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
+On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
 
-A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
+- {applies_to}`self: ga 9.5+` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space. A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
+- {applies_to}`self: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
 
 ## Change whether Kibana remembers your space
 ```{applies_to}

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -26,8 +26,8 @@ From the global header, select your current space, then select the space you wan
 
 What {{kib}} opens when you log in depends on your version and whether it has remembered a space:
 
-- {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
 - {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space.
+- {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
 
 A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
 

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -40,7 +40,7 @@ serverless: unavailable
 This personal preference controls whether {{kib}} returns you to your last space or shows the space selector when you log in and can access multiple spaces.
 
 **Requirements**:
-- Your Kibana instance must be self-managed or deployed through {{ece}} or {{eck}}. This menu option is not available on {{ecloud}}.
+- Your Kibana instance must be self-managed or deployed through {{ece}} or {{eck}}. This option is not available on {{ecloud}}.
 
 1. From the global header's user menu, select **Edit profile**.
 2. In **Space Configuration**, turn **Remember last selected space** on or off.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -1,0 +1,48 @@
+---
+description: Select and switch Kibana spaces, and control whether Kibana returns to your last space when you log in.
+applies_to:
+  stack: ga
+  serverless: ga
+products:
+  - id: kibana
+  - id: cloud-serverless
+---
+
+# Select and switch Kibana spaces
+
+The spaces you can access depend on your roles. Switching spaces does not change your permissions.
+
+## Switch spaces
+
+From the global header, select your current space, then select the space you want to open.
+
+:::{image} /deploy-manage/images/kibana-change-space.png
+:alt: Change current space menu
+:screenshot:
+:width: 50%
+:::
+
+## Understand what happens when you log in
+
+What {{kib}} opens when you log in depends on your version and whether it has remembered a space:
+
+- {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
+- {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space.
+
+A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
+
+## Change whether Kibana remembers your space
+```{applies_to}
+deployment:
+  self: ga 9.5+
+```
+
+This personal preference controls whether {{kib}} returns you to your last space or shows the space selector when you log in and can access multiple spaces.
+
+1. From the global header's user menu, select **Edit profile**.
+2. In **Space Configuration**, turn **Remember last selected space** on or off.
+3. Select **Save changes**.
+
+When you turn off **Remember last selected space**, {{kib}} shows the space selector the next time you log in and can access more than one space.
+
+To create, configure, or delete spaces, refer to [Manage spaces](/deploy-manage/manage-spaces.md).

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -26,7 +26,7 @@ From the global header, select your current space, then select the space you wan
 
 {applies_to}`ech: ga` {applies_to}`serverless: ga` If you can access more than one space, {{kib}} asks you to select a space when you log in.
 
-{applies_to}`self: ga` On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
+{applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
 
    - {applies_to}`self: ga 9.5+` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space. A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
    - {applies_to}`self: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -26,10 +26,10 @@ From the global header, select your current space, then select the space you wan
 
 {applies_to}`ech: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` {applies_to}`serverless: ga` If you can access more than one space, {{kib}} asks you to select a space when you log in.
 
-On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
+{applies_to}`self: ga` On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
 
-- {applies_to}`self: ga 9.5+` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space. A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
-- {applies_to}`self: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
+   - {applies_to}`self: ga 9.5+` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space. A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
+   - {applies_to}`self: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
 
 ## Change whether Kibana remembers your space
 ```{applies_to}

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -33,10 +33,8 @@ From the global header, select your current space, then select the space you wan
 
 ## Change whether Kibana remembers your space
 ```{applies_to}
-deployment:
-  self: ga
-  ece: ga
-  eck: ga
+stack: ga 9.5
+serverless: unavailable
 ```
 
 This personal preference controls whether {{kib}} returns you to your last space or shows the space selector when you log in and can access multiple spaces.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -39,6 +39,9 @@ serverless: unavailable
 
 This personal preference controls whether {{kib}} returns you to your last space or shows the space selector when you log in and can access multiple spaces.
 
+**Requirements**:
+- Your Kibana instance must be self-managed or deployed through {{ece}} or {{eck}}. This menu option is not available on {{ecloud}}.
+
 1. From the global header's user menu, select **Edit profile**.
 2. In **Space Configuration**, turn **Remember last selected space** on or off.
 3. Select **Save changes**.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -28,8 +28,8 @@ From the global header, select your current space, then select the space you wan
 
 {applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` On self-managed deployments, what {{kib}} opens when you log in depends on your version and whether it has remembered a space:
 
-   - {applies_to}`self: ga 9.5+` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space. A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
-   - {applies_to}`self: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
+   - {applies_to}`stack: ga 9.5+` {{kib}} can remember the space you use and return you to it. If {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space. A direct link continues to open the linked {{kib}} app or object instead of redirecting you to the remembered space.
+   - {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
 
 ## Change whether Kibana remembers your space
 ```{applies_to}

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -11,7 +11,9 @@ type: how-to
 
 # Select and switch Kibana spaces
 
-The spaces you can open depend on your roles. Switching spaces does not change your permissions.
+Switch between the spaces your roles allow. Switching spaces does not change your permissions.
+
+You can also set whether {{kib}} opens your last space when you log in.
 
 ## Before you begin
 
@@ -26,7 +28,7 @@ You can open only the spaces that your roles grant access to.
    * In all other cases, select the avatar of your current space in the global header to open the **Spaces** menu.
 
    :::{image} /deploy-manage/images/kibana-change-space.png
-   :alt: Change current space menu
+   :alt: The My spaces menu in the global header
    :screenshot:
    :width: 50%
    :::

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -1,0 +1,91 @@
+---
+description: Switch between Kibana spaces from the global header. Control whether Kibana opens your last selected space when you log in, or shows the space selector.
+applies_to:
+  stack: ga
+  serverless: ga
+products:
+  - id: kibana
+  - id: cloud-serverless
+type: how-to
+---
+
+# Select and switch Kibana spaces
+
+The spaces you can open depend on your roles. Switching spaces does not change your permissions.
+
+## Before you begin
+
+You can open only the spaces that your roles grant access to.
+
+## Switch spaces
+
+1. Open the space selector from the [global header](/explore-analyze/find-and-organize/kibana-interface.md#global-header). Where you find it depends on your deployment type and version:
+
+   * {applies_to}`serverless: ga` Select the name of your project in the global header, then select your current space to open **My spaces**.
+   * {applies_to}`stack: ga 9.6` In spaces that use a solution view, select the name of your deployment in the global header, then select your current space to open **My spaces**. When the global header shows the name of your current space instead of a deployment name, selecting it opens **My spaces** directly.
+   * In all other cases, select the avatar of your current space in the global header to open the **Spaces** menu.
+
+   :::{image} /deploy-manage/images/kibana-change-space.png
+   :alt: Change current space menu
+   :screenshot:
+   :width: 50%
+   :::
+
+2. Select the space you want to open.
+
+The header shows the space you opened.
+
+## Understand what happens when you log in
+
+If you can access only one space, {{kib}} opens it.
+
+If you can access more than one space, {{kib}} does one of the following:
+
+- {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
+- {applies_to}`stack: ga =9.5` On self-managed deployments and on {{ece}} and {{eck}}, {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
+- {applies_to}`stack: ga 9.0-9.4` {{kib}} asks you to select a space.
+
+{applies_to}`stack: ga =9.5` On {{ecloud}}, {{kib}} asks you to select a space. It does not persist your last space.
+
+## Change whether Kibana remembers your last space [remember-last-selected-space]
+```{applies_to}
+stack: ga 9.5+
+serverless: ga
+```
+
+This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.
+
+:::{note}
+:applies_to: stack: ga =9.5
+On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
+:::
+
+### On {{ecloud}} and serverless
+```{applies_to}
+ech: ga
+serverless: ga
+```
+
+1. Open the user menu from the header.
+2. Select **Spaces preferences**.
+3. Turn **Remember last selected space** on or off.
+4. Select **Save**.
+
+### On self-managed, {{ece}}, and {{eck}}
+```{applies_to}
+self: ga
+ece: ga
+eck: ga
+```
+
+1. Open the user menu from the header.
+2. Select **Edit profile**.
+3. In **Spaces preferences** or **Space Configuration** (depending on your {{stack}} version), turn **Remember last selected space** on or off.
+4. Select **Save changes**.
+
+The next time you log in, {{kib}} follows this preference. If the preference is off and you can access more than one space, {{kib}} shows the space selector.
+
+## Related pages
+
+- [Spaces](/deploy-manage/manage-spaces.md)
+- [The {{kib}} interface](/explore-analyze/find-and-organize/kibana-interface.md)

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -35,7 +35,7 @@ You can open only the spaces that your roles grant access to.
 
 2. Select the space you want to open.
 
-The selected space opens. It's visible in the header.
+The selected space opens.
 
 ## Understand what happens when you log in
 

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -24,7 +24,7 @@ You can open only the spaces that your roles grant access to.
 1. Open the space selector from the [global header](/explore-analyze/find-and-organize/kibana-interface.md#global-header). Where you find it depends on your deployment type and version:
 
    * {applies_to}`serverless: ga` Select the name of your project in the global header, then select your current space to open **My spaces**.
-   * {applies_to}`stack: ga 9.6` In spaces that use a solution view, select the name of your deployment in the global header, then select your current space to open **My spaces**. When the global header shows the name of your current space instead of a deployment name, selecting it opens **My spaces** directly.
+   * {applies_to}`stack: ga 9.6+` In spaces that use a solution view, select the name of your deployment in the global header, then select your current space to open **My spaces**. When the global header shows the name of your current space instead of a deployment name, selecting it opens **My spaces** directly.
    * In all other cases, select the avatar of your current space in the global header to open the **Spaces** menu.
 
    :::{image} /deploy-manage/images/kibana-change-space.png

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -33,7 +33,7 @@ You can open only the spaces that your roles grant access to.
 
 2. Select the space you want to open.
 
-The header shows the space you opened.
+The selected space opens. It's visible in the header.
 
 ## Understand what happens when you log in
 
@@ -56,7 +56,7 @@ serverless: ga
 This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.
 
 :::{note}
-:applies_to: stack: ga =9.5
+:applies_to: ech:
 On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
 :::
 
@@ -69,12 +69,7 @@ On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preference
 
 3. Turn **Remember last selected space** on or off.
 
-   * {applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` The control is in **Spaces preferences** or **Space Configuration** (depending on your {{stack}} version).
-
-4. Save your changes. The button label depends on your deployment:
-
-   * {applies_to}`ech: ga` {applies_to}`serverless: ga` Select **Save**.
-   * {applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` Select **Save changes**.
+4. Save your changes.
 
 The next time you log in, {{kib}} follows this preference. If the preference is off and you can access more than one space, {{kib}} shows the space selector.
 

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -44,7 +44,7 @@ If you can access more than one space, {{kib}} does one of the following:
 - {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
 - {applies_to}`stack: ga =9.5` The behavior depends on your deployment type:
   - On self-managed deployments, {{ece}}, and {{eck}}, {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
-  - On {{ecloud}}, {{kib}} asks you to select a space. It does not persist your last space. The **Spaces preferences** user menu item is not available.
+  - On {{ech}}, {{kib}} asks you to select a space. It does not persist your last space. The **Spaces preferences** user menu item is not available.
 - {applies_to}`stack: ga 9.0-9.4` {{kib}} asks you to select a space.
 
 ## Change whether Kibana remembers your last space [remember-last-selected-space]
@@ -57,8 +57,8 @@ serverless: ga
 This preference is available on:
 
 * {applies_to}`serverless: ga` {{serverless-full}} projects
-* {applies_to}`stack: ga 9.6+` Self-managed deployments, {{ece}}, {{eck}}, and {{ecloud}}
-* {applies_to}`stack: ga =9.5` Self-managed deployments, {{ece}}, and {{eck}}. It is not available on {{ecloud}}.
+* {applies_to}`stack: ga 9.6+` Self-managed deployments, {{ece}}, {{eck}}, and {{ech}}
+* {applies_to}`stack: ga =9.5` Self-managed deployments, {{ece}}, and {{eck}}. It is not available on {{ech}}.
 :::
 
 This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -53,12 +53,15 @@ stack: ga 9.5+
 serverless: ga
 ```
 
-This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.
+:::{admonition} Requirements
+This preference is available on:
 
-:::{note}
-:applies_to: ech:
-On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
+* {applies_to}`serverless: ga` {{serverless-full}} projects
+* {applies_to}`stack: ga 9.6+` Self-managed deployments, {{ece}}, {{eck}}, and {{ecloud}}
+* {applies_to}`stack: ga =9.5` Self-managed deployments, {{ece}}, and {{eck}}. It is not available on {{ecloud}}.
 :::
+
+This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.
 
 1. Open the user menu from the header.
 

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -42,10 +42,10 @@ If you can access only one space, {{kib}} opens it.
 If you can access more than one space, {{kib}} does one of the following:
 
 - {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
-- {applies_to}`stack: ga =9.5` On self-managed deployments and on {{ece}} and {{eck}}, {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
+- {applies_to}`stack: ga =9.5` The behavior depends on your deployment type:
+  - On self-managed deployments, {{ece}}, and {{eck}}, {{kib}} can remember the space you last used and open it. If {{kib}} has no remembered space, or you no longer have access to it, {{kib}} asks you to select a space. A direct link to a {{kib}} app or object opens that destination. It does not send you to the remembered space.
+  - On {{ecloud}}, {{kib}} asks you to select a space. It does not persist your last space. The **Spaces preferences** user menu item is not available.
 - {applies_to}`stack: ga 9.0-9.4` {{kib}} asks you to select a space.
-
-{applies_to}`stack: ga =9.5` On {{ecloud}}, {{kib}} asks you to select a space. It does not persist your last space.
 
 ## Change whether Kibana remembers your last space [remember-last-selected-space]
 ```{applies_to}
@@ -55,21 +55,18 @@ serverless: ga
 
 This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.
 
-:::{note}
-:applies_to: stack: ga =9.5
-On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
-:::
-
 ### On {{ecloud}} and serverless
 ```{applies_to}
 ech: ga
 serverless: ga
 ```
 
-1. Open the user menu from the header.
-2. Select **Spaces preferences**.
-3. Turn **Remember last selected space** on or off.
-4. Select **Save**.
+{applies_to}`stack: ga =9.5` On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
+
+1. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Open the user menu from the header.
+2. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Select **Spaces preferences**.
+3. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Turn **Remember last selected space** on or off.
+4. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Select **Save**.
 
 ### On self-managed, {{ece}}, and {{eck}}
 ```{applies_to}

--- a/deploy-manage/choose-and-switch-spaces.md
+++ b/deploy-manage/choose-and-switch-spaces.md
@@ -55,30 +55,26 @@ serverless: ga
 
 This personal preference is on by default. It controls whether {{kib}} opens your last space when you log in.
 
-### On {{ecloud}} and serverless
-```{applies_to}
-ech: ga
-serverless: ga
-```
-
-{applies_to}`stack: ga =9.5` On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
-
-1. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Open the user menu from the header.
-2. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Select **Spaces preferences**.
-3. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Turn **Remember last selected space** on or off.
-4. {applies_to}`stack: ga 9.6+` {applies_to}`serverless: ga` Select **Save**.
-
-### On self-managed, {{ece}}, and {{eck}}
-```{applies_to}
-self: ga
-ece: ga
-eck: ga
-```
+:::{note}
+:applies_to: stack: ga =9.5
+On {{ecloud}}, {{kib}} does not persist your last space. The **Spaces preferences** user menu item is not available.
+:::
 
 1. Open the user menu from the header.
-2. Select **Edit profile**.
-3. In **Spaces preferences** or **Space Configuration** (depending on your {{stack}} version), turn **Remember last selected space** on or off.
-4. Select **Save changes**.
+
+2. Open the space preference settings. The menu item depends on your deployment:
+
+   * {applies_to}`ech: ga` {applies_to}`serverless: ga` Select **Spaces preferences**.
+   * {applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` Select **Edit profile**.
+
+3. Turn **Remember last selected space** on or off.
+
+   * {applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` The control is in **Spaces preferences** or **Space Configuration** (depending on your {{stack}} version).
+
+4. Save your changes. The button label depends on your deployment:
+
+   * {applies_to}`ech: ga` {applies_to}`serverless: ga` Select **Save**.
+   * {applies_to}`self: ga` {applies_to}`ece: ga` {applies_to}`eck: ga` Select **Save changes**.
 
 The next time you log in, {{kib}} follows this preference. If the preference is off and you can access more than one space, {{kib}} shows the space selector.
 

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -18,18 +18,7 @@ products:
 - Users can access only the spaces that they have been granted access to. This access is based on user roles, and a given role can have different permissions per space.
 - In {{stack}} deployments on version 8.16 and later, each space has its own navigation, called solution view.
 
-{{kib}} creates a default space for you. You can change your current space at any time from the top menu.
-
-When you log in:
-
-- {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
-- {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` {{kib}} can remember the space you use and return you to it. If you can access more than one space and {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space.
-
-:::{image} /deploy-manage/images/kibana-change-space.png
-:alt: Change current space menu
-:screenshot:
-:width: 50%
-:::
+{{kib}} creates a default space for you. To select or switch spaces as an individual user, refer to [Select and switch Kibana spaces](/deploy-manage/choose-and-switch-spaces.md).
 
 You can find the **Spaces** management page in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -20,30 +20,16 @@ products:
 
 {{kib}} creates a default space for you. You can change your current space at any time from the top menu.
 
-{applies_to}`stack: ga 9.0-9.4` When you create more spaces, {{kib}} asks users to select a space when they log in.
+When you log in:
+
+- {applies_to}`stack: ga 9.0-9.4` If you can access more than one space, {{kib}} asks you to select a space.
+- {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` {{kib}} can remember the space you use and return you to it. If you can access more than one space and {{kib}} has no remembered space or you no longer have access to it, {{kib}} asks you to select a space.
 
 :::{image} /deploy-manage/images/kibana-change-space.png
 :alt: Change current space menu
 :screenshot:
 :width: 50%
 :::
-
-## Control which space opens after login [remember-last-selected-space]
-```{applies_to}
-stack: ga 9.5+
-serverless: ga
-```
-
-When you have access to more than one space and **Remember last selected space** is enabled, {{kib}} opens your remembered space the next time you log in. If no space is remembered or you no longer have access to it, {{kib}} opens the space selector.
-
-On self-managed deployments, you can change this preference:
-
-1. Open the user menu from the header.
-2. Select **Edit profile**.
-3. In **Space Configuration**, turn **Remember last selected space** on or off.
-4. Select **Save changes**.
-
-When you turn off **Remember last selected space** and have access to more than one space, {{kib}} opens the space selector when you log in.
 
 You can find the **Spaces** management page in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -26,8 +26,10 @@ The rest of this page explains how to manage spaces and their settings. For info
 
 ## Required permissions [_required_privileges_3]
 
-* {applies_to}`serverless:` `Admin` role or equivalent
-* {applies_to}`stack:` `kibana_admin` or equivalent
+To manage spaces, you need the following role or equivalent privileges for your deployment type:
+
+* {applies_to}`serverless:` `Admin` role
+* {applies_to}`stack:` `kibana_admin`
 
 
 ## Create a space [spaces-managing]

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -18,13 +18,32 @@ products:
 - Users can access only the spaces that they have been granted access to. This access is based on user roles, and a given role can have different permissions per space.
 - In {{stack}} deployments on version 8.16 and later, each space has its own navigation, called solution view.
 
-{{kib}} creates a default space for you. When you create more spaces, users are asked to choose a space when they log in, and can change their current space at any time from the top menu.
+{{kib}} creates a default space for you. You can change your current space at any time from the top menu.
+
+{applies_to}`stack: ga 9.0-9.4` When you create more spaces, {{kib}} asks users to select a space when they log in.
 
 :::{image} /deploy-manage/images/kibana-change-space.png
 :alt: Change current space menu
 :screenshot:
 :width: 50%
 :::
+
+## Control which space opens after login [remember-last-selected-space]
+```{applies_to}
+stack: ga 9.5+
+serverless: ga
+```
+
+When you have access to more than one space and **Remember last selected space** is enabled, {{kib}} opens your remembered space the next time you log in. If no space is remembered or you no longer have access to it, {{kib}} opens the space selector.
+
+On self-managed deployments, you can change this preference:
+
+1. Open the user menu from the header.
+2. Select **Edit profile**.
+3. In **Space Configuration**, turn **Remember last selected space** on or off.
+4. Select **Save changes**.
+
+When you turn off **Remember last selected space** and have access to more than one space, {{kib}} opens the space selector when you log in.
 
 You can find the **Spaces** management page in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -18,20 +18,7 @@ products:
 - Users can access only the spaces that they have been granted access to. This access is based on user roles, and a given role can have different permissions per space.
 - In {{stack}} deployments on version 8.16 and later, each space has its own navigation, called solution view.
 
-{{kib}} creates a default space for you. When you create more spaces, users are asked to choose a space when they log in, and can change their current space at any time from the [global header](/explore-analyze/find-and-organize/kibana-interface.md#global-header).
-
-Where you find the space selector depends on your deployment type and version:
-
-* {applies_to}`serverless: ga` Select the name of your project in the global header, then select your current space to open **My spaces**.
-* {applies_to}`stack: ga 9.6` In spaces that use a solution view, select the name of your deployment in the global header, then select your current space to open **My spaces**. When the global header shows the name of your current space instead of a deployment name, selecting it opens **My spaces** directly.
-* In all other cases, select the avatar of your current space in the global header to open the **Spaces** menu.
-
-
-:::{image} /deploy-manage/images/kibana-change-space.png
-:alt: Change current space menu
-:screenshot:
-:width: 50%
-:::
+{{kib}} creates a default space for you. To select or switch spaces as an individual user, refer to [Select and switch Kibana spaces](/deploy-manage/choose-and-switch-spaces.md).
 
 You can find the **Spaces** management page in the navigation menu or use the [global search field](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 
@@ -39,8 +26,10 @@ The rest of this page explains how to manage spaces and their settings. For info
 
 ## Required permissions [_required_privileges_3]
 
-* {applies_to}`serverless:` `Admin` role or equivalent
-* {applies_to}`stack:` `kibana_admin` or equivalent
+To manage spaces, you need the following role or equivalent privileges for your deployment type:
+
+* {applies_to}`serverless:` `Admin` role
+* {applies_to}`stack:` `kibana_admin`
 
 
 ## Create a space [spaces-managing]

--- a/deploy-manage/manage-spaces.md
+++ b/deploy-manage/manage-spaces.md
@@ -2,6 +2,7 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/kibana/current/xpack-spaces.html
   - https://www.elastic.co/guide/en/serverless/current/spaces.html
+navigation_title: Kibana Spaces
 applies_to:
   stack: ga
   serverless: ga
@@ -10,7 +11,7 @@ products:
   - id: cloud-serverless
 ---
 
-# Spaces [xpack-spaces]
+# Manage {{kib}} Spaces [xpack-spaces]
 
 **Spaces** let you organize your content and users according to your needs.
 

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -643,6 +643,7 @@ toc:
               - file: users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md
   - file: manage-spaces.md
     children:
+      - file: choose-and-switch-spaces.md
       - file: manage-spaces-fleet.md
   - file: api-keys.md
     children:

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -652,6 +652,7 @@ toc:
               - file: users-roles/cluster-or-deployment-auth/submitting-requests-on-behalf-of-other-users.md
   - file: manage-spaces.md
     children:
+      - file: choose-and-switch-spaces.md
       - file: manage-spaces-fleet.md
   - file: api-keys.md
     children:

--- a/explore-analyze/find-and-organize/kibana-interface.md
+++ b/explore-analyze/find-and-organize/kibana-interface.md
@@ -38,7 +38,7 @@ The global header holds the following elements.
 | AI assistant or agent | Opens the AI assistant or agent of your solution. Its label depends on which one your project or deployment offers. |
 | Your avatar | Opens the user menu, where you can change your appearance and language preferences, customize your navigation menu, and log out. |
 
-Where you find the space selector depends on your deployment type and version. Refer to [Spaces](/deploy-manage/manage-spaces.md) for the steps.
+Where you find the space selector depends on your deployment type and version. Refer to [Select and switch Kibana spaces](/deploy-manage/choose-and-switch-spaces.md) for the steps.
 
 ## Navigation menu
 
@@ -55,4 +55,4 @@ The application menu sits at the top of the workspace and holds the actions avai
 
 * To open an app or find an object you created, refer to [Find apps and objects](/explore-analyze/find-and-organize/find-apps-and-objects.md).
 * To change which apps appear in the navigation menu, refer to [Customize your navigation menu](/explore-analyze/find-and-organize/customize-navigation.md).
-* To switch to another space or create one, refer to [Spaces](/deploy-manage/manage-spaces.md).
+* To switch to another space, refer to [Select and switch Kibana spaces](/deploy-manage/choose-and-switch-spaces.md). To create one, refer to [Spaces](/deploy-manage/manage-spaces.md).


### PR DESCRIPTION
## Summary

This PR addresses #6937 with the following changes:

- **`deploy-manage/choose-and-switch-spaces.md`**: New how-to for switching spaces and setting whether Kibana opens your last space at login. Documents login behavior across versions, including last-space recollection on Elastic Cloud Hosted and serverless from 9.6 (kibana#281118). Uses one procedure for the remembered-space preference, with deployment-specific menu items as sub-bullets. A Requirements list shows where the preference is available, including that it is not available on Elastic Cloud Hosted in 9.5. The screenshot shows the **My spaces** switcher as it appears on serverless.
- **`deploy-manage/manage-spaces.md`**: Renames the admin page to **Manage Kibana Spaces** (nav title **Kibana Spaces**). Links individual users to the new child page. Folds the space-selector location steps that landed on `main` into the child page.
- **`deploy-manage/toc.yml`**: Adds the new page beneath **Spaces**.
- **`explore-analyze/find-and-organize/kibana-interface.md`**: Points space-selector steps at the new how-to.
- **`cloud-account/index.md`**: Links **Customize your interface** to the remembered-space preference.

## Resolves

Closes #6937

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.