### PR TITLE
[ECK]: 3.5.0 document pause-orchestration annotation for maintenance windows

### DIFF
--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -14,7 +14,7 @@ During maintenance windows, such as draining {{k8s}} nodes or applying infrastru
 
 ## Paused vs. fully unmanaged [k8s-pause-vs-unmanaged]
 
-ECK provides two annotations that affect reconciliation behaviour:
+ECK provides two annotations that affect reconciliation behavior:
 
 | Annotation | Effect |
 |---|---|
@@ -49,7 +49,7 @@ The same annotation works on any other resource type. Only the exact string valu
 
 ## What continues and what pauses [k8s-pause-orchestration-behaviour]
 
-| Operation | Behaviour when paused |
+| Operation | Behavior when paused |
 |---|---|
 | Certificate rotation (HTTP and transport) | Continues |
 | Service reconciliation | Continues |

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -21,11 +21,7 @@ ECK provides two annotations that affect reconciliation behavior:
 | `eck.k8s.elastic.co/pause-orchestration: "true"` | {applies_to}`eck: ga 3.5+` | Pauses spec-driven changes only. Housekeeping continues. |
 | `eck.k8s.elastic.co/managed: "false"` | {applies_to}`eck: deprecated 3.5+` | Stops all reconciliation entirely. Deprecated in favor of `pause-orchestration`. |
 
-The key difference is that `pause-orchestration` keeps certificate rotation, service reconciliation, user and secret management, and health monitoring running. This avoids cluster degradation during extended maintenance windows.
-
-## Supported resources [k8s-pause-orchestration-resources]
-
-The annotation is supported on all ECK-managed resource types: {{es}}, {{kib}}, {{apm-server}}, Enterprise Search, {{hosted-ems}}, {{ls}}, {{agent}}, {{beats}}, and AutoOps Agent Policy.
+The key difference is that `pause-orchestration` keeps certificate rotation, service reconciliation, user and secret management, and health monitoring running. This avoids cluster degradation during extended maintenance windows. The annotation is supported on all ECK-managed resource types: {{es}}, {{kib}}, {{apm-server}}, Enterprise Search, {{hosted-ems}}, {{ls}}, {{agent}}, {{beats}}, Elastic Package Registry, and AutoOps Agent Policy.
 
 ## How to pause orchestration [k8s-pause-orchestration-usage]
 

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -1,0 +1,73 @@
+---
+navigation_title: Pause orchestration
+applies_to:
+  deployment:
+    eck: ga 3.5
+products:
+  - id: cloud-kubernetes
+---
+
+# Pause orchestration on ECK [k8s-pause-orchestration]
+
+During maintenance windows — such as draining {{k8s}} nodes or applying infrastructure changes — it can be useful to temporarily prevent ECK from applying spec changes to your Elastic resources. The `eck.k8s.elastic.co/pause-orchestration` annotation lets you freeze spec-driven orchestration on any ECK-managed resource while keeping essential housekeeping running.
+
+## Paused vs. fully unmanaged [k8s-pause-vs-unmanaged]
+
+ECK provides two annotations that affect reconciliation behaviour:
+
+| Annotation | Effect |
+|---|---|
+| `eck.k8s.elastic.co/pause-orchestration: "true"` | Pauses spec-driven changes only. Housekeeping continues. |
+| `eck.k8s.elastic.co/managed: "false"` | Stops all reconciliation entirely. **Deprecated** — use `pause-orchestration` instead. |
+
+The key difference is that `pause-orchestration` keeps certificate rotation, service reconciliation, user and secret management, and health monitoring running. This avoids cluster degradation during extended maintenance windows.
+
+## Supported resources [k8s-pause-orchestration-resources]
+
+The annotation is supported on all ECK-managed resource types: {{es}}, {{kib}}, {{apm-server}}, Enterprise Search, {{hosted-ems}}, {{ls}}, {{agent}}, {{beats}}, and AutoOps Agent Policy.
+
+## How to pause orchestration [k8s-pause-orchestration-usage]
+
+Set the annotation to `"true"` on any ECK resource:
+
+```yaml subs=true
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: quickstart
+  annotations:
+    eck.k8s.elastic.co/pause-orchestration: "true"
+spec:
+  version: {{version.stack}}
+  nodeSets:
+  - name: default
+    count: 3
+```
+
+The same annotation works on any other resource type. Only the exact string values `"true"` and `"false"` are accepted — the webhook rejects any other value (for example `"True"`, `"1"`, or an empty string).
+
+## What continues and what pauses [k8s-pause-orchestration-behaviour]
+
+| Operation | Behaviour when paused |
+|---|---|
+| Certificate rotation (HTTP and transport) | Continues |
+| Service reconciliation | Continues |
+| User and role reconciliation | Continues |
+| Health monitoring and status updates | Continues |
+| Keystore reconciliation | Continues |
+| Pod disruption budget reconciliation | Continues |
+| StatefulSet or Deployment spec updates | Paused |
+| Rolling upgrades | Paused |
+| Scale up and scale down | Paused |
+| Volume expansion | Paused |
+
+## Observability [k8s-pause-orchestration-observability]
+
+When orchestration is paused, ECK sets an `OrchestrationPaused` condition on the resource status. If spec changes are pending at the time of the pause, ECK also emits a {{k8s}} warning event indicating that changes will be applied once the annotation is removed.
+
+```sh
+kubectl get elasticsearch quickstart -o jsonpath='{.status.conditions}' | jq .
+```
+
+On resume (annotation removed or set to `"false"`), ECK clears the condition and immediately applies any pending spec changes through the normal reconciliation path.
+

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -16,10 +16,10 @@ During maintenance windows, such as draining {{k8s}} nodes or applying infrastru
 
 ECK provides two annotations that affect reconciliation behavior:
 
