### PR TITLE
docs: note automatic embedding model selection for installed documentation (#7433)

### DIFF
--- a/explore-analyze/ai-features/manage-access-to-ai-assistant.md
+++ b/explore-analyze/ai-features/manage-access-to-ai-assistant.md
@@ -37,6 +37,7 @@ The **GenAI Settings** page has the following settings:
 - **Chat experience**: Select whether to use AI Assistant or AI Agent. To learn about the differences, go to [Compare AI Agent and AI Assistant](/explore-analyze/ai-features/ai-chat-experiences/ai-agent-or-ai-assistant.md).
 - **Token usage tracking**: Turn on tracking of token usage by AI features.
 - **Documentation**: Install Elastic documentation or content from Security labs to improve Agent Builder responses.
+  - When you install this content, {{kib}} automatically selects the best available embedding model. Elastic documentation uses Jina v5 (`.jina-embeddings-v5-text-small`) when that endpoint is available, and otherwise falls back to ELSER (`.elser-2-elastic` or `.elser-2-elasticsearch`). Security labs content uses ELSER.
 ::::
 ::::{applies-item} stack: ga 9.4+
 
@@ -50,6 +51,7 @@ The **GenAI Settings** page has the following settings:
 - **AI feature visibility**: This button opens the current Space's settings page, where you can specify which features are enabled in your environment, including AI-powered features.
 - **Chat experience**: Select whether to use AI Assistant or AI Agent. To learn about the differences, go to [Compare AI Agent and AI Assistant](/explore-analyze/ai-features/ai-chat-experiences/ai-agent-or-ai-assistant.md).
 - **Documentation**: Install Elastic documentation or content from Security labs to improve Agent Builder responses.
+  - {applies_to}`stack: ga 9.5` When you install this content, {{kib}} automatically selects the best available embedding model. Elastic documentation uses Jina v5 (`.jina-embeddings-v5-text-small`) when that endpoint is available, and otherwise falls back to ELSER (`.elser-2-elastic` or `.elser-2-elasticsearch`). Security labs content uses ELSER.
 ::::
 ::::{applies-item} stack: ga 9.2-9.3
 


### PR DESCRIPTION
## Summary

This PR addresses #7433. Kibana 9.5 and Serverless now pick the embedding endpoint automatically when you install documentation from **GenAI Settings**, instead of always using ELSER. The install action and workflow are unchanged, so this adds a short background note for administrators and troubleshooting.

- **`explore-analyze/ai-features/manage-access-to-ai-assistant.md`**: adds a sub-bullet under the **Documentation** setting explaining that Elastic documentation prefers Jina v5 (`.jina-embeddings-v5-text-small`) when available and otherwise falls back to ELSER (`.elser-2-elastic` or `.elser-2-elasticsearch`), while Security labs content uses ELSER. Added unscoped in the Serverless block and scoped to `stack: ga 9.5` in the 9.4+ block (9.4 keeps the previous ELSER-only behavior).

Verified against Kibana [#275461](https://github.com/elastic/kibana/pull/275461) at HEAD: endpoint IDs confirmed in `inference_endpoints.ts`, selection logic in `default_inference_id.ts`.

## Resolves

Closes #7433

## Note for reviewers

This is transparent model-selection logic with no user-facing surface, so a future change is unlikely to trigger a docs issue. The line most likely to go stale is **"Security labs content uses ELSER"** — the implementation PR notes that Security Labs will move to Jina "once Jina versions are available." Worth rechecking when Jina support expands.

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.
