### PR TITLE
Adding Vector Database docs URL stub

### DIFF
--- a/solutions/toc.yml
+++ b/solutions/toc.yml
@@ -86,6 +86,9 @@ toc:
           - file: elasticsearch-solution-project/search-applications/search-application-api.md
           - file: elasticsearch-solution-project/search-applications/search-application-security.md
           - file: elasticsearch-solution-project/search-applications/search-application-client.md
+  - hidden: vector-database.md
+    children:
+      - hidden: vector-database/get-started.md
   - file: observability.md
     children:
       - file: observability/get-started.md

--- a/solutions/vector-database.md
+++ b/solutions/vector-database.md
@@ -1,0 +1,17 @@
+---
+navigation_title: Vector Database project
+applies_to:
+  serverless: ga
+description: >-
+  The Elasticsearch Vector Database project type on Elastic Cloud Serverless is
+  optimized for vector workloads, with vector-tuned defaults, hardware profile,
+  inference access, and pricing. It supports semantic and hybrid search.
+products:
+  - id: elasticsearch
+  - id: cloud-serverless
+---
+
+<!-- Temporary hidden stub. This page will be updated with the full Vector Database project documentation.
+See https://github.com/elastic/docs-content-internal/issues/1413. -->
+
+# The {{es}} Vector Database project overview

--- a/solutions/vector-database/get-started.md
+++ b/solutions/vector-database/get-started.md
@@ -1,0 +1,16 @@
+---
+navigation_title: Get started
+description: >-
+  Create an Elasticsearch Vector Database project on Elastic Cloud Serverless,
+  ingest embeddings, and run your first vector or semantic searches.
+applies_to:
+  serverless: ga
+products:
+  - id: elasticsearch
+  - id: cloud-serverless
+---
+
+<!-- Temporary hidden stub. This page will be updated with the full get started guide.
+See https://github.com/elastic/docs-content-internal/issues/1413. -->
+
+# Get started with the {{es}} Vector Database project type


### PR DESCRIPTION
Adds a temporary, hidden stub for the getting started page so that it can be linked from Kibana. The page will be updated with the corresponding docs content as outlined in https://github.com/elastic/docs-content-internal/issues/1413


## Changes

* adds a new sub-directory: `solutions/vector-database`
* adds new pages: `solutions/vector-database/get-started.md` and `solutions/vector-database.md` (the parent overview page). Both pages include only front matter and titles 
* updates `solutions/toc.yml` with the hidden entries

## Related links

* https://github.com/elastic/kibana/pull/281146
* https://github.com/elastic/search-team/issues/15523