-| Annotation | Effect |
-|---|---|
-| `eck.k8s.elastic.co/pause-orchestration: "true"` | Pauses spec-driven changes only. Housekeeping continues. |
-| `eck.k8s.elastic.co/managed: "false"` | Stops all reconciliation entirely. **Deprecated** — use `pause-orchestration` instead. |
+| Annotation | Availability | Effect |
+|---|---|---|
+| `eck.k8s.elastic.co/pause-orchestration: "true"` | {applies_to}`eck: ga 3.5+` | Pauses spec-driven changes only. Housekeeping continues. |
+| `eck.k8s.elastic.co/managed: "false"` | {applies_to}`eck: deprecated 3.5+` | Stops all reconciliation entirely. Deprecated in favor of `pause-orchestration`. |
 
 The key difference is that `pause-orchestration` keeps certificate rotation, service reconciliation, user and secret management, and health monitoring running. This avoids cluster degradation during extended maintenance windows.
 

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -5,11 +5,12 @@ applies_to:
     eck: ga 3.5
 products:
   - id: cloud-kubernetes
+description: Learn how to temporarily pause ECK spec-driven orchestration during maintenance windows.
 ---
 
 # Pause orchestration on ECK [k8s-pause-orchestration]
 
-During maintenance windows — such as draining {{k8s}} nodes or applying infrastructure changes — it can be useful to temporarily prevent ECK from applying spec changes to your Elastic resources. The `eck.k8s.elastic.co/pause-orchestration` annotation lets you freeze spec-driven orchestration on any ECK-managed resource while keeping essential housekeeping running.
+During maintenance windows, such as draining {{k8s}} nodes or applying infrastructure changes, you can temporarily prevent ECK from applying spec changes to your Elastic resources. The `eck.k8s.elastic.co/pause-orchestration` annotation lets you freeze spec-driven orchestration on any ECK-managed resource while keeping essential housekeeping running.
 
 ## Paused vs. fully unmanaged [k8s-pause-vs-unmanaged]
 

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -45,6 +45,12 @@ spec:
     count: 3
 ```
 
+Or using `kubectl annotate`:
+
+```sh
+kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/pause-orchestration=true --overwrite
+```
+
 The same annotation works on any other resource type. Only the exact string values `"true"` and `"false"` are accepted — the webhook rejects any other value (for example `"True"`, `"1"`, or an empty string).
 
 ## What continues and what pauses [k8s-pause-orchestration-behaviour]

--- a/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
+++ b/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md
@@ -10,7 +10,7 @@ description: Learn how to temporarily pause ECK spec-driven orchestration during
 
 # Pause orchestration on ECK [k8s-pause-orchestration]
 
-During maintenance windows, such as draining {{k8s}} nodes or applying infrastructure changes, you can temporarily prevent ECK from applying spec changes to your Elastic resources. The `eck.k8s.elastic.co/pause-orchestration` annotation lets you freeze spec-driven orchestration on any ECK-managed resource while keeping essential housekeeping running.
+During maintenance windows, such as draining {{k8s}} nodes or applying infrastructure changes, you can temporarily prevent ECK from applying spec changes to your Elastic resources. The `eck.k8s.elastic.co/pause-orchestration` annotation lets you freeze spec-driven orchestration on any ECK-managed resource while ECK continues essential maintenance tasks such as certificate rotation and health monitoring (see [What continues and what pauses](#k8s-pause-orchestration-behaviour)).
 
 ## Paused vs. fully unmanaged [k8s-pause-vs-unmanaged]
 

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -238,6 +238,7 @@ toc:
                       - file: deploy/cloud-on-k8s/k8s-kibana-plugins.md
                   - file: deploy/cloud-on-k8s/customize-pods.md
                   - file: deploy/cloud-on-k8s/propagate-labels-annotations.md
+                  - file: deploy/cloud-on-k8s/k8s-pause-orchestration.md
                   - file: deploy/cloud-on-k8s/manage-compute-resources.md
                   - file: deploy/cloud-on-k8s/recipes.md
                   - file: deploy/cloud-on-k8s/connect-to-external-elastic-resources.md

--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
@@ -111,14 +111,42 @@ Stepping over one of these versions, for example, upgrading ECK from 2.6 to 2.9,
 ::::
 
 
-If you have a very large {{es}} cluster or multiple {{stack}} deployments, this rolling restart might be disruptive or inconvenient. To have more control over when the pods belonging to a particular deployment should be restarted, you can [add an annotation](../../../troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md#k8s-exclude-resource) to the corresponding resources to temporarily exclude them from being managed by the operator. When the time is convenient, you can remove the annotation and let the rolling restart go through.
+If you have a very large {{es}} cluster or multiple {{stack}} deployments, this rolling restart might be disruptive or inconvenient. To have more control over when the pods belonging to a particular deployment should be restarted, temporarily pause orchestration on the corresponding resources. When the time is convenient, remove the annotation and let the rolling restart go through.
 
-::::{warning}
-Once a resource is excluded from being managed by ECK, you will not be able to add/remove nodes, upgrade Stack version, or perform other [orchestration tasks](../../deploy/cloud-on-k8s/configure-deployments.md) by updating the resource manifest. You must remember to remove the exclusion to ensure that your {{stack}} deployment is continually monitored and managed by the operator.
+:::::{tab-set}
+
+::::{tab-item} ECK 3.5 and later
+Use [pause orchestration](/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md), which stops spec-driven changes while keeping housekeeping running:
+
+```shell subs=true
+ANNOTATION='eck.k8s.elastic.co/pause-orchestration=true'
+
+# Pause a single Elasticsearch resource named "quickstart"
+kubectl annotate --overwrite elasticsearch quickstart $ANNOTATION
+
+# Pause all resources in the current namespace
+kubectl annotate --overwrite elastic --all $ANNOTATION
+
+# Pause all resources in all of the namespaces:
+for NS in $(kubectl get ns -o=custom-columns='NAME:.metadata.name' --no-headers); do kubectl annotate --overwrite elastic --all $ANNOTATION -n $NS; done
+```
+
+Once the operator has been upgraded and you are ready to resume orchestration, remove the annotation.
+
+```shell subs=true
+RM_ANNOTATION='eck.k8s.elastic.co/pause-orchestration-'
+
+# Resume a single {{es}} cluster named "quickstart"
+kubectl annotate elasticsearch quickstart $RM_ANNOTATION
+```
 ::::
 
-Exclude Elastic resources from being managed by the operator:
+::::{tab-item} Earlier versions
+Use the `eck.k8s.elastic.co/managed` annotation:
 
+:::{warning}
+Once a resource is excluded from being managed by ECK, you will not be able to add/remove nodes, upgrade Stack version, or perform other [orchestration tasks](../../deploy/cloud-on-k8s/configure-deployments.md) by updating the resource manifest. You must remember to remove the exclusion to ensure that your {{stack}} deployment is continually monitored and managed by the operator.
+:::
 
 ```shell subs=true
 ANNOTATION='eck.k8s.elastic.co/managed=false'
