### PR TITLE
[OAuth] Remove reference to API key support

### DIFF
--- a/deploy-manage/app-connections/create-oauth-client.md
+++ b/deploy-manage/app-connections/create-oauth-client.md
@@ -88,16 +88,6 @@ The client ID and MCP server URL can be retrieved at any time from the **MCP cli
 
 :::::
 
-% todo: endpoint link
-:::{note}
-
-OAuth clients can also be created through the {{kib}} API. To create a client through the API, you must use an {{ecloud}} API key with [Cloud, {{es}}, and {{kib}} API access](/deploy-manage/api-keys/elastic-cloud-api-keys.md#project-access). Creating a client with an API key created directly in {{es}} is not supported. 
-
-Clients created through the API are not visible in the Agent Builder client list in {{kib}}, because they are not owned by a specific user. They appear only in the organization-level [Application connections](manage-app-connections.md) view in the {{ecloud}} Console.
-
-% source: https://elastic.slack.com/archives/C0AH1CA7S3Y/p1780340150585789
-:::
-
 ## Next steps
 
 Now that you have the client ID and MCP server URL for your OAuth client, [configure your MCP host to use them](connect-mcp-host.md).


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
Removes the mention of using API keys to create clients. It is not currently supported. 

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [ x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

