### PR TITLE
add crosslink for mcp oauth to ab docs

### DIFF
--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -239,7 +239,7 @@ toc:
                  children:
                    - file: ai-features/agent-builder/mcp-server-api-keys.md
                    - title: "OAuth authentication"
-                     crosslink: deploy-manage://app-connections/oauth-clients.md
+                     crosslink: docs-content://deploy-manage/app-connections/oauth-clients.md
           - file: ai-features/agent-builder/monitor-usage.md
           - file: ai-features/agent-builder/permissions.md
           - file: ai-features/agent-builder/troubleshooting.md

--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -238,9 +238,8 @@ toc:
                - file: ai-features/agent-builder/mcp-server.md
                  children:
                    - file: ai-features/agent-builder/mcp-server-api-keys.md
-                   # TODO: uncomment OAuth crosslinks once deploy-manage/app-connections pages are in the link index
-                   # - title: "OAuth authentication"
-                   #   crosslink: docs-content://deploy-manage/app-connections/oauth-clients.md
+                   - title: "OAuth authentication"
+                     crosslink: deploy-manage://app-connections/oauth-clients.md
           - file: ai-features/agent-builder/monitor-usage.md
           - file: ai-features/agent-builder/permissions.md
           - file: ai-features/agent-builder/troubleshooting.md


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary

followup to https://github.com/elastic/docs-content/pull/7104
adds x-link so both auth methods for agent builder mcp have equal nav presence under Agent Builder

<img width="219" height="637" alt="image" src="https://github.com/user-attachments/assets/f0beb55c-5c99-4dab-8025-d1721e99e5fa" />


## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

