### PR TITLE
docs: Mark ES|QL views note as available in serverless (#7437)

### DIFF
--- a/explore-analyze/discover/try-esql.md
+++ b/explore-analyze/discover/try-esql.md
@@ -106,7 +106,7 @@ When you write a query, the {{esql}} editor includes two interactive browsers th
 - **Fields browser**: lists fields for the data sources currently in your query and lets you insert one field at a time at the cursor position.
 
 :::{note}
-:applies_to: {stack: preview 9.4.0, serverless: unavailable}
+:applies_to: {stack: preview 9.4.0, serverless: preview}
 [{{esql}} views](elasticsearch://reference/query-languages/esql/esql-views.md) aren't shown in the data source browser but they're visible through the autocomplete menu suggestions.
 :::
 


### PR DESCRIPTION
## Summary

Follow-up to #7437, which corrected the page-level availability metadata on the ES|QL Views reference (in `elastic/elasticsearch`, [PR #154579](https://github.com/elastic/elasticsearch/pull/154579)).

ES|QL views are now available in serverless as a preview feature: Elasticsearch exposes the views API with `@ServerlessScope(Scope.PUBLIC)` and `stability: experimental` in the REST specs, and Kibana enabled views in serverless via [elastic/kibana#274819](https://github.com/elastic/kibana/pull/274819). The Discover ES|QL editor note that describes how views surface in the editor was still tagged `serverless: unavailable`.

- **`explore-analyze/discover/try-esql.md`**: update the views note `applies_to` from `serverless: unavailable` to `serverless: preview`.

The described behavior is unchanged and verified at Kibana `main`: views are surfaced through the `FROM` autocomplete suggestions (`get_command_context.ts` calls `getViews()`) but not listed in the data source browser (`use_data_source_browser.ts` doesn't fetch views). Confirmed on a live instance across stack and serverless.

Tested on live serverless ✅ 

## Related

Related to #7437

---

> **AI-generated draft** — created with Claude (Opus 4.8).
> Review all generated content for factual accuracy before merging.