### PR TITLE
Add new Azure regions for AutoOps on ECH

### DIFF
--- a/deploy-manage/monitor/autoops/ec-autoops-regions.md
+++ b/deploy-manage/monitor/autoops/ec-autoops-regions.md
@@ -79,9 +79,20 @@ AutoOps is currently not available in any region for GovCloud customers.
 | Region | Name |
 | --- | --- |
 | australiaeast | Australia East (New South Wales) |
+| brazilsouth | Brazil South (Sao Paulo) |
+| canadacentral | Canada Central (Toronto) |
+| centralindia | Central India (Pune) |
+| centralus | Central US (Iowa) |
 | eastus | East US (Virginia) |
 | eastus2 | East US 2 (Virginia) |
+| francecentral | France Central (Paris) |
+| japaneast | Japan East (Tokyo) |
 | northeurope | North Europe (Ireland) |
+| southafricanorth | South Africa North (Johannesburg) |
+| southcentralus | South Central US (Texas) |
+| southeastasia | Southeast Asia (Singapore) |
+| uksouth | UK South (London) |
+| westeurope | West Europe (Netherlands) |
 | westus2 | West US 2 (Washington) |
 
 ## AutoOps for {{serverless-full}} regions


### PR DESCRIPTION

## Summary
AutoOps ECH has now been rolled out across all applicable Azure regions. This PR updates the Regions page to reflect this change.

Closes: https://github.com/elastic/docs-content/issues/7755

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor auto

