### PR TITLE
docs: document the CPS space-panel downgrade exception (#7635)

### DIFF
--- a/deploy-manage/cross-project-search-config.md
+++ b/deploy-manage/cross-project-search-config.md
@@ -64,8 +64,6 @@ To be available for linking, projects must meet the following requirements:
 
 Only compatible projects appear in the [{{cps}} linking wizard](/deploy-manage/cross-project-search-config/cps-config-link-and-manage.md#cps-link-projects). If a project you expected to link to is missing from the list, it might not meet the requirements, or you might not have the necessary [permissions](#cps-compatibility) on the project.
 
-The same tier requirement determines whether the **{{cps-cap}}** panel appears in a space's settings. Refer to [Set the default {{cps-init}} scope for a space](/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md#cps-default-search-scope).
-
 
 ## Plan your {{cps-init}} architecture [cps-arch]
 

--- a/deploy-manage/cross-project-search-config.md
+++ b/deploy-manage/cross-project-search-config.md
@@ -64,6 +64,8 @@ To be available for linking, projects must meet the following requirements:
 
 Only compatible projects appear in the [{{cps}} linking wizard](/deploy-manage/cross-project-search-config/cps-config-link-and-manage.md#cps-link-projects). If a project you expected to link to is missing from the list, it might not meet the requirements, or you might not have the necessary [permissions](#cps-compatibility) on the project.
 
+The same tier requirement determines whether the **{{cps-cap}}** panel appears in a space's settings. Refer to [Set the default {{cps-init}} scope for a space](/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md#cps-default-search-scope).
+
 
 ## Plan your {{cps-init}} architecture [cps-arch]
 

--- a/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
+++ b/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
@@ -65,8 +65,6 @@ The scope controls which projects receive the search request, while [querying an
 
 You can adjust the {{cps-init}} system-level default scope by setting a narrower {{cps}} scope for each space. This setting determines the default search scope for the space. Users can override both the system-level default and the space-level default by setting their preferred scope when searching, filtering, or running queries. 
 
-The **{{cps-cap}}** panel in space settings follows the same tier eligibility required to link projects for {{cps-init}}. Refer to [Projects available for linking](/deploy-manage/cross-project-search-config.md#cps-compatibility) for tier requirements. On an ineligible tier, the panel doesn't appear.
-
 :::{tip}
 For best results, set the default {{cps-init}} scope for each space **before** you link projects.
 :::
@@ -92,7 +90,7 @@ Space settings are managed in {{kib}}.
 ::::{note}
 The default {{cps}} scope is a space setting, not an access control. Users can still set the scope at the query level. You can also [manage user access](#manage-user-and-api-key-access).
 
-If a space already has a non-default scope, for example after a tier downgrade, the **{{cps-cap}}** panel stays visible so you can reset it to **All projects**. After you save that change, the panel no longer appears.
+If a space already has a non-default scope, for example after a [tier downgrade](/deploy-manage/cross-project-search-config.md#cps-compatibility), the **{{cps-cap}}** panel stays visible so you can reset it to **All projects**. After you save that change, the panel no longer appears.
 ::::
 
 ## Next steps

--- a/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
+++ b/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
@@ -65,7 +65,7 @@ The scope controls which projects receive the search request, while [querying an
 
 You can adjust the {{cps-init}} system-level default scope by setting a narrower {{cps}} scope for each space. This setting determines the default search scope for the space. Users can override both the system-level default and the space-level default by setting their preferred scope when searching, filtering, or running queries. 
 
-The **{{cps-cap}}** panel appears in space settings only when the project is on a tier eligible for {{cps-init}}. Refer to [Projects available for linking](/deploy-manage/cross-project-search-config.md#cps-compatibility) for tier requirements.
+The **{{cps-cap}}** panel in space settings follows the same tier eligibility required to link projects for {{cps-init}}. Refer to [Projects available for linking](/deploy-manage/cross-project-search-config.md#cps-compatibility) for tier requirements. On an ineligible tier, the panel doesn't appear.
 
 :::{tip}
 For best results, set the default {{cps-init}} scope for each space **before** you link projects.

--- a/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
+++ b/deploy-manage/cross-project-search-config/cps-config-access-and-scope.md
@@ -65,6 +65,8 @@ The scope controls which projects receive the search request, while [querying an
 
 You can adjust the {{cps-init}} system-level default scope by setting a narrower {{cps}} scope for each space. This setting determines the default search scope for the space. Users can override both the system-level default and the space-level default by setting their preferred scope when searching, filtering, or running queries. 
 
+The **{{cps-cap}}** panel appears in space settings only when the project is on a tier eligible for {{cps-init}}. Refer to [Projects available for linking](/deploy-manage/cross-project-search-config.md#cps-compatibility) for tier requirements.
+
 :::{tip}
 For best results, set the default {{cps-init}} scope for each space **before** you link projects.
 :::
@@ -89,6 +91,8 @@ Space settings are managed in {{kib}}.
 
 ::::{note}
 The default {{cps}} scope is a space setting, not an access control. Users can still set the scope at the query level. You can also [manage user access](#manage-user-and-api-key-access).
+
+If a space already has a non-default scope, for example after a tier downgrade, the **{{cps-cap}}** panel stays visible so you can reset it to **All projects**. After you save that change, the panel no longer appears.
 ::::
 
 ## Next steps


### PR DESCRIPTION
## Summary

This PR addresses #7635 with the following change:

- **`deploy-manage/cross-project-search-config/cps-config-access-and-scope.md`**: notes that if a space already has a non-default cross-project search scope (for example after a tier downgrade), the **Cross-project search** panel stays visible in space settings so you can reset it to **All projects**, after which it no longer appears.

The base fact from the issue ("the panel doesn't appear on an ineligible tier") is not included: it's fully implied by the already-documented tier requirement ("Elastic Security Serverless and Elastic Observability Serverless projects require the Complete feature tier... Essentials tier is not compatible with cross-project search" in [Projects available for linking](https://www.elastic.co/docs/deploy-manage/cross-project-search-config#cps-compatibility)). Restating it here would duplicate that fact without adding information. The downgrade exception is the one genuinely new, non-obvious behavior: it breaks the otherwise clean "ineligible tier = no CPS UI at all" expectation, so it earns its own note.

## Resolves

Closes #7635

---

> **AI-generated draft** — created with Claude Sonnet 5.
> Review all generated content for factual accuracy before merging.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool(s) and model(s) used: Claude Code, Claude Sonnet 5.