@@ -133,7 +161,7 @@ kubectl annotate --overwrite elastic --all $ANNOTATION
 for NS in $(kubectl get ns -o=custom-columns='NAME:.metadata.name' --no-headers); do kubectl annotate --overwrite elastic --all $ANNOTATION -n $NS; done
 ```
 
-Once the operator has been upgraded and you are ready to let the resource become managed again (triggering a rolling restart of pods in the process), remove the annotation.
+Once the operator has been upgraded and you are ready to resume orchestration, remove the annotation.
 
 ```shell subs=true
 RM_ANNOTATION='eck.k8s.elastic.co/managed-'
@@ -141,6 +169,9 @@ RM_ANNOTATION='eck.k8s.elastic.co/managed-'
 # Resume management of a single {{es}} cluster named "quickstart"
 kubectl annotate elasticsearch quickstart $RM_ANNOTATION
 ```
+::::
+
+:::::
 
 ::::{note}
 The ECK source repository contains a [shell script](https://github.com/elastic/cloud-on-k8s/tree/{{version.eck | M.M}}/hack/annotator) to assist with mass addition/deletion of annotations.

--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
@@ -141,7 +141,7 @@ kubectl annotate elasticsearch quickstart $RM_ANNOTATION
 ```
 ::::
 
-::::{applies-item} eck: ga 3.0-3.5
+::::{applies-item} eck: ga 3.0-3.4
 Use the `eck.k8s.elastic.co/managed` annotation:
 
 :::{warning}

