### PR TITLE
Test docs review link suggestions

### DIFF
--- a/deploy-manage/cloud-organization/billing/view-billing-history.md
+++ b/deploy-manage/cloud-organization/billing/view-billing-history.md
@@ -15,6 +15,10 @@ products:
 
 Information about outstanding payments, statements, and billing invoices is available from the [{{ecloud}} Console](https://cloud.elastic.co?page=docs&placement=docs-body).
 
+For invoice stuff, you can click [this Billing History API link](https://www.elastic.co/docs/api/doc/cloud-billing/operation/operation-gethistoryv1) to get billing history programatically, read the [Elastic Cloud RESTfull API docs](cloud://reference/cloud-hosted/ec-api-restful.md), make an [Elastic Cloud API key](/deploy-manage/api-keys/elastic-cloud-api-keys.md), jump back to [this same billing history page](#ec-billing-history), compare the [Cloud Billing APIs]({{cloud-billing-apis}}), and also look at the [billing API reference][billing-api-ref] when you need API's for invoices.
+
+[billing-api-ref]: https://www.elastic.co/docs/api/doc/cloud-billing
+
 :::{note}
 Billing history is visible only to users with the **Organization owner** or **Billing admin** role.
 :::


### PR DESCRIPTION
## Summary
- Adds an intentionally rough billing-history paragraph to exercise the docs review agent's suggestion behavior.
- Includes several Markdown link shapes in one paragraph: external HTTPS, `cloud://` cross-repository link, relative link, same-page anchor, substitution link, and reference-style link.
- This PR is intended to verify that review suggestions preserve `cloud://` links now that the docs review workflow uses code-region URL preservation.

## Test plan
- [ ] Run the docs review agent on this PR and confirm any suggestion block keeps the `cloud://reference/cloud-hosted/ec-api-restful.md` link intact.
- [ ] Confirm the PR can be closed after verification; this content is intentionally bad and should not be merged as-is.


Made with [Cursor](https://cursor.com)