### PR TITLE
Scope solution onboarding CTAs via docset.yml paths

### DIFF
--- a/docset.yml
+++ b/docset.yml
@@ -29,6 +29,37 @@ cta:
       - "Simplified billing and MACC burndown"
       - "Manage resources from the Azure portal"
       - "Built-in logs and metrics forwarding"
+  observability:
+    button:
+      label: Get started free
+      url: https://cloud.elastic.co/serverless-registration?onboarding_token=observability
+    benefits:
+      - "14-day free trial"
+      - "All features included"
+      - "No setup required"
+    paths:
+      - solutions/observability
+  security:
+    button:
+      label: Get started free
+      url: https://cloud.elastic.co/serverless-registration?onboarding_token=security
+    benefits:
+      - "14-day free trial"
+      - "All features included"
+      - "No setup required"
+    paths:
+      - solutions/security
+  search:
+    button:
+      label: Get started free
+      url: https://cloud.elastic.co/serverless-registration?onboarding_token=search
+    benefits:
+      - "14-day free trial"
+      - "All features included"
+      - "No setup required"
+    paths:
+      - solutions/search
+      - solutions/elasticsearch-solution-project
 
 exclude:
   - 'README.md'


### PR DESCRIPTION
## What

Adds three CTA templates to `docset.yml` and scopes each to its solution subtree, so the "Get started free" sidebar CTA deep-links into the matching Serverless onboarding flow:

| Token | Scoped paths |
|-------|--------------|
| `onboarding_token=observability` | `solutions/observability` |
| `onboarding_token=security` | `solutions/security` |
| `onboarding_token=search` | `solutions/search`, `solutions/elasticsearch-solution-project` |

This uses the new `cta.<name>.paths` key added in elastic/docs-builder#3716. Every page under a scoped prefix gets the right CTA with no per-page frontmatter, and new pages inherit it automatically.

Implements [elastic/docs-content-internal#1475](https://github.com/elastic/docs-content-internal/issues/1475).

## Exclusions handled for free

The issue asks to exclude the pages already updated in [#635](https://github.com/elastic/docs-eng-team/issues/635) (the `monitor-kubernetes` / `monitor-aws` pages from #7135 / #7191). Those pages set an explicit `cta` id in frontmatter, which always wins over a path scope, so they keep their more specific CTA without any exclusion list. The `azure-native-isv-service` page lives under `deploy-manage/`, outside these scopes, and is unaffected.

## ⚠️ Merge order

This depends on elastic/docs-builder#3716. The current docs-builder does not recognize the `paths` key, so this must merge **after** #3716 is released into the docs-builder version docs-content builds with. Do not merge before then.

## Open question

ziv's comment on #1475 gave the search scope as `solutions/elasticsearch-solution-project`, but the published search solution content lives under `solutions/search` (49 pages vs. 13). I scoped **both** to `onboarding_token=search` to be safe. Confirm whether both should carry the search token, or only one.

## Test plan

- [ ] After #3716 is released, build docs-content and confirm pages under each scope render the correct token in the sidebar CTA URL
- [ ] Confirm the `monitor-kubernetes` / `monitor-aws` pages still render their own CTA

Made with [Cursor](https://cursor.com)