### PR TITLE
[ECK]: 3.5.0 document AutoOps agent collector configuration via spec.config/configRef

### DIFF
--- a/deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
+++ b/deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
@@ -20,7 +20,13 @@ If you don't want the agent to access certain types of data, you can disable the
 Disable data collection only when necessary, as it limits the insights that AutoOps can provide. For example, disabling the collection of cluster health metrics prevents you from receiving critical warnings and diagnostics about your cluster's health.
 :::
 
-## Edit your AutoOps configuration file
+## Configure data collection
+
+:::::{tab-set}
+:group: autoops-configure-collection
+
+::::{tab-item} Edit configuration file
+:sync: configure-collection-other
 
 To disable the collection of certain types of data from your environment, delete the lines related to that data from your `autoops_es.yml` file on the host machine where {{agent}} is installed.
 
@@ -60,3 +66,64 @@ Complete the following steps:
     2. to disable the collection of template-related data, delete all the lines in the `Templates` section
 4. Save your changes to the `autoops_es.yml` file.
 5. Restart {{agent}} for the new settings to take effect.
+
+::::
+
+::::{tab-item} ECK
+:sync: configure-collection-eck
+```{applies_to}
+deployment:
+  eck: ga 3.5
+```
+
+When using {{eck}}, configure data collection directly in the `AutoOpsAgentPolicy` resource using `spec.config` or `spec.configRef`. At most one of these fields can be set at a time.
+
+Use `spec.config` for inline configuration:
+
+```yaml
+apiVersion: autoops.k8s.elastic.co/v1alpha1
+kind: AutoOpsAgentPolicy
+metadata:
+  name: autoops-agent-policy
+spec:
+  config:
+    receivers:
+      metricbeatreceiver:
+        metricbeat:
+          modules:
+            - module: autoops_es
+              period: 30s
+              metricsets: [cluster_health]
+```
+
+Or use `spec.configRef` to reference a Kubernetes Secret. The secret must use the key `autoops_es.yml`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-autoops-config
+stringData:
+  autoops_es.yml: |
+    receivers:
+      metricbeatreceiver:
+        metricbeat:
+          modules:
+            - module: autoops_es
+              period: 30s
+              metricsets: [cluster_health]
+---
+apiVersion: autoops.k8s.elastic.co/v1alpha1
+kind: AutoOpsAgentPolicy
+metadata:
+  name: autoops-agent-policy
+spec:
+  configRef:
+    secretName: my-autoops-config
+```
+
+When you supply at least one `autoops_es` module, ECK uses it instead of the built-in Metrics and Templates modules, giving you full control over which metricsets are collected and at what interval. Elasticsearch connection details, the OTLP exporter endpoint, and the healthcheck extension are always injected by ECK and cannot be overridden.
+
+::::
+
+:::::

--- a/deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
+++ b/deploy-manage/monitor/autoops/autoops-disable-metrics-collection.md
@@ -14,7 +14,7 @@ products:
 
 When you connect your ECE, ECK, or self-managed {{es}} cluster to AutoOps, {{agent}} collects data from your cluster and sends it to AutoOps to diagnose issues and provide performance recommendations. 
 
-If you don't want the agent to access certain types of data, you can disable the collection of related metrics by editing your configuration file as described in the following section.
+If you don't want the agent to access certain types of data, you can disable the collection of related metrics as described in the following section.
 
 :::{warning}
 Disable data collection only when necessary, as it limits the insights that AutoOps can provide. For example, disabling the collection of cluster health metrics prevents you from receiving critical warnings and diagnostics about your cluster's health.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Extends the AutoOps data collection page with an ECK tab showing how to configure the AutoOps agent collector via `spec.config` (inline YAML) or `spec.configRef` (Secret reference) on `AutoOpsAgentPolicy`, replacing the manual file-editing approach for ECK users.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

Tool(s) and model(s) used: Sonnet 4.6
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Sonnet 4.6
-->

