### PR TITLE
Update known-issues.md Entity Store Kibana Crash with disabling the feature flag

### DIFF
--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -84,27 +84,6 @@ Follow these steps to stabilize {{kib}}:
 
    The entity store uses a 3-hour lookback window for log extraction, so entity records missed during the outage are recovered after you re-enable the store.
 
-3. Disable the Entity Store feature flag.
-
-   Send the following request in every {{kib}} space where the entity store needs to be removed:
-
-   ```
-   POST kbn:/api/kibana/settings/securitySolution:entityStoreEnableV2
-   {
-      "value": false
-   }
-   ```
-
-   If you're using a non-default {{kib}} space, prefix the path with `/s/{space_id}`:
-
-   ```
-   POST kbn:/s/{space_id}/api/kibana/settings/securitySolution:entityStoreEnableV2
-   {
-      "value": false
-   }
-   ```
-
-   The Entity Analytics experience will be unavailable while the feature flag is disabled.
 
 4. Remove the `xpack.task_manager.unsafe.exclude_task_types` setting.
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -59,7 +59,7 @@ Follow these steps to stabilize {{kib}}:
    {}
    ```
 
-   If you're using a non-default {{kib}} space, prefix the path with `/s/{space_id}`:
+   - For all non-default spaces, prefix the path with `/s/{space_id}`:
 
    ```
    PUT kbn:/s/{space_id}/api/security/entity_store/stop

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -55,9 +55,16 @@ Follow these steps to stabilize {{kib}}:
    - For the default space:
 
       ```
-   PUT kbn:/api/security/entity_store/stop
-   {}
-   ```
+      PUT kbn:/api/security/entity_store/stop
+      {}
+      ```
+
+      ```
+      POST kbn:/api/kibana/settings/securitySolution:entityStoreEnableV2
+      {
+         "value": false
+      }
+      ```
 
    - For all non-default spaces, prefix the path with `/s/{space_id}`:
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -54,7 +54,7 @@ Follow these steps to stabilize {{kib}}:
 
    - For the default space:
 
-   ```
+      ```
    PUT kbn:/api/security/entity_store/stop
    {}
    ```

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -82,8 +82,6 @@ To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabl
 
    At this point, entity engines stop running, data processing is paused, and the Entity Analytics experience becomes unavailable. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).
 
-   The entity store uses a 3-hour lookback window for log extraction, so entity records missed during the outage are recovered after you re-enable the store.
-
 
 3. Remove the `xpack.task_manager.unsafe.exclude_task_types` setting.
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -69,9 +69,16 @@ Follow these steps to stabilize {{kib}}:
    - For all non-default spaces, prefix the path with `/s/{space_id}`:
 
       ```
-   PUT kbn:/s/{space_id}/api/security/entity_store/stop
-   {}
-   ```
+      PUT kbn:/s/{space_id}/api/security/entity_store/stop
+      {}
+      ```
+
+      ```
+      POST kbn:/s/{space_id}/api/kibana/settings/securitySolution:entityStoreEnableV2
+      {
+         "value": false
+      }
+      ```
 
    At this point, entity engines stop running, data processing is paused, and the Entity Analytics experience becomes unavailable. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -50,7 +50,7 @@ Follow these steps to stabilize {{kib}}:
 
    After the override is in place, {{kib}} stabilizes and the crash loop stops.
 
-2. Stop the entity store engines.
+2. Stop the entity store engines and disable the Entity store feature in all {{kib}} where it is enabled:
 
    Send the following request in every {{kib}} space where the entity store is enabled:
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -90,7 +90,7 @@ To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabl
    * **Self-managed**: Remove the setting from `kibana.yml`, save your change, and restart {{kib}}.
 
 
-We will update this page with instructions on how to enable the feature again once once versions with a fix are available.
+We will update this page with instructions on how to enable the feature again once versions with a fix are available.
 
 :::
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -50,7 +50,7 @@ To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabl
 
    After the override is in place, {{kib}} stabilizes and the crash loop stops.
 
-2. Stop the entity store engines and disable the Entity store feature in all {{kib}} where it is enabled:
+2. Stop the entity store engines and disable the Entity store feature in all {{kib}} spaces where it is enabled:
 
    - For the default space:
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -68,7 +68,7 @@ Follow these steps to stabilize {{kib}}:
 
    - For all non-default spaces, prefix the path with `/s/{space_id}`:
 
-   ```
+      ```
    PUT kbn:/s/{space_id}/api/security/entity_store/stop
    {}
    ```

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -85,7 +85,7 @@ To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabl
    The entity store uses a 3-hour lookback window for log extraction, so entity records missed during the outage are recovered after you re-enable the store.
 
 
