### PR TITLE
docs: note Vega ES|QL unified-search limitation lifted in 9.5 (#7621)

### DIFF
--- a/explore-analyze/visualize/custom-visualizations-with-vega.md
+++ b/explore-analyze/visualize/custom-visualizations-with-vega.md
@@ -1465,6 +1465,11 @@ The following example creates a metric that counts documents over time, using th
 {applies_to}`stack: preview 9.5` {applies_to}`serverless: preview` **Vega** and **Vega-Lite** panels that use an {{esql}} data source are subject to the {icon}`bolt` [**Fast mode**](../query-filter/languages/esql-kibana.md#approximation-fast-mode) dashboard option. When this option is active on a dashboard, these panels return faster, estimated results for `STATS` aggregations.
 
 
+#### {{esql}} data source limitations [vega-esql-limitations]
+
+{applies_to}`stack: ga =9.4` The dashboard query bar, filters, and controls don't recognize the fields from the index that a **Vega** or **Vega-Lite** {{esql}} panel queries. Later versions recognize these fields.
+
+
 #### Access Elastic Map Service files [vega-esmfiles]
 ```{applies_to}
 stack: preview


### PR DESCRIPTION
## Summary

This PR addresses #7621 with the following change:

- **`explore-analyze/visualize/custom-visualizations-with-vega.md`**: Add an **ES|QL data source limitations** subsection at the end of the **Writing ES|QL queries in Vega** section. It documents that in 9.4 the dashboard query bar, filters, and controls don't recognize the fields queried by Vega or Vega-Lite ES|QL panels, and that later versions recognize those fields.

## Details

The behavior change comes from [elastic/kibana#277120](https://github.com/elastic/kibana/pull/277120): Vega ES|QL panels now resolve an ad-hoc data view from their query, so the dashboard's unified search recognizes the queried index and its fields.

Framed as a lifted limitation, per reviewer preference, so the section has a clear home if related ES|QL-in-Vega limitations are added or resolved later.

Version scoping: ES|QL data sources in Vega shipped in 9.4 ([elastic/kibana#247186](https://github.com/elastic/kibana/pull/247186)), so the limitation only ever applied in 9.4. The note is tagged `{applies_to}` `stack: ga =9.4` to scope the badge to that single version. Serverless is evergreen and already has the fix, so it is not tagged.

## Resolves

Closes #7621

---

> **AI-generated draft** — created with Claude Opus 4.8.
> Review all generated content for factual accuracy before merging.