--- a/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
+++ b/deploy-manage/upgrade/orchestrator/upgrade-cloud-on-k8s.md
@@ -113,9 +113,9 @@ Stepping over one of these versions, for example, upgrading ECK from 2.6 to 2.9,
 
 If you have a very large {{es}} cluster or multiple {{stack}} deployments, this rolling restart might be disruptive or inconvenient. To have more control over when the pods belonging to a particular deployment should be restarted, temporarily pause orchestration on the corresponding resources. When the time is convenient, remove the annotation and let the rolling restart go through.
 
-:::::{tab-set}
+:::::{applies-switch}
 
-::::{tab-item} ECK 3.5 and later
+::::{applies-item} eck: ga 3.5+
 Use [pause orchestration](/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md), which stops spec-driven changes while keeping housekeeping running:
 
 ```shell subs=true
@@ -141,7 +141,7 @@ kubectl annotate elasticsearch quickstart $RM_ANNOTATION
 ```
 ::::
 
-::::{tab-item} Earlier versions
+::::{applies-item} eck: ga 3.0-3.5
 Use the `eck.k8s.elastic.co/managed` annotation:
 
 :::{warning}

--- a/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
+++ b/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
@@ -204,7 +204,7 @@ kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/pause-orchestration
 ```
 ::::
 
-::::{applies-item} eck: ga 3.0-3.5
+::::{applies-item} eck: ga 3.0-3.4
 Use the `eck.k8s.elastic.co/managed` annotation:
 
 ```yaml

--- a/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
+++ b/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
@@ -180,11 +180,32 @@ kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/es-client-timeout=6
 
 ## Exclude resources from reconciliation [k8s-exclude-resource]
 
