### PR TITLE
Deployment types surface on install page

### DIFF
--- a/deploy-manage/deploy/_snippets/deploy-options.md
+++ b/deploy-manage/deploy/_snippets/deploy-options.md
@@ -1,5 +1,5 @@
 :::{admonition} Simplify the deployment process
-Self-managed clusters are useful for local development, and for exploring Elastic features. However, Elastic offers several deployment options that can simplify the process of deploying and managing multi-node deployments, especially in production. They also allow you to deploy and manage multiple deployments from a single surface.
+Self-managed clusters are useful for local development, and for exploring {{es}} features. However, Elastic offers several deployment options that can simplify the process of deploying and managing multi-node deployments, especially in production. They also allow you to deploy and manage multiple deployments from a single surface.
 
 Managed by Elastic:
 * [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md)

--- a/deploy-manage/deploy/_snippets/deploy-options.md
+++ b/deploy-manage/deploy/_snippets/deploy-options.md
@@ -1,0 +1,13 @@
+:::{admonition} Simplify the deployment process
+Self-managed clusters are useful for local development, and for exploring Elastic features. However, Elastic offers several deployment options that can simplify the process of deploying and managing multi-node deployments, especially in production. They also allow you to deploy and manage multiple deployments from a single surface.
+
+Managed by Elastic:
+* [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md)
+* [{{ech}}](/deploy-manage/deploy/elastic-cloud/cloud-hosted.md)
+
+Self-hosted options:
+* [{{eck}}](/deploy-manage/deploy/cloud-on-k8s.md)
+* [{{ece}}](/deploy-manage/deploy/cloud-enterprise.md)
+
+For a comparison of these deployment options, refer to [Choosing your deployment type](/deploy-manage/deploy.md#choosing-your-deployment-type) and [](/deploy-manage/deploy/deployment-comparison.md).
+:::

--- a/deploy-manage/deploy/self-managed.md
+++ b/deploy-manage/deploy/self-managed.md
@@ -15,18 +15,7 @@ If you want to install Elastic on your own premises without the assistance of an
 
 To quickly set up {{es}} and {{kib}} in Docker for local development or testing, jump to [](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md).
 
-:::{admonition} Simplify the deployment process
-Self-managed clusters are useful for local development, and for exploring Elastic features. However, Elastic offers several deployment options that can simplify the process of deploying and managing multi-node deployments, especially in production. They also allow you to deploy and manage multiple deployments from a single surface.
-
-Managed by Elastic:
-* [{{serverless-full}}](/deploy-manage/deploy/elastic-cloud/serverless.md)
-* [{{ech}}](/deploy-manage/deploy/elastic-cloud/cloud-hosted.md)
-
-Self-hosted options:
-* [{{eck}}](/deploy-manage/deploy/cloud-on-k8s.md)
-* [{{ece}}](/deploy-manage/deploy/cloud-enterprise.md)
-
-For a comparison of these deployment options, refer to [Choosing your deployment type](/deploy-manage/deploy.md#choosing-your-deployment-type) and [](/deploy-manage/deploy/deployment-comparison.md).
+:::{include} /deploy-manage/deploy/_snippets/deploy-options.md
 :::
 
 :::{admonition} Use cloud services in your self-managed cluster with Cloud Connect

--- a/deploy-manage/deploy/self-managed/installing-elasticsearch.md
+++ b/deploy-manage/deploy/self-managed/installing-elasticsearch.md
@@ -24,6 +24,9 @@ This section includes information on how to set up {{es}} and get it running, in
 
 To quickly set up {{es}} and {{kib}} in Docker for local development or testing, jump to [](/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md).
 
+:::{include} /deploy-manage/deploy/_snippets/deploy-options.md
+:::
+
 ## Installation methods
 
 If you want to install and manage {{es}} yourself, you can:

--- a/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md
+++ b/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md
@@ -17,7 +17,7 @@ products:
 The instructions on this page are for **local development only**. Do not use this configuration for production deployments, because it is not secure. Refer to [deployment options](/get-started/deployment-options.md) for a list of production deployment options.
 ::::
 
-Quickly set up {{es}} and {{kib}} in Docker for local development or testing, using this one-liner in the command line. This setup comes with a one-month trial license that includes all Elastic features.
+Quickly set up {{es}} and {{kib}} in Docker for local development or testing, using this one-liner in the command line. This setup comes with a one-month trial license that includes all {{es}} features.
 
 As an alternative, you can also explore {{es}} and {{kib}} by [signing up for a free {{ecloud}} trial](https://cloud.elastic.co/registration).
 

--- a/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md
+++ b/deploy-manage/deploy/self-managed/local-development-installation-quickstart.md
@@ -9,7 +9,7 @@ products:
   - id: elasticsearch
 ---
 
-# Local development installation (quickstart) [run-elasticsearch-locally]
+# Install {{es}} locally (quickstart) [run-elasticsearch-locally]
 
 ::::{warning}
 **DO NOT USE THESE INSTRUCTIONS FOR PRODUCTION DEPLOYMENTS**
@@ -17,11 +17,9 @@ products:
 The instructions on this page are for **local development only**. Do not use this configuration for production deployments, because it is not secure. Refer to [deployment options](/get-started/deployment-options.md) for a list of production deployment options.
 ::::
 
-Quickly set up {{es}} and {{kib}} in Docker for local development or testing, using this one-liner in the command line.
+Quickly set up {{es}} and {{kib}} in Docker for local development or testing, using this one-liner in the command line. This setup comes with a one-month trial license that includes all Elastic features.
 
-:::{info}
-This setup comes with a one-month trial license that includes all Elastic features.
-:::
+As an alternative, you can also explore {{es}} and {{kib}} by [signing up for a free {{ecloud}} trial](https://cloud.elastic.co/registration).
 
 ## Prerequisites [local-dev-prerequisites]
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
when people search for install elasticsearch, they get driven to the functional local install options page

adding a note to make people aware of {{ecloud}} and other deployment types one level lower (on this high seo value page), and also changing the title and positioning of the quickstart so it might surface in "install" queries. also added a cloud trial cta to the quickstart page

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

