### PR TITLE
Grant actions:write to triage and size agentic workflows

### DIFF
--- a/.github/workflows/docs-size.yml
+++ b/.github/workflows/docs-size.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   discussions: write
   issues: write

--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   discussions: write
   issues: write


### PR DESCRIPTION
## Summary

Changes `actions: read` → `actions: write` in `docs-triage.yml` and `docs-size.yml`.

## Why

The `conclusion` job in the reusable workflows (`gh-aw-issue-triage`, `gh-aw-issue-size`) calls `actions/cache/save` to persist daily AIC usage data. A calling workflow can only grant permissions it holds — currently `actions: read` — so the cache save fails with:

```
cache write denied: token has no writable scopes
```

The reusable workflows in docs-actions are updated to request `actions: write` in elastic/docs-actions#275.

## Test plan

- [ ] Trigger `/triage` on a test issue — confirm no cache-write error in the conclusion log.
- [ ] Trigger `/size` on a test issue — same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)