### PR TITLE
Documents `security.enableRule` and `security.disableRule` workflow steps

### DIFF
--- a/explore-analyze/toc.yml
+++ b/explore-analyze/toc.yml
@@ -578,6 +578,7 @@ toc:
                   - file: workflows/steps/elasticsearch.md
                   - file: workflows/steps/kibana.md
                   - file: workflows/steps/cases.md
+                  - file: workflows/steps/security.md
                   - file: workflows/steps/streams.md
                   - file: workflows/steps/external-systems-apps.md
               - file: workflows/steps/flow-control-steps.md

--- a/explore-analyze/workflows/reference/step-types.md
+++ b/explore-analyze/workflows/reference/step-types.md
@@ -83,6 +83,8 @@ Every step type available for Elastic Workflows, ordered alphabetically. Use thi
 | [`kibana.streams.list`](/explore-analyze/workflows/steps/streams.md#kibana-streams-list) | Streams (tech preview) | List available streams. |
 | [`loop.break`](/explore-analyze/workflows/steps/loop-break.md) | Flow control | Exit the innermost loop. |
 | [`loop.continue`](/explore-analyze/workflows/steps/loop-continue.md) | Flow control | Skip to the next iteration. |
+| [`security.disableRule`](/explore-analyze/workflows/steps/security.md#security-disablerule) | Security | Disable one or more detection rules by ID list or KQL query, with partial-failure reporting. {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` |
+| [`security.enableRule`](/explore-analyze/workflows/steps/security.md#security-enablerule) | Security | Enable one or more detection rules by ID list or KQL query, with partial-failure reporting. {applies_to}`stack: ga 9.5+` {applies_to}`serverless: ga` |
 | [`switch`](/explore-analyze/workflows/steps/switch.md) | Flow control | Multi-way dispatch. |
 | [`wait`](/explore-analyze/workflows/steps/wait.md) | Flow control | Pause for a fixed duration. |
 | [`waitForInput`](/explore-analyze/workflows/steps/wait-for-input.md) | Flow control | Pause for human input (human-in-the-loop). |

--- a/explore-analyze/workflows/steps/action-steps.md
+++ b/explore-analyze/workflows/steps/action-steps.md
@@ -49,6 +49,19 @@ Cases actions provide 27 step types for creating, querying, updating, and managi
 
 Refer to [](/explore-analyze/workflows/steps/cases.md) for the complete 27-step catalog.
 
+## Security
+
+```{applies_to}
+stack: ga 9.5+
+serverless: ga
+```
+
+Security actions provide named steps for {{elastic-sec}} detection-rule management. Use Security actions to:
+
+* Enable or disable detection rules by ID list or query (`security.enableRule`, `security.disableRule`)
+
+Refer to [](/explore-analyze/workflows/steps/security.md) for more information.
+
 ## Streams
 
 ```{applies_to}

--- a/explore-analyze/workflows/steps/security.md
+++ b/explore-analyze/workflows/steps/security.md
@@ -1,0 +1,156 @@
+---
+navigation_title: Security
+applies_to:
+  stack: ga 9.5+
+  serverless: ga
+description: Reference for Security action steps that enable or disable detection rules from a workflow by rule ID list or KQL query.
+products:
+  - id: kibana
+  - id: cloud-serverless
+  - id: cloud-hosted
+  - id: cloud-enterprise
+  - id: cloud-kubernetes
+  - id: elastic-stack
+---
+
+# Security action steps [workflows-security-steps]
+
+Security action steps let workflows enable or disable {{elastic-sec}} detection rules. Prefer these named `security.*` steps over a generic [`kibana.request`](/explore-analyze/workflows/steps/kibana.md#kibana-request) call when you need to change rule state.
+
+Both steps on this page are authenticated automatically using the permissions or API key of the identity executing the workflow, the same model as the [`kibana.*`](/explore-analyze/workflows/steps/kibana.md) and [`cases.*`](/explore-analyze/workflows/steps/cases.md) steps.
+
+Use Security steps for patterns like:
+
+- Enable a rule (or set of rules) after a maintenance window ends.
+- Disable noisy or high-volume rules when a threshold is crossed, then re-enable them later.
+- Drive rule lifecycle changes from a scheduled audit or an on-demand manual workflow.
+
+## Shared conventions [workflows-security-conventions]
+
+The rule management steps share the same conventions.
+
+**All parameters live under `with`.** Both `ids` and `query` are `with`-level fields.
+
+**Selector: provide exactly one of `ids` or `query`.** `ids` is an explicit list of rule UUIDs. `query` is a KQL string that selects rules by their attributes.
+
+% SME/eng: confirm whether workflow Save (Zod validation) catches the exactly-one-of refine, or only runtime fails. Source comment in bulk_action_schemas.ts says "workflow validation time"; issue #7352 says runtime-only. First-pass wording below follows the issue.
+:::{note}
+You must set either `ids` or `query`. The YAML editor does not catch a missing or duplicate selector. If you set both or omit both, the workflow can still save, and the step fails when it runs.
+:::
+
+**Use the rule `id` (UUID), not `rule_id`.** The `ids` field takes the rule object's `id`. The list must contain at least one ID. An empty `query` is not allowed because it would match every rule.
+
+**Success and failure.** Rules already in the target state count as **skipped**, not failures. The step succeeds if at least one targeted rule was updated or skipped. Per-rule failures appear in the output `errors` array. The step fails if every targeted rule fails (including when a rule is not found) or another error stops the step.
+
+**Per-rule handling.** To act on the outcome of individual rules, search for the rules first and use a [`foreach`](/explore-analyze/workflows/steps/foreach.md) step to invoke enable or disable once per rule.
+
+:::{include} ../_snippets/schema-location-legend.md
+:::
+
+## Step catalog [workflows-security-catalog]
+
+Jump to a step:
+
+**Rules**
+[`security.enableRule`](#security-enablerule) ·
+[`security.disableRule`](#security-disablerule)
+
+---
+
+## Rules
+
+### `security.enableRule` [security-enablerule]
+
+Enable one or more detection rules by rule ID list or KQL query.
+
+| Parameter | Location | Type | Required | Description |
+|---|---|---|---|---|
+| `ids` | `with` | `string[]` (rule UUIDs) | Provide exactly one of `ids`/`query` | Rule `id` UUIDs to enable (at least one). Use the rule `id`, not `rule_id`. |
+| `query` | `with` | string (KQL) | Provide exactly one of `ids`/`query` | KQL query selecting the rules to enable. Cannot be empty. |
+
+```yaml
+# Enable a single rule by id
+- name: enable_rule
+  type: security.enableRule
+  with:
+    ids:
+      - "{{ variables.rule_id }}"
+```
+
+```yaml
+# Enable every rule matching a query
+- name: enable_high_severity_rules
+  type: security.enableRule
+  with:
+    query: 'alert.attributes.params.severity: high'
+```
+
+### `security.disableRule` [security-disablerule]
+
+Disable one or more detection rules by rule ID list or KQL query.
+
+| Parameter | Location | Type | Required | Description |
+|---|---|---|---|---|
+| `ids` | `with` | `string[]` (rule UUIDs) | Provide exactly one of `ids`/`query` | Rule `id` UUIDs to disable (at least one). Use the rule `id`, not `rule_id`. |
+| `query` | `with` | string (KQL) | Provide exactly one of `ids`/`query` | KQL query selecting the rules to disable. Cannot be empty. |
+
+```yaml
+# Disable a single rule by id
+- name: disable_rule
+  type: security.disableRule
+  with:
+    ids:
+      - "{{ variables.rule_id }}"
+```
+
+```yaml
+# Disable every rule matching a query
+- name: disable_noisy_rules
+  type: security.disableRule
+  with:
+    query: 'alert.attributes.tags: noisy'
+```
+
+## Output reference [workflows-security-rule-output]
+
+Both rule steps return the same summary shape on `steps.<step_name>.output`:
+
+| Field | Type | Description |
+|---|---|---|
+| `succeeded` | number | Rules whose state changed. |
+| `failed` | number | Rules that could not be updated. |
+| `skipped` | number | Rules already in the target state (already enabled or already disabled). |
+| `total` | number | Total rules targeted. |
+| `errors` | array | Included when one or more rules failed. Each entry has `message`, `status_code`, and `rules` (each with `id`; `name` when available). |
+
+Use the summary for branching or logging after the step. For example, check `steps.disable_noisy_rules.output.failed` before notifying an on-call channel.
+
+## Combine with a search and foreach [workflows-security-foreach]
+
+When you need per-rule control, fetch the rule set first (for example with [`kibana.request`](/explore-analyze/workflows/steps/kibana.md#kibana-request)), then loop:
+
+```yaml
+- name: find_noisy_rules
+  type: kibana.request
+  with:
+    method: GET
+    path: /api/detection_engine/rules/_find
+    query:
+      filter: 'alert.attributes.tags: "noisy"'
+      per_page: 100
+
+- name: disable_each_noisy_rule
+  foreach: "${{ steps.find_noisy_rules.output.body.data }}"
+  type: security.disableRule
+  with:
+    ids:
+      - "{{ foreach.item.id }}"
+```
+
+## Related
+
+- [Manage detection rules at scale](/explore-analyze/workflows/use-cases/security/manage-detection-rules.md): Rule-operations patterns that pair scheduled audits with rule lifecycle steps.
+- [Kibana action steps](/explore-analyze/workflows/steps/kibana.md): Generic `kibana.request` for detection engine APIs without a named step.
+- [Step type index](/explore-analyze/workflows/reference/step-types.md): Alphabetical lookup of every step type.
+- [Choose the right step](/explore-analyze/workflows/authoring-techniques/choose-the-right-step.md): Intent-based guide to picking a step.
+- [Manage detection rules](/solutions/security/detect-and-alert/manage-detection-rules.md): The Detection rules UI in {{elastic-sec}}.

--- a/explore-analyze/workflows/use-cases/security/manage-detection-rules.md
+++ b/explore-analyze/workflows/use-cases/security/manage-detection-rules.md
@@ -19,11 +19,14 @@ Teams that run large sets of detection rules (prebuilt, custom, or both) have re
 
 Use workflows to automate these rule-operations tasks. Workflows can query detection engine APIs on a schedule, post summaries to a chat channel, index results for dashboarding, or open a ticket when something is wrong, all using existing workflow building blocks.
 
+To enable or disable detection rules from a workflow, use [`security.enableRule`](/explore-analyze/workflows/steps/security.md#security-enablerule) and [`security.disableRule`](/explore-analyze/workflows/steps/security.md#security-disablerule). These steps validate their inputs and return a per-rule success summary. Prefer them instead of calling the detection engine bulk API with [`kibana.request`](/explore-analyze/workflows/steps/kibana.md#kibana-request).
+
 ## What you can automate [workflows-rule-ops-patterns]
 
-The following patterns combine [scheduled triggers](/explore-analyze/workflows/triggers/scheduled-triggers.md) with [{{kib}} request actions](/explore-analyze/workflows/steps/kibana.md#kibana-request) to drive rule-operations work:
+The following patterns combine [scheduled triggers](/explore-analyze/workflows/triggers/scheduled-triggers.md) with [{{kib}} request actions](/explore-analyze/workflows/steps/kibana.md#kibana-request) and [Security action steps](/explore-analyze/workflows/steps/security.md) to drive rule-operations work:
 
 - **Audit rule health on a schedule.** A scheduled workflow queries the detection engine API for rule status, filters for rules in an error or disabled state, and publishes a daily summary.
+- **Enable or disable rules by ID or query.** Use [`security.enableRule`](/explore-analyze/workflows/steps/security.md#security-enablerule) and [`security.disableRule`](/explore-analyze/workflows/steps/security.md#security-disablerule) to change rule state.
 - **Surface rule errors.** Use [`if` steps](/explore-analyze/workflows/steps/if.md) to branch on rule status and send a targeted notification when the failing rule is business-critical.
 - **Report on coverage.** Use [`foreach` steps](/explore-analyze/workflows/steps/foreach.md) to iterate over rules, group by tag or framework mapping, and index the result to an {{es}} index for dashboard visualization.
 - **Sync rule status to external systems.** Use [HTTP actions](/explore-analyze/workflows/steps/external-systems-apps.md) to mirror rule status into an external tracker, or post to Slack or PagerDuty when a rule crosses a threshold.
@@ -37,6 +40,7 @@ Step-by-step guides for rule-operations workflows:
 ## Learn more
 
 - [Scheduled triggers](/explore-analyze/workflows/triggers/scheduled-triggers.md): Run workflows on a cron-like schedule.
+- [Security action steps](/explore-analyze/workflows/steps/security.md): Native steps to enable or disable detection rules.
 - [{{kib}} action steps](/explore-analyze/workflows/steps/kibana.md): Reference for generic {{kib}} API requests.
 - [Foreach step](/explore-analyze/workflows/steps/foreach.md): Iterate over arrays returned by API calls.
 - [Detection rule concepts](/solutions/security/detect-and-alert/detection-rule-concepts.md): Background on how detection rules work.


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/docs-content/issues/7352.

Adds a Security action steps reference for `security.enableRule` and `security.disableRule`, including shared conventions, parameters, YAML examples, output shape, and a foreach pattern. Also updates the Action steps overview, step type index, navigation, and the manage-detection-rules use-case page to point to the native steps.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
   - [x] Yes - Cursor + Claude
   - [ ] No
