### PR TITLE
docs: note Vega loader options limited to target and rel (#7624)

### DIFF
--- a/explore-analyze/visualize/custom-visualizations-with-vega.md
+++ b/explore-analyze/visualize/custom-visualizations-with-vega.md
@@ -1692,6 +1692,8 @@ kibanaSetTimeFilter(start, end)
 }
 ```
 
+{{kib}} reads a limited set of embed options from a spec's `usermeta.embedOptions.loader` object: only the `target` and `rel` link attributes are honored, and all other loader properties, such as `baseURL` or HTTP request options, are ignored. As a result, a spec cannot change how {{kib}} loads external resources.
+
 
 ### Resources and examples [resources-and-examples]
 


### PR DESCRIPTION
## Summary

This PR addresses #7624 with the following change:

- **`explore-analyze/visualize/custom-visualizations-with-vega.md`**: adds a short reference note in the **Vega reference → Additional configuration options** section stating that {{kib}} only honors the `target` and `rel` link attributes from a spec's `usermeta.embedOptions.loader` object and ignores all other loader properties, so a spec cannot change how {{kib}} loads external resources.

### Context

Kibana [PR #276772](https://github.com/elastic/kibana/pull/276772) hardened Vega by sanitizing `usermeta.embedOptions.loader`, allowlisting only `target` and `rel` and stripping everything else (`baseURL`, `mode`, and HTTP request options such as `method`, `headers`, `body`). The loader options were never documented, but advanced users who relied on them see their saved specs silently lose those properties, so a short authoritative note is warranted.

Verified against the implementation file at HEAD (`src/platform/plugins/private/vis_types/vega/public/vega_view/vega_base_view.js`): the allowlist is exactly `['target', 'rel']`, confirmed by the accompanying unit tests.

### On version scoping

No `applies_to` tag is used, and this is intentional. The change was backported across every actively maintained release line — **8.19.20, 9.3.9, 9.4.4, 9.5.0, and 9.6.0** — so the restriction applies to all supported versions. Tagging it `stack: ga 9.5` (as the issue's suggested-edit line proposes) would wrongly imply that earlier supported versions still forward all loader properties. The note therefore inherits the page's existing all-versions scope and reads as current behavior.

## Resolves

Closes #7624

---

> **AI-generated draft** — created with Claude.
> Review all generated content for factual accuracy before merging.