### PR TITLE
Documents `cases.addAttachments` workflow step

### DIFF
--- a/explore-analyze/workflows/authoring-techniques/choose-the-right-step.md
+++ b/explore-analyze/workflows/authoring-techniques/choose-the-right-step.md
@@ -41,6 +41,7 @@ For an alphabetical catalog of every step type, refer to the [Step type index](/
 | Look up a case | [`cases.getCase`](/explore-analyze/workflows/steps/cases.md#cases-getcase), [`cases.findCases`](/explore-analyze/workflows/steps/cases.md#cases-findcases), [`cases.getCasesByAlertId`](/explore-analyze/workflows/steps/cases.md#cases-getcasesbyalertid) |
 | Change status, severity, or tags | [`cases.updateCase`](/explore-analyze/workflows/steps/cases.md#cases-updatecase) or the field-specific `set*` steps |
 | Attach alerts or observables | [`cases.addAlerts`](/explore-analyze/workflows/steps/cases.md#cases-addalerts), [`cases.addObservables`](/explore-analyze/workflows/steps/cases.md#cases-addobservables) |
+| Attach comments, alerts, dashboards, and more | [`cases.addAttachments`](/explore-analyze/workflows/steps/cases.md#cases-addattachments) {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` |
 | Add a comment | [`cases.addComment`](/explore-analyze/workflows/steps/cases.md#cases-addcomment) |
 | Close the case | [`cases.closeCase`](/explore-analyze/workflows/steps/cases.md#cases-closecase) |
 | Assign or unassign | [`cases.assignCase`](/explore-analyze/workflows/steps/cases.md#cases-assigncase), [`cases.unassignCase`](/explore-analyze/workflows/steps/cases.md#cases-unassigncase) |

--- a/explore-analyze/workflows/reference/cheat-sheet.md
+++ b/explore-analyze/workflows/reference/cheat-sheet.md
@@ -87,7 +87,7 @@ Minimum schedule interval: **1 minute**. Refer to [Triggers](/explore-analyze/wo
 |---|---|
 | Query {{es}} | `elasticsearch.search`, `elasticsearch.esql.query` |
 | Write to {{es}} | `elasticsearch.index`, `elasticsearch.bulk`, `elasticsearch.update` |
-| Manage cases | `cases.createCase`, `cases.updateCase`, `cases.addComment`, `cases.addAlerts`, `cases.pushCases` |
+| Manage cases | `cases.createCase`, `cases.updateCase`, `cases.addComment`, `cases.addAlerts`, `cases.addAttachments`, `cases.pushCases` |
 | Manage alerts | `kibana.SetAlertsStatus`, `kibana.SetAlertTags` (PascalCase) |
 | Call an API | `http` (with optional `connector-id`) |
 | Call a service | `<connector>.<action>` (for example, `slack.postMessage`, `jira.createIssue`) |

--- a/explore-analyze/workflows/reference/step-types.md
+++ b/explore-analyze/workflows/reference/step-types.md
@@ -24,6 +24,7 @@ Every step type available for Elastic Workflows, ordered alphabetically. Use thi
 | [`ai.prompt`](/explore-analyze/workflows/steps/ai-steps.md#ai-prompt) | AI | Prompt a model, optionally with structured output. |
 | [`ai.summarize`](/explore-analyze/workflows/steps/ai-steps.md#ai-summarize) | AI | Summarize content with an LLM. |
 | [`cases.addAlerts`](/explore-analyze/workflows/steps/cases.md#cases-addalerts) | Cases | Attach detection alerts to a case. |
+| [`cases.addAttachments`](/explore-analyze/workflows/steps/cases.md#cases-addattachments) {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` | Cases | Attach several attachment types to a case in one request. |
 | [`cases.addComment`](/explore-analyze/workflows/steps/cases.md#cases-addcomment) | Cases | Add a comment to a case. |
 | [`cases.addEvents`](/explore-analyze/workflows/steps/cases.md#cases-addevents) | Cases | Attach events to a case. |
 | [`cases.addObservables`](/explore-analyze/workflows/steps/cases.md#cases-addobservables) | Cases | Add observables (IPs, hashes, domains) to a case. |

--- a/explore-analyze/workflows/steps/cases.md
+++ b/explore-analyze/workflows/steps/cases.md
@@ -534,14 +534,14 @@ Each entry in `attachments` uses a `type` field that selects the payload shape. 
 
 Common `type` values include:
 
-- `comment`
-- `stack.alert`, `security.alert`, `observability.alert`
-- `security.event`, `security.endpoint`, `security.indicator`, `security.timeline`
+- `comment` ([`cases.addComment`](#cases-addcomment))
+- `stack.alert`, `security.alert`, `observability.alert` ([`cases.addAlerts`](#cases-addalerts))
+- `security.event` ([`cases.addEvents`](#cases-addevents)), `security.endpoint`, `security.indicator`, `security.timeline`
 - `osquery`
 - `dashboard`, `map`, `discoverSession`
 - `lens` (by saved-object reference: `attachmentId` plus `metadata.title` and `metadata.soType: "lens"`)
 
-Which types appear depends on the solutions and plugins enabled in your deployment. The YAML editor lists the types available in your environment.
+Which types appear depends on the solutions and plugins enabled in your deployment. Use the example below for the payload shapes this step expects.
 
 | Parameter | Location | Type | Required | Description |
 |---|---|---|---|---|

--- a/explore-analyze/workflows/steps/cases.md
+++ b/explore-analyze/workflows/steps/cases.md
@@ -3,7 +3,7 @@ navigation_title: Cases
 applies_to:
   stack: ga 9.4+
   serverless: ga
-description: Reference for the 28 Cases action steps that let workflows create, query, update, attach content, push to external connectors, and manage the lifecycle of cases in any Cases-enabled app.
+description: Reference for the Cases action steps that let workflows create, query, update, attach content, push to external connectors, and manage the lifecycle of cases in any Cases-enabled app.
 products:
   - id: kibana
   - id: cloud-serverless
@@ -66,7 +66,7 @@ Every `cases.*` step shares the same conventions, so once you learn one step the
 
 ## Step catalog [workflows-cases-catalog]
 
-The 28 Cases steps group into seven operational categories. Jump to any step:
+The Cases steps group into seven operational categories. Jump to any step:
 
 **Create, fetch, and search**
 [`cases.createCase`](#cases-createcase) ·
@@ -93,6 +93,7 @@ The 28 Cases steps group into seven operational categories. Jump to any step:
 [`cases.addAlerts`](#cases-addalerts) ·
 [`cases.addEvents`](#cases-addevents) ·
 [`cases.addObservables`](#cases-addobservables) ·
+[`cases.addAttachments`](#cases-addattachments) ·
 [`cases.getAllAttachments`](#cases-getallattachments)
 
 **Tags and assignees**
@@ -518,6 +519,71 @@ Add observables (indicators of compromise such as IPs, file hashes, domains, or 
 ```
 
 The `typeKey` must match one of the built-in observable type keys: `observable-type-ipv4`, `observable-type-ipv6`, `observable-type-url`, `observable-type-domain`, or `observable-type-file-hash`. Use `observable-type-file-hash` for all hash algorithms (MD5, SHA-1, SHA-256, and so on).
+
+### `cases.addAttachments` [cases-addattachments]
+
+```{applies_to}
+stack: ga 9.5+
+serverless: ga
+```
+
+Attach one or more items to a case in a single request. Use this when you need to add several attachment types together, such as a comment, an alert, and a dashboard, instead of chaining dedicated steps such as [`cases.addComment`](#cases-addcomment) or [`cases.addAlerts`](#cases-addalerts).
+
+Each entry in `attachments` uses a `type` field that selects the payload shape. Required fields depend on that type (`data`, `attachmentId`, and `metadata` appear only when the type needs them). The YAML editor narrows the available fields after you set `type`. Don't set `owner`. The step injects it from the target case.
+
+Common `type` values include:
+
+- `comment`
+- `stack.alert`, `security.alert`, `observability.alert`
+- `security.event`, `security.endpoint`, `security.indicator`, `security.timeline`
+- `osquery`
+- `dashboard`, `map`, `discoverSession`
+- `lens` (by saved-object reference: `attachmentId` plus `metadata.title` and `metadata.soType: "lens"`)
+
+Which types appear depends on the solutions and plugins enabled in your deployment. The YAML editor lists the types available in your environment.
+
+| Parameter | Location | Type | Required | Description |
+|---|---|---|---|---|
+| `case_id` | `with` | string | Yes | Case ID. |
+| `attachments` | `with` | array | Yes | Array of `{ type, attachmentId?, data?, metadata? }` objects (1–100). |
+
+Output: `{ case: object }` (the updated case).
+
+```yaml
+- name: attach_attachments
+  type: cases.addAttachments
+  with:
+    case_id: "{{ steps.create_case.output.case.id }}"
+    attachments:
+      - type: "comment"
+        data:
+          content: "Investigating this incident."
+      - type: "security.alert"
+        attachmentId: "{{ event.alerts[0]._id }}"
+        metadata:
+          index: "{{ event.alerts[0]._index }}"
+          rule:
+            id: "{{ event.rule.id }}"
+            name: "{{ event.rule.name }}"
+      - type: "dashboard"
+        attachmentId: "dashboard-id-1"
+        metadata:
+          title: "Security dashboard"
+          soType: "dashboard"
+```
+
+:::{note}
+These attachment types aren't available through this step:
+
+- File attachments
+- Anomaly charts, anomaly swim lane, and single metric viewer
+- Change point detection, log pattern analysis, and log rate analysis
+- Lens visualizations that include the full visualization state instead of a saved-object reference
+
+For those, use the dedicated Cases UI flows. You can still attach a Lens visualization by saved-object reference with `type: lens`.
+:::
+
+% TODO: After https://github.com/elastic/docs-content/pull/7450 merges, link "Cases UI flows" above to explore-analyze/cases/attach-objects-to-cases.md (Attach objects to cases).
 
 ### `cases.getAllAttachments` [cases-getallattachments]
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Fixes https://github.com/elastic/docs-content/issues/7466.

Adds the `cases.addAttachments` step to the Cases action steps reference, including parameters, supported attachment types, unavailable types, and a YAML example. Also updates the step catalog count, step type index, cheat sheet, and choose-the-right-step guidance.


## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes - Cursor + Claude  
- [ ] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

