### PR TITLE
Add copilot-requests: write to docs-pr-ai-menu and docs-size workflows

### DIFF
--- a/.github/workflows/docs-pr-ai-menu.yml
+++ b/.github/workflows/docs-pr-ai-menu.yml
@@ -20,6 +20,7 @@ permissions:
   discussions: write
   issues: write
   pull-requests: write
+  copilot-requests: write
 
 jobs:
   post-menu:
@@ -193,13 +194,13 @@ jobs:
       discussions: write
       issues: write
       pull-requests: write
+      copilot-requests: write
     uses: elastic/docs-actions/.github/workflows/gh-aw-docs-review.lock.yml@v1
     with:
       review-scope: repo-wide-markdown
       additional-instructions: |
         This repository stores documentation as markdown across the repository, not only under `docs/`.
         Prefer concise, high-signal review comments with exact replacement text when possible.
-    secrets: inherit
 
   refresh-menu-after-docs-review:
     name: Refresh AI PR menu after docs review

--- a/.github/workflows/docs-size.yml
+++ b/.github/workflows/docs-size.yml
@@ -10,6 +10,7 @@ permissions:
   discussions: write
   issues: write
   pull-requests: write
+  copilot-requests: write
 
 jobs:
   run:


### PR DESCRIPTION
## Summary

- Adds `copilot-requests: write` to `docs-pr-ai-menu.yml` (top-level and `run-docs-review` job permissions) and `docs-size.yml`
- Removes `secrets: inherit` from `run-docs-review` — no secret passthrough needed with the Copilot engine
- These two files were missed in #7578 when switching docs-actions @v1 to the Copilot engine (v1.36.1)

## Test plan

- [ ] Trigger the AI PR menu on a PR and confirm `run-docs-review` job authenticates via the Copilot built-in token
- [ ] Trigger `/size` on an issue and confirm the workflow completes without auth errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)