### PR TITLE
SEO improvements for vector search and semantic search docs

### DIFF
--- a/explore-analyze/ai-features.md
+++ b/explore-analyze/ai-features.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: AI-powered features
-description: Explore AI-powered features in the Elastic Stack, including the AI Assistant, Elastic Agent Builder, and machine learning tools for search, observability, and security workflows.
+description: Explore AI-powered features in the Elastic Stack, including Elastic Agent Builder, and machine learning tools for search, observability, and security workflows.
 applies_to:
   stack: ga
   serverless: ga

--- a/explore-analyze/ai-features.md
+++ b/explore-analyze/ai-features.md
@@ -1,5 +1,6 @@
 ---
 navigation_title: AI-powered features
+description: Explore AI-powered features in the Elastic Stack, including the AI Assistant, Elastic Agent Builder, and machine learning tools for search, observability, and security workflows.
 applies_to:
   stack: ga
   serverless: ga

--- a/solutions/search/get-started/semantic-search.md
+++ b/solutions/search/get-started/semantic-search.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Semantic search
-description: Quickstart for semantic search in Elasticsearch with the semantic_text workflow, which uses vector search and embeddings to match documents by meaning.
+description: Get started with semantic search and vector search in Elasticsearch using the semantic_text field type. This tutorial walks through indexing documents, generating embeddings automatically, and running your first semantic search query.
 applies_to:
   serverless: all
   stack: all

--- a/solutions/search/search-approaches.md
+++ b/solutions/search/search-approaches.md
@@ -1,4 +1,5 @@
 ---
+description: Compare search approaches in Elasticsearch, including full-text search, vector search, semantic search, and hybrid search, and choose the right strategy for your use case.
 applies_to:
   stack:
   serverless:

--- a/solutions/search/semantic-search.md
+++ b/solutions/search/semantic-search.md
@@ -20,7 +20,7 @@ This page focuses on semantic search for text in {{es}}. For multimodal search a
 
 Semantic search uses [{{nlp}} (NLP)](/explore-analyze/machine-learning/nlp.md) models and [vector search](vector.md) to find results based on meaning, not just keywords. This page covers the managed workflows available in {{es}} for implementing semantic search on text.
 
-For the foundational concepts behind vector search, refer to [Vector search in {{es}}](vector.md). To compare semantic search with lower-level vector search and decide which path fits your project, refer to [Semantic search and vector search](vector.md#semantic-search-vs-vector-search). To understand the infrastructure that powers semantic search and other NLP tasks, including managed services and {{infer}} endpoints, refer to the [Elastic {{infer-cap}} overview](../../explore-analyze/elastic-inference.md) page.
+For the foundational concepts behind vector search, refer to [Vector search in {{es}}](vector.md). To compare semantic search with lower-level vector search and decide which path fits your project, refer to [Semantic search and vector search](vector.md#semantic-search-vs-vector-search). To understand the infrastructure that powers semantic search and other NLP tasks, including managed services and {{infer}} endpoints, refer to the [Elastic {{infer-cap}} overview](../../explore-analyze/elastic-inference.md) page. To explore AI-powered features across the {{stack}}, refer to [AI-powered features](/explore-analyze/ai-features.md).
 
 ## Overview of semantic search workflows [semantic-search-workflows-overview]
 

--- a/solutions/search/vector.md
+++ b/solutions/search/vector.md
@@ -1,5 +1,6 @@
 ---
 navigation_title: Vector search
+description: Learn how vector search works in Elasticsearch, including dense and sparse vectors, embeddings, kNN search, and how to choose between semantic_text and direct vector field configuration.
 applies_to:
   stack:
   serverless:
@@ -65,7 +66,7 @@ $$$sparse-vectors$$$ Sparse vectors
 
 Once you've implemented any of these approaches, you can combine them with full-text search to create [hybrid search](hybrid-search.md) solutions that leverage both meaning-based and keyword-based matching.
 
-For a broader view of when each search approach fits your goals, refer to [Search approaches](search-approaches.md).
+For a broader view of when each search approach fits your goals, refer to [Search approaches](search-approaches.md). To explore AI-powered features across the {{stack}}, including the AI Assistant and {{agent-builder}}, refer to [AI-powered features](/explore-analyze/ai-features.md).
 
 ## Field types and queries [vector-queries-and-field-types]
 


### PR DESCRIPTION
## Summary

- Add `description` frontmatter to `vector.md`, `search-approaches.md`, and `ai-features.md` (all previously missing)
- Update `description` on `get-started/semantic-search.md` to add specificity and include both semantic search and vector search terms
- Add links to [AI-powered features](/explore-analyze/ai-features.md) from `vector.md` and `semantic-search.md` to restore cross-section link equity lost when `ai-search/ai-search.md` was deleted in the restructure

These changes address findings from a post-restructure traffic analysis (PRs #5643, #5567). The `ai-features` page dropped in position in Search Console after losing inbound links from the search section. The missing descriptions on `search-approaches` and `vector` leave Google without clear page signals for high-value queries like "vector search elasticsearch" and "elasticsearch search types."

## Test plan

- [ ] Verify description frontmatter renders correctly in the docs build
- [ ] Confirm links to `/explore-analyze/ai-features.md` resolve correctly
- [ ] Check no redirects are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)