### PR TITLE
Update Serverless mOTLP endpoint UI label from Ingest to OpenTelemetry

### DIFF
--- a/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md
+++ b/solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md
@@ -41,7 +41,7 @@ Follow these steps to send data to Elastic using the {{motlp}}.
 ::::{applies-item} serverless:
 1. Log in to the {{ecloud}} Console.
 2. Find your project and select **Manage**.
-3. In the **Application endpoints, cluster and component IDs** section, select **Ingest**.
+3. In the **Application endpoints, cluster and component IDs** section, select **OpenTelemetry**.
 4. Copy the endpoint value.
 
 :::{tip}


### PR DESCRIPTION
The Serverless steps for finding the Managed OTLP endpoint referenced an outdated UI label. In the **Application endpoints, cluster and component IDs** section, the entry is now labeled **OpenTelemetry** instead of **Ingest**. This updates `solutions/observability/get-started/quickstart-elastic-cloud-otel-endpoint.md` accordingly.

Resolves https://github.com/elastic/docs-content/issues/7532

Made with Cursor