### PR TITLE
[ECK]: 3.5.0 document file-based secure settings hot-reload for Elasticsearch

### DIFF
--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -158,7 +158,7 @@ spec:
   - secretName: s3-credentials
 ```
 
-When the annotation is set and the cluster is running {{es}} 9.5+, ECK delivers all `spec.secureSettings` entries through {{es}} file-based settings instead of the keystore init container. Updating a source secret no longer triggers a rolling restart. Instead, {{es}} applies the updated credentials in place on each node.
+When the annotation is set and the cluster is running {{es}} 9.5+, ECK delivers all `spec.secureSettings` entries through {{es}} file-based settings instead of the keystore init container. Updating a source secret no longer triggers a rolling restart. Instead, {{es}} applies the updated credentials in place on each node. Note that enabling or disabling the annotation itself causes a one-time rolling restart, because it changes the Pod template by adding or removing the keystore init container.
 
 When the annotation is absent or the cluster is running {{es}} earlier than 9.5, the existing keystore init container path is used unchanged.
 

--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -168,7 +168,7 @@ When the annotation is set and the cluster is running {{es}} 9.5+, ECK delivers 
 When the annotation is absent or the cluster is running {{es}} earlier than 9.5, the existing keystore init container path is used unchanged.
 
 ::::{important}
-Only use this annotation when **all** entries in `spec.secureSettings` are hot-reloadable settings. Settings that must be present in the keystore at startup — such as OIDC `client_secret`, SAML key passphrases, and `xpack.watcher.encryption_key` — will cause {{es}} to fail to start if the keystore is absent. Typical reloadable settings include S3, GCS, and Azure repository credentials, and remote-cluster API keys.
+Only use this annotation when all entries in `spec.secureSettings` are [reloadable settings](/deploy-manage/security/secure-settings.md#reloadable-secure-settings). Settings that must be present in the keystore at startup, such as OIDC `client_secret`, SAML key passphrases, and `xpack.watcher.encryption_key`, will cause {{es}} to fail to start if the keystore is absent.
 ::::
 
 ## {{kib}} secure settings [k8s-kibana-secure-settings]

--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -15,12 +15,7 @@ With the help of ECK operator, you can specify {{es}} and {{kib}} [secure settin
 
 The secrets should contain a key-value pair for each secure setting you want to add. ECK watches the referenced secrets for changes and delivers them to your {{es}} or {{kib}} Pods. By default, each update triggers a rolling restart of the affected Pods to repopulate the keystore.
 
-```{applies_to}
-deployment:
-  eck: ga 3.5+
-```
-
-For {{es}} 9.5 and later, you can opt in to [updating secure settings without a restart](#k8s-es-secure-settings-hot-reload).
+You also can opt in to [updating secure settings without a restart](#k8s-es-secure-settings-hot-reload).
 
 ## {{es}} secure settings [k8s-es-secure-settings]
 

--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -128,6 +128,40 @@ stringData:
     }
 ```
 
+## {{es}} secure settings hot-reload [k8s-es-secure-settings-hot-reload]
+```{applies_to}
+deployment:
+  eck: ga 3.5
+```
+
+By default, every change to a `spec.secureSettings` source secret triggers a rolling restart of the {{es}} cluster because the keystore init container must re-run to repopulate the keystore. For {{es}} 9.5 and later, ECK supports an opt-in file-based delivery mechanism that eliminates this restart: secrets are written into the {{es}} file-based settings path and {{es}} reloads them in place when the file changes.
+
+To enable file-based delivery, add the following annotation to your {{es}} resource:
+
+```yaml subs=true
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: quickstart
+  annotations:
+    eck.k8s.elastic.co/file-based-secure-settings: "true"
+spec:
+  version: {{version.stack}}
+  nodeSets:
+  - name: default
+    count: 3
+  secureSettings:
+  - secretName: s3-credentials
+```
+
+When the annotation is set and the cluster is running {{es}} 9.5+, ECK delivers all `spec.secureSettings` entries via the `cluster_secrets` field of the file-based settings mechanism instead of the keystore init container. Updating a source secret no longer triggers a pod restart — {{es}} reloads the credentials in place on each node.
+
+::::{important}
+Only use this annotation when **all** entries in `spec.secureSettings` are hot-reloadable settings. Settings that must be present in the keystore at startup — such as OIDC `client_secret`, SAML key passphrases, and `xpack.watcher.encryption_key` — will cause {{es}} to fail to start if the keystore is absent. Typical reloadable settings include S3, GCS, and Azure repository credentials, and remote-cluster API keys.
+
+When the annotation is absent or the cluster is running {{es}} earlier than 9.5, the existing keystore init container path is used unchanged.
+::::
+
 ## {{kib}} secure settings [k8s-kibana-secure-settings]
 
 Similar to {{es}} secure settings, you can use Kubernetes secrets to manage keystore settings for {{kib}}.

--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -13,9 +13,14 @@ products:
 
 With the help of ECK operator, you can specify {{es}} and {{kib}} [secure settings](/deploy-manage/security/secure-settings.md) to your deployments through [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
-The secrets should contain a key-value pair for each secure setting you want to add. ECK automatically injects these settings into the keystore on each {{es}} or {{kib}} Pod before it starts. The ECK operator continues to watch the secrets for changes and will update the {{es}} or {{kib}} keystores when it detects a change.
+The secrets should contain a key-value pair for each secure setting you want to add. ECK watches the referenced secrets for changes and delivers them to your {{es}} or {{kib}} Pods. By default, each update triggers a rolling restart of the affected Pods to repopulate the keystore.
 
-To allow the operator to inject the settings into the application, you must reference your secrets in the `spec.secureSettings` field of your {{es}} or {{kib}} object definition. Next, you’ll find examples for both {{es}} and {{kib}}.
+```{applies_to}
+deployment:
+  eck: ga 3.5+
+```
+
+For {{es}} 9.5 and later, you can opt in to [updating secure settings without a restart](#k8s-es-secure-settings-hot-reload).
 
 ## {{es}} secure settings [k8s-es-secure-settings]
 
@@ -135,7 +140,7 @@ stringData:
 ### Update secure settings without a restart [k8s-es-secure-settings-hot-reload]
 ```{applies_to}
 deployment:
-  eck: ga 3.5
+  eck: ga 3.5+
 ```
 
 By default, every change to a `spec.secureSettings` source secret triggers a rolling restart of the {{es}} cluster because the keystore init container must re-run to repopulate the keystore. For {{es}} 9.5 and later, ECK supports an opt-in file-based delivery mechanism that eliminates this restart: secrets are written into the {{es}} file-based settings path and {{es}} reloads them in place when the file changes.

--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -17,7 +17,11 @@ The secrets should contain a key-value pair for each secure setting you want to 
 
 To allow the operator to inject the settings into the application, you must reference your secrets in the `spec.secureSettings` field of your {{es}} or {{kib}} object definition. Next, you’ll find examples for both {{es}} and {{kib}}.
 
-## {{es}} basic usage [k8s_basic_usage]
+## {{es}} secure settings [k8s-es-secure-settings]
+
+Reference one or more Kubernetes secrets from `spec.secureSettings` so ECK can inject secure settings into your {{es}} Pods. You can [add secrets to the resource](#k8s_basic_usage), [map secret keys to keystore setting names](#k8s_projection_of_secret_keys_to_specific_paths), and [update secure settings without a rolling restart](#k8s-es-secure-settings-hot-reload).
+
+### Reference secrets in the Elasticsearch resource [k8s_basic_usage]
 
 It is possible to reference several secrets:
 
@@ -56,7 +60,7 @@ stringData:
 Note that by default [Kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) are expecting the value to be base64 encoded unless under a `stringData` field.
 ::::
 
-### Projection of secret keys to specific paths [k8s_projection_of_secret_keys_to_specific_paths]
+### Project secret keys to specific paths [k8s_projection_of_secret_keys_to_specific_paths]
 
 You can export a subset of secret keys and also project keys to specific paths using the `entries`, `key` and `path` fields:
 
@@ -128,7 +132,7 @@ stringData:
     }
 ```
 
-## {{es}} secure settings hot-reload [k8s-es-secure-settings-hot-reload]
+### Update secure settings without a restart [k8s-es-secure-settings-hot-reload]
 ```{applies_to}
 deployment:
   eck: ga 3.5

--- a/deploy-manage/security/k8s-secure-settings.md
+++ b/deploy-manage/security/k8s-secure-settings.md
@@ -163,12 +163,12 @@ spec:
   - secretName: s3-credentials
 ```
 
-When the annotation is set and the cluster is running {{es}} 9.5+, ECK delivers all `spec.secureSettings` entries via the `cluster_secrets` field of the file-based settings mechanism instead of the keystore init container. Updating a source secret no longer triggers a pod restart — {{es}} reloads the credentials in place on each node.
+When the annotation is set and the cluster is running {{es}} 9.5+, ECK delivers all `spec.secureSettings` entries through {{es}} file-based settings instead of the keystore init container. Updating a source secret no longer triggers a rolling restart. Instead, {{es}} applies the updated credentials in place on each node.
+
+When the annotation is absent or the cluster is running {{es}} earlier than 9.5, the existing keystore init container path is used unchanged.
 
 ::::{important}
 Only use this annotation when **all** entries in `spec.secureSettings` are hot-reloadable settings. Settings that must be present in the keystore at startup — such as OIDC `client_secret`, SAML key passphrases, and `xpack.watcher.encryption_key` — will cause {{es}} to fail to start if the keystore is absent. Typical reloadable settings include S3, GCS, and Azure repository credentials, and remote-cluster API keys.
-
-When the annotation is absent or the cluster is running {{es}} earlier than 9.5, the existing keystore init container path is used unchanged.
 ::::
 
 ## {{kib}} secure settings [k8s-kibana-secure-settings]


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Documents the opt-in file-based secure settings hot-reload for Elasticsearch 9.5+ on ECK 3.5, covering the annotation, compatible settings, and the important caveat about startup-required settings.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

Tool(s) and model(s) used: Sonnet 4.6
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Sonnet 4.6
-->
