### PR TITLE
docs: document Vega-Lite visualizations in Agent Builder chat (#7445)

### DIFF
--- a/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md
+++ b/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md
@@ -123,6 +123,8 @@ You can also go back to any previously generated version of a dashboard in the c
 
 Agents create [{{esql}}](/explore-analyze/visualize/esorql.md)-powered visualizations. If a dashboard contains [data view](/explore-analyze/find-and-organize/data-views.md)-based visualizations, the agent asks to replace them with {{esql}} equivalents when making changes.
 
+{applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` By default, the agent renders visualizations with [Lens](/explore-analyze/visualize/lens.md). When a request is better expressed with Vega-Lite, such as small multiples, layered or combination charts, scatter plots, or bubble charts, the agent generates a Vega-Lite visualization instead. It also uses Vega-Lite when you ask for a Vega or custom visualization. You can create and edit both types through chat, preview them inline with a time picker, and select **Save to dashboard** to add them to a dashboard. The agent supports Vega-Lite specifications only, not raw Vega. Chart types that Vega-Lite can't express, such as Sankey, radar, or network diagrams, fall back to the closest supported chart.
+
 Agents can also create markdown panels and collapsible sections.
 
 ## Related pages

--- a/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md
+++ b/explore-analyze/ai-features/agent-builder/builtin-skills-reference.md
@@ -33,7 +33,7 @@ Platform skills are available across all deployment types. They cover core capab
 ### Core skills
 
 $$$agent-builder-visualization-creation-skill$$$ `visualization-creation` {applies_to}`stack: ga 9.4+`
-:   Creates standalone or reusable Lens visualizations from index and field context. Use when a user asks for a chart, metric, trend, or breakdown visualization, or wants to update an existing one.
+:   Creates standalone or reusable Lens or Vega-Lite visualizations from index and field context. Use when a user asks for a chart, metric, trend, or breakdown visualization, or wants to update an existing one.
 
     :::{dropdown} Assigned tools
     `platform.core.generate_esql`, `platform.core.execute_esql`, `platform.core.create_visualization`

--- a/explore-analyze/dashboards/create-dashboards-using-ai.md
+++ b/explore-analyze/dashboards/create-dashboards-using-ai.md
@@ -38,7 +38,9 @@ Use {{agent-builder}} when you want to:
 
 {{agent-builder}} generates ES|QL-powered visualizations, markdown panels, and collapsible sections. For panel types the agent does not support yet, such as controls, use the [Dashboards API](create-dashboards-programmatically.md) directly.
 
-Refer to [Chat with {{agent-builder}} agents](/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md).
+{applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Visualizations render with Lens by default. For chart shapes Lens can't express, such as small multiples, combination charts, and scatter or bubble charts, the agent can use Vega-Lite instead.
+
+Refer to [Chat with {{agent-builder}} agents](/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md) for renderer guidance and limitations.
 
 ## {{product.kibana}} dashboards agent skill [dashboards-agent-skill]
 ```{applies_to}

--- a/explore-analyze/dashboards/create-dashboards-using-ai.md
+++ b/explore-analyze/dashboards/create-dashboards-using-ai.md
@@ -36,11 +36,9 @@ Use {{agent-builder}} when you want to:
 - Explore an unfamiliar data source by asking the agent to surface and visualize key fields
 - Prototype a dashboard through conversation, then save it when you are satisfied
 
-{{agent-builder}} generates ES|QL-powered visualizations, markdown panels, and collapsible sections. For panel types the agent does not support yet, such as controls, use the [Dashboards API](create-dashboards-programmatically.md) directly.
+{{agent-builder}} generates ES|QL-powered visualizations, Vega-Lite visualizations, markdown panels, and collapsible sections. For panel types the agent does not support yet, such as controls, use the [Dashboards API](create-dashboards-programmatically.md) directly.
 
-{applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` Visualizations render with Lens by default. For chart shapes Lens can't express, such as small multiples, combination charts, and scatter or bubble charts, the agent can use Vega-Lite instead.
-
-Refer to [Chat with {{agent-builder}} agents](/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md) for renderer guidance and limitations.
+Refer to [Chat with {{agent-builder}} agents](/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md).
 
 ## {{product.kibana}} dashboards agent skill [dashboards-agent-skill]
 ```{applies_to}


### PR DESCRIPTION
## Summary

This PR addresses #7445 with the following changes:

- **`explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md`**: In *Supported panel types*, add version-scoped guidance explaining that the agent renders with Lens by default and uses Vega-Lite for shapes Lens can't express (small multiples, layered or combination charts, scatter plots, bubble charts) or when you ask for a Vega/custom visualization, that you can create, edit, preview inline with a time picker, and **Save to dashboard**, and that support is Vega-Lite specifications only (not raw Vega), with unsupported shapes falling back to the closest chart.
- **`explore-analyze/dashboards/create-dashboards-using-ai.md`**: In the *Agent Builder* section, add Vega-Lite visualizations to the supported output summary.
- **`explore-analyze/ai-features/agent-builder/builtin-skills-reference.md`**: Update the `visualization-creation` skill description to note it creates Lens or Vega-Lite visualizations.

New content on the dedicated dashboards-and-visualizations page is scoped `stack: preview 9.5` and `serverless: preview`, matching the pages' existing preview framing. The existing ES|QL/Lens content is preserved for 9.4+ per the cumulative docs model.

## Resolves

Closes #7445

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.