### PR TITLE
Update locally.md - url https://ela.st/docs-builder-install.ps1 404

### DIFF
--- a/contribute-docs/locally.md
+++ b/contribute-docs/locally.md
@@ -77,7 +77,7 @@ If you get a `Permission denied` error, make sure that you aren't trying to run 
    You can optionally specify a specific version to install:
 
    ```powershell
-   $env:DOCS_BUILDER_VERSION = '0.40.0'; iwr -useb https://ela.st/docs-builder-install.ps1 | iex
+   $env:DOCS_BUILDER_VERSION = '0.40.0'; iwr -useb https://ela.st/docs-builder-install-win | iex
    ```
 
    To download and install the binary file manually, refer to [Releases](https://github.com/elastic/docs-builder/releases) on GitHub.


### PR DESCRIPTION
Hello folks,

I´m submiting a small fix for the win install of docs-builder!

https://ela.st/docs-builder-install.ps1 returns 404, changing it to `https://ela.st/docs-builder-install-win` fixes it all! :)

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [ x] No  


