### PR TITLE
docs: note Enterprise license for ES|QL approximation (#7481)

### DIFF
--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -459,9 +459,9 @@ stack: preview 9.4
 serverless: preview
 ```
 
-**Requirements**
-
-- For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, you need an Enterprise license.
+::::{admonition} Requirements
+For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, you need an Enterprise license.
+::::
 
 On large datasets, you can trade exact results for speed by enabling [approximate results](elasticsearch://reference/query-languages/esql/esql-query-approximation.md) for [`STATS`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-stats-by) queries. Approximation runs your `STATS` aggregations on a sample of the data and extrapolates to estimate results for the full dataset, so the numbers come out close to the exact ones. You can enable approximation in two ways:
 

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -464,6 +464,10 @@ On large datasets, you can trade exact results for speed by enabling [approximat
 - {applies_to}`{stack: "preview 9.5", serverless: "preview"}` From the {{kib}} UI, with [Fast mode](#esql-kibana-fast-mode-toggle).
 - From within a query, with the [`SET approximation`](#esql-kibana-approximation) directive.
 
+**Requirements**
+
+- For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, you need an Enterprise license.
+
 However you enable it, {{es}} applies approximation only when it actually speeds up the query. When your data is smaller than the sample size (by default around 1 million rows for `STATS ... BY` queries and 100,000 rows for other `STATS` queries), or a filter has already narrowed the results, {{es}} returns exact results instead. Approximation only works with certain aggregations, so functions such as `COUNT_DISTINCT`, `MIN`, `MAX`, and `LAST` always run exactly. Because approximate results are estimates, they can vary between runs and might drop low-frequency groups. For the full conditions and supported functions, refer to [Approximate `STATS` queries](elasticsearch://reference/query-languages/esql/esql-query-approximation.md).
 
 ### Use Fast mode [esql-kibana-fast-mode-toggle]

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -459,14 +459,14 @@ stack: preview 9.4
 serverless: preview
 ```
 
+**Requirements**
+
+- For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, you need an Enterprise license.
+
 On large datasets, you can trade exact results for speed by enabling [approximate results](elasticsearch://reference/query-languages/esql/esql-query-approximation.md) for [`STATS`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-stats-by) queries. Approximation runs your `STATS` aggregations on a sample of the data and extrapolates to estimate results for the full dataset, so the numbers come out close to the exact ones. You can enable approximation in two ways:
 
 - {applies_to}`{stack: "preview 9.5", serverless: "preview"}` From the {{kib}} UI, with [Fast mode](#esql-kibana-fast-mode-toggle).
 - From within a query, with the [`SET approximation`](#esql-kibana-approximation) directive.
-
-**Requirements**
-
-- For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, you need an Enterprise license.
 
 However you enable it, {{es}} applies approximation only when it actually speeds up the query. When your data is smaller than the sample size (by default around 1 million rows for `STATS ... BY` queries and 100,000 rows for other `STATS` queries), or a filter has already narrowed the results, {{es}} returns exact results instead. Approximation only works with certain aggregations, so functions such as `COUNT_DISTINCT`, `MIN`, `MAX`, and `LAST` always run exactly. Because approximate results are estimates, they can vary between runs and might drop low-frequency groups. For the full conditions and supported functions, refer to [Approximate `STATS` queries](elasticsearch://reference/query-languages/esql/esql-query-approximation.md).
 

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -460,7 +460,7 @@ serverless: preview
 ```
 
 ::::{admonition} Requirements
-For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, you need an Enterprise license.
+For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions).
 ::::
 
 On large datasets, you can trade exact results for speed by enabling [approximate results](elasticsearch://reference/query-languages/esql/esql-query-approximation.md) for [`STATS`](elasticsearch://reference/query-languages/esql/commands/processing-commands.md#esql-stats-by) queries. Approximation runs your `STATS` aggregations on a sample of the data and extrapolates to estimate results for the full dataset, so the numbers come out close to the exact ones. You can enable approximation in two ways:

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -460,6 +460,7 @@ serverless: preview
 ```
 
 ::::{admonition} Requirements
+:applies_to: { ess:, ece:, eck:, self: }
 For {{ech}}, {{ece}}, and {{eck}} deployments or self-managed clusters, approximation requires an [Enterprise subscription](https://www.elastic.co/subscriptions).
 ::::
 


### PR DESCRIPTION
## Summary

This PR addresses #7481 with the following changes:

- **`explore-analyze/query-filter/languages/esql-kibana.md`**: Add an Enterprise license **Requirements** note at the start of [Get faster results with approximate `STATS`](https://www.elastic.co/docs/explore-analyze/query-filter/languages/esql-kibana#approximation-fast-mode), before the enablement intro, matching the AI assistance pattern on the same page. The prerequisite applies to approximation itself (both **Fast mode** and `SET approximation`), not only the UI toggle.

Related product work: [elastic/kibana#279718](https://github.com/elastic/kibana/issues/279718) will disable **Fast mode** on Basic/Platinum and show a tooltip. That issue is **not** closed by this PR. After that Kibana change merges, verify the final unavailable/tooltip copy and add it under **Use Fast mode** if needed.

Verified against Elasticsearch `EsqlLicenseChecker.checkQueryApproximation` ([elastic/elasticsearch#147097](https://github.com/elastic/elasticsearch/pull/147097)): `"A valid Enterprise license is required to use ES|QL query approximation."`

Companion ES reference PR: [elastic/elasticsearch#154530](https://github.com/elastic/elasticsearch/pull/154530).

## Resolves

Closes #7481

## Follow-up

- After kibana#279718 merges: confirm Fast mode unavailable UI copy at HEAD.

---

> **AI-generated draft** — created with Claude Sonnet 4.6.
> Review all generated content for factual accuracy before merging.