-4. Remove the `xpack.task_manager.unsafe.exclude_task_types` setting.
+3. Remove the `xpack.task_manager.unsafe.exclude_task_types` setting.
 
    Remove this setting for your deployment:
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -88,6 +88,10 @@ To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabl
 
    * **{{ech}}**: [Contact Elastic Support](https://www.elastic.co/support) to remove the system-level override.
    * **Self-managed**: Remove the setting from `kibana.yml`, save your change, and restart {{kib}}.
+
+
+We will update this page with instructions on how to enable the feature again once once versions with a fix are available.
+
 :::
 
 :::{dropdown} Response actions fail and endpoints do not appear for agents on version-specific policies

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -48,7 +48,6 @@ To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabl
    * **{{ech}}**: [Contact Elastic Support](https://www.elastic.co/support) to apply this as a system-level override. You cannot add it to `kibana.yml` directly. {{kib}} restarts as part of applying the change.
    * **Self-managed**: Add the setting to `kibana.yml`, save your change, and restart {{kib}}.
 
-   After the override is in place, {{kib}} stabilizes and the crash loop stops.
 
 2. Stop the entity store engines and disable the Entity store feature in all {{kib}} spaces where it is enabled:
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -57,7 +57,24 @@ Follow these steps to stabilize {{kib}}:
    ```
    PUT kbn:/api/security/entity_store/stop
    {}
+   ```
 
+   If you're using a non-default {{kib}} space, prefix the path with `/s/{space_id}`:
+
+   ```
+   PUT kbn:/s/{space_id}/api/security/entity_store/stop
+   {}
+   ```
+
+   The request stops running entity engines and pauses data processing. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).
+
+   The entity store uses a 3-hour lookback window for log extraction, so entity records missed during the outage are recovered after you re-enable the store.
+
+3. Disable the Entity Store feature flag.
+
+   Send the following request in every {{kib}} space where the entity store needs to be removed:
+
+   ```
    POST kbn:/api/kibana/settings/securitySolution:entityStoreEnableV2
    {
       "value": false
@@ -67,20 +84,15 @@ Follow these steps to stabilize {{kib}}:
    If you're using a non-default {{kib}} space, prefix the path with `/s/{space_id}`:
 
    ```
-   PUT kbn:/s/{space_id}/api/security/entity_store/stop
-   {}
-
    POST kbn:/s/{space_id}/api/kibana/settings/securitySolution:entityStoreEnableV2
    {
       "value": false
    }
    ```
 
-   The request stops running entity engines and pauses data processing. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).
+   The Entity Analytics experience will be unavailable while the feature flag is disabled.
 
-   The entity store uses a 3-hour lookback window for log extraction, so entity records missed during the outage are recovered after you re-enable the store.
-
-3. Remove the `xpack.task_manager.unsafe.exclude_task_types` setting.
+4. Remove the `xpack.task_manager.unsafe.exclude_task_types` setting.
 
    Remove this setting for your deployment:
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -52,7 +52,7 @@ Follow these steps to stabilize {{kib}}:
 
 2. Stop the entity store engines and disable the Entity store feature in all {{kib}} where it is enabled:
 
-   Send the following request in every {{kib}} space where the entity store is enabled:
+   - For the default space:
 
    ```
    PUT kbn:/api/security/entity_store/stop

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -73,7 +73,7 @@ Follow these steps to stabilize {{kib}}:
    {}
    ```
 
-   The request stops running entity engines and pauses data processing. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).
+   At this point, entity engines stop running, data processing is paused, and the Entity Analytics experience becomes unavailable. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).
 
    The entity store uses a 3-hour lookback window for log extraction, so entity records missed during the outage are recovered after you re-enable the store.
 

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -55,13 +55,25 @@ Follow these steps to stabilize {{kib}}:
    Send the following request in every {{kib}} space where the entity store is enabled:
 
    ```
-   PUT /api/security/entity_store/stop
+   PUT kbn:/api/security/entity_store/stop
+   {}
+
+   POST kbn:/api/kibana/settings/securitySolution:entityStoreEnableV2
+   {
+      "value": false
+   }
    ```
 
    If you're using a non-default {{kib}} space, prefix the path with `/s/{space_id}`:
 
    ```
-   PUT /s/{space_id}/api/security/entity_store/stop
+   PUT kbn:/s/{space_id}/api/security/entity_store/stop
+   {}
+
+   POST kbn:/s/{space_id}/api/kibana/settings/securitySolution:entityStoreEnableV2
+   {
+      "value": false
+   }
    ```
 
    The request stops running entity engines and pauses data processing. For the full API reference, refer to [Stop Entity Store engines](https://www.elastic.co/docs/api/doc/kibana/operation/operation-put-security-entity-store-stop).

--- a/release-notes/elastic-security/known-issues.md
+++ b/release-notes/elastic-security/known-issues.md
@@ -31,7 +31,7 @@ On {{stack}} 9.4.4, {{elastic-sec}} deployments with a large number of indices c
 
 
 **Workaround**<br>
-Follow these steps to stabilize {{kib}}:
+To stabilize {{kib}} until we resolve the issue, we recommend temporarily disabling the Entity store feature:
 
 1. Block the entity store tasks from running by applying this setting:
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

Follow up on https://github.com/elastic/docs-content-internal/issues/1511.

Documents a known issue where Entity Store extraction tasks can crash Kibana on Elastic Stack 9.4.4 deployments with a large number of indices. Previously we need one extra step: disable the feature flag and stop the entity store calls completely.

