### PR TITLE
[Nightshift] Add nightshift stub pages in docs-content

### DIFF
--- a/solutions/observability/nightshift/get-started.md
+++ b/solutions/observability/nightshift/get-started.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+  stack: beta 9.5
+  serverless: beta
+description: Get started with Nightshift in Elastic Observability.
+products:
+  - id: observability
+  - id: cloud-serverless
+---
+
+# Get started with Nightshift

--- a/solutions/observability/nightshift/nightshift.md
+++ b/solutions/observability/nightshift/nightshift.md
@@ -1,0 +1,11 @@
+---
+applies_to:
+  stack: beta 9.5
+  serverless: beta
+description: Nightshift provides automated on-call assistance and alert triage for Elastic Observability.
+products:
+  - id: observability
+  - id: cloud-serverless
+---
+
+# Nightshift

--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -499,6 +499,9 @@ toc:
           - file: observability/streams/processors/uri-parts.md
           - file: observability/streams/processors/user-agent.md
           - file: observability/streams/processors/manual-pipeline-configuration.md
+      - hidden: observability/nightshift/nightshift.md
+        children:
+          - hidden: observability/nightshift/get-started.md
       - file: observability/incident-management.md
         children:
           - file: observability/incident-management/alerting.md


### PR DESCRIPTION
## Summary
This PR closes https://github.com/elastic/nightshift-program/issues/636 and adds an area in the docs for the private beta of Nightshift. The directory is to remain hidden in the TOC until a public release.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

Tool(s) and model(s) used: Claude Code, Sonnet 4.6


