### PR TITLE
[redo] Document azure portal flow for network security policies

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/_snippets/azure-native-network-security-surfaces.md
+++ b/deploy-manage/deploy/elastic-cloud/_snippets/azure-native-network-security-surfaces.md
@@ -1,0 +1,6 @@
+Where you manage the Elastic-side policies depends on the hosting type:
+
+| Policy type | {{ech}} | {{serverless-full}} |
+| --- | --- | --- |
+| IP filters | Azure portal **Traffic Filter** or {{ecloud}} Console. Changes sync between the two surfaces. | {{ecloud}} Console only. The Azure portal Traffic Filter page does not support Serverless policies yet. |
+| Private Link private connection policy | Azure portal **Traffic Filter** or {{ecloud}} Console. Changes sync between the two surfaces. | {{ecloud}} Console only. The Azure portal Traffic Filter page does not support Serverless policies yet. |

--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-network-security.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-network-security.md
@@ -1,0 +1,73 @@
+---
+applies_to:
+  deployment:
+    ech: ga
+products:
+  - id: cloud-hosted
+navigation_title: Network security
+description: Restrict access to Azure Native Service hosted deployments with IP filters and private connection policies.
+---
+
+# Manage network security in the Azure Native Service
+
+You can restrict access to {{ech}} deployments created through the [Azure Native Service](azure-native-isv-service.md) by applying [network security policies](/deploy-manage/security/network-security-policies.md). Policies include [IP filters](/deploy-manage/security/ip-filtering-cloud.md) and [private connections](/deploy-manage/security/private-connectivity.md).
+
+This page covers how to create and associate those policies from the Azure portal Traffic Filter page.
+
+:::{include} _snippets/azure-native-network-security-surfaces.md
+:::
+
+For {{ecloud}} Console steps that apply to both {{ech}} and {{serverless-short}}, refer to [](/deploy-manage/security/ip-filtering-cloud.md) and [](/deploy-manage/security/private-connectivity-azure.md).
+
+Policies you create in the Azure portal appear in the {{ecloud}} Console under **Network security**, labeled **Created from Azure**. Policies created in the {{ecloud}} Console also appear in the Azure portal list. Linking or unlinking in either place updates the association.
+
+Microsoft also documents this page in [Manage settings for your Elastic resource](https://learn.microsoft.com/en-us/azure/partner-solutions/elastic/manage#traffic-filters).
+
+
+## Add a Private Link private connection policy
+
+To create a private connection policy, you must first create the private endpoint and DNS records in Azure, and then create the policy in the Azure portal.
+
+### Step 1: Create the private endpoint and DNS records in Azure
+
+Follow the steps to [create your private endpoint and DNS entries in Azure](/deploy-manage/security/private-connectivity-azure.md#ec-private-link-azure-dns). This procedure creates the private endpoint and DNS records using regional [service aliases and private hosted zone names](/deploy-manage/security/private-connectivity-azure.md#ec-private-link-azure-service-aliases).
+
+### Step 2: Create the private connection policy in the Azure portal
+
+After you create the private endpoint and DNS records in Azure, you can create the private connection policy in the Azure portal.
+
+1. In the Azure portal, open your Elastic resource, then select **Elastic Cloud Resource Configuration** > **Traffic Filter**.
+2. Select **Add**.
+3. Enter a filter name.
+4. Set **Filter Type** to **Private Link**.
+5. Choose how to identify the private endpoint:
+
+   * **Select Existing**: Choose the Azure subscription that contains the private endpoint, then choose the private endpoint from the list.
+   * **Add Manually**: Enter the private endpoint GUID and name. To find these values, refer to [](/deploy-manage/security/private-connectivity-azure.md#ec-find-your-resource-name) and [](/deploy-manage/security/private-connectivity-azure.md#ec-find-your-resource-id).
+
+6. Create the filter.
+7. Select the new filter in the list, then select **Link** so the status shows **Linked** for this deployment.
+
+The policy must be in the same region as the deployment. Policies from other regions can appear in the list but remain **Not Linked** on this resource.
+
+## Add an IP filter
+
+Create and link an IP filter from the Azure portal to allowlist IPv4 addresses or CIDR blocks.
+
+1. In the Azure portal, open your Elastic resource, then select **Elastic Cloud Resource Configuration** > **Traffic Filter**.
+2. Select **Add**.
+3. Enter a filter name.
+4. Set **Filter Type** to **IP filtering rule set**.
+5. Add the IPv4 addresses or CIDR blocks to allow.
+6. Create the filter.
+7. Select the filter, then select **Link**.
+
+The policy must be in the same region as the deployment. Policies from other regions can appear in the list but remain **Not Linked** on this resource.
+
+## Unlink or delete a policy
+
+Remove a policy from this deployment, or delete it from your organization, in the Azure portal.
+
+1. In the Azure portal, open your Elastic resource, then select **Elastic Cloud Resource Configuration** > **Traffic Filter**.
+2. To stop a policy from applying to this deployment, select it and choose **Unlink**. The policy remains available in your organization.
+3. To delete a policy, unlink it from all deployments first, then select **Delete**.

--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md
@@ -281,6 +281,20 @@ Delete the deployment directly from the Azure portal. The delete operation perfo
 $$$azure-integration-delete-resource-group$$$
 If you delete an Azure Resource Group containing {{ecloud}} resources, the latter will be deleted automatically. However, you should not delete the Azure Resource Group containing the first deployment or project that you created. The usage associated with any other Elastic deployment created outside of the first resource group will continue to get reported and charged against this resource group. If you want to stop all charges to this Resource Group, you should delete the individual deployments.
 
+## Network security [azure-native-network-security]
+
+{{ech}} deployments and {{serverless-full}} projects created through the Azure Native Service support [network security policies](/deploy-manage/security/network-security.md), including [IP filters](/deploy-manage/security/ip-filtering-cloud.md) and [Azure Private Link](/deploy-manage/security/private-connectivity-azure.md). You always create private endpoints and DNS records in Azure.
+
+:::{include} _snippets/azure-native-network-security-surfaces.md
+:::
+
+* For Azure portal steps for {{ech}}, refer to [](azure-native-isv-service-network-security.md).
+* For {{serverless-short}} {{ecloud}} Console steps, refer to [](/deploy-manage/security/ip-filtering-cloud.md) and [](/deploy-manage/security/private-connectivity-azure.md).
+
+:::{warning}
+If a network security policy has **Apply to future resources by default** enabled, new Azure Native resources can fail to create. For more information, refer to the [Azure Native Service troubleshooting guide](azure-native-isv-service-troubleshooting.md#azure-integration-deployment-failed-network-security).
+:::
+
 ## Troubleshooting
 
 To troubleshoot issues with the Azure Native Service, refer to [](azure-native-isv-service-troubleshooting.md).

--- a/deploy-manage/security/ip-filtering-cloud.md
+++ b/deploy-manage/security/ip-filtering-cloud.md
@@ -24,7 +24,13 @@ There are types of filters are available for filtering by IP address or CIDR blo
 * **Ingress or inbound IP filters**: These restrict access to your deployments from a set of IP addresses or CIDR blocks. These filters are available through the UI.
 * **Egress or outbound IP filters**: These restrict the set of IP addresses or CIDR blocks accessible from your deployment. These might be used to restrict access to a certain region or service. This feature is currently only available through the [Traffic Filtering API](/deploy-manage/security/network-security-api.md). {applies_to}`ess: beta` {applies_to}`serverless: unavailable` 
 
-Follow the step described here to set up ingress or inbound IP filters through the {{ecloud}} Console.
+Follow the steps described here to set up ingress or inbound IP filters through the {{ecloud}} Console.
+
+:::{tip}
+applies_to: ech: ga
+
+If you created your deployment through the [Azure Native Service](/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md), you can also create and link IP filters from the Azure portal Traffic Filter page. Refer to [](/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-network-security.md).
+:::
 
 To learn how IP filters work together, and alongside [private connection policies](private-connectivity.md), refer to [](/deploy-manage/security/network-security-policies.md).
 

--- a/deploy-manage/security/private-connectivity-azure.md
+++ b/deploy-manage/security/private-connectivity-azure.md
@@ -31,7 +31,8 @@ Azure Private Link requires that you also filter traffic to your deployments or 
 To learn how private connection policies impact your deployment or project, refer to [](/deploy-manage/security/network-security-policies.md).
 
 :::{tip}
-{{ech}} and {{serverless-full}} also support [IP filters](/deploy-manage/security/ip-filtering-cloud.md). You can apply both IP filters and private connections to a single {{ecloud}} resource.
+* {{ech}} and {{serverless-full}} also support [IP filters](/deploy-manage/security/ip-filtering-cloud.md). You can apply both IP filters and private connections to a single {{ecloud}} resource.
+* {applies_to}`ech: ga` If you created your deployment through the [Azure Native Service](/deploy-manage/deploy/elastic-cloud/azure-native-isv-service.md), you can also create and link Private Link private connection policies from the Azure portal Traffic Filter page. Refer to [](/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-network-security.md).
 :::
 
 ## Requirements

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -24,6 +24,7 @@ toc:
                   - file: deploy/elastic-cloud/azure-native-isv-service.md
                     children:
                       - file: deploy/elastic-cloud/azure-native-isv-service-logs-metrics.md
+                      - file: deploy/elastic-cloud/azure-native-isv-service-network-security.md
                       - file: deploy/elastic-cloud/azure-native-isv-service-troubleshooting.md
                   - file: deploy/elastic-cloud/google-cloud-platform-marketplace.md
                   - file: deploy/elastic-cloud/heroku.md


### PR DESCRIPTION
recreating https://github.com/elastic/docs-content/pull/7610

<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary

- fixes https://github.com/elastic/docs-content-internal/issues/1526
- Documents Azure Native Service network security: ECH can manage IP filters and Private Link private connection policies from the Azure portal Traffic Filter page. Serverless stays cloud console only for now.
	- Added an ECH how-to for portal flows
	- Cross-linked from the Azure Native overview, IP filter docs, and Azure Private Link docs

this PR is a child of #7595 so I can add the "doesn't work in serverless" context where needed

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: cursor auto