-For debugging purposes, you might want to temporarily prevent ECK from modifying Kubernetes resources belonging to a particular Elastic Stack resource. To do this, annotate the Elastic object with `eck.k8s.elastic.co/managed=false`. This annotation can be added to any of the following types of objects:
+For debugging purposes, you might want to temporarily prevent ECK from modifying Kubernetes resources belonging to a particular Elastic Stack resource. This annotation can be added to any of the following types of objects:
 
 * Elasticsearch
 * Kibana
 * ApmServer
+
+:::::{tab-set}
+
+::::{tab-item} ECK 3.5 and later
+Use [pause orchestration](/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md), which stops spec-driven changes while keeping housekeeping running:
+
+```yaml
+metadata:
+  annotations:
+    eck.k8s.elastic.co/pause-orchestration: "true"
+```
+
+Or in one line:
+
+```sh
+kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/pause-orchestration=true --overwrite
+```
+::::
+
+::::{tab-item} Earlier versions
+Use the `eck.k8s.elastic.co/managed` annotation:
 
 ```yaml
 metadata:
@@ -197,6 +218,9 @@ Or in one line:
 ```sh
 kubectl annotate elasticsearch quickstart --overwrite eck.k8s.elastic.co/managed=false
 ```
+::::
+
+:::::
 
 
 ## Get Kubernetes events [k8s-get-k8s-events]

--- a/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
+++ b/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
@@ -186,9 +186,9 @@ For debugging purposes, you might want to temporarily prevent ECK from modifying
 * Kibana
 * ApmServer
 
-:::::{tab-set}
+:::::{applies-switch}
 
-::::{tab-item} ECK 3.5 and later
+::::{applies-item} eck: ga 3.5+
 Use [pause orchestration](/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md), which stops spec-driven changes while keeping housekeeping running:
 
 ```yaml
@@ -204,7 +204,7 @@ kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/pause-orchestration
 ```
 ::::
 
-::::{tab-item} Earlier versions
+::::{applies-item} eck: ga 3.0-3.5
 Use the `eck.k8s.elastic.co/managed` annotation:
 
 ```yaml

--- a/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
+++ b/troubleshoot/deployments/cloud-on-k8s/troubleshooting-methods.md
@@ -180,16 +180,12 @@ kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/es-client-timeout=6
 
 ## Exclude resources from reconciliation [k8s-exclude-resource]
 
-For debugging purposes, you might want to temporarily prevent ECK from modifying Kubernetes resources belonging to a particular Elastic Stack resource. This annotation can be added to any of the following types of objects:
-
-* Elasticsearch
-* Kibana
-* ApmServer
+For debugging purposes, you might want to temporarily prevent ECK from modifying Kubernetes resources belonging to a particular Elastic Stack resource.
 
 :::::{applies-switch}
 
 ::::{applies-item} eck: ga 3.5+
-Use [pause orchestration](/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md), which stops spec-driven changes while keeping housekeeping running:
+Use [pause orchestration](/deploy-manage/deploy/cloud-on-k8s/k8s-pause-orchestration.md), which stops spec-driven changes while ECK continues essential maintenance tasks. The annotation is supported on all ECK-managed resource types.
 
 ```yaml
 metadata:
@@ -205,7 +201,12 @@ kubectl annotate elasticsearch quickstart eck.k8s.elastic.co/pause-orchestration
 ::::
 
 ::::{applies-item} eck: ga 3.0-3.4
-Use the `eck.k8s.elastic.co/managed` annotation:
+Use the `eck.k8s.elastic.co/managed` annotation. This annotation can be added to any of the following types of objects:
+
+* Elasticsearch
+* Kibana
+* ApmServer
+
 
 ```yaml
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Adds a new ECK 3.5 page documenting the `eck.k8s.elastic.co/pause-orchestration` annotation, covering supported resources, what continues vs. pauses, observability via the OrchestrationPaused condition, and its distinction from the deprecated `managed=false` annotation.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

Tool(s) and model(s) used: Sonnet 4.6
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Sonnet 4.6
-->

