### PR TITLE
Add API Explorer declarations for assembler staging

### DIFF
--- a/api/kibana/kibana-api-overview.md
+++ b/api/kibana/kibana-api-overview.md
@@ -1,0 +1,19 @@
+---
+navigation_title: Spaces
+---
+# Kibana spaces
+
+Spaces enable you to organize your dashboards and other saved objects into meaningful categories.
+You can use the default space or create your own spaces.
+
+To run APIs in non-default spaces, you must add `s/{space_id}/` to the path.
+For example:
+
+```bash
+curl -X GET "http://${KIBANA_URL}/s/marketing/api/data_views" \
+-H "Authorization: ApiKey ${API_KEY}"
+```
+
+If you use the Kibana console to send API requests, it automatically adds the appropriate space identifier.
+
+To learn more, check out [Spaces](https://www.elastic.co/docs/deploy-manage/manage-spaces).

--- a/docset.yml
+++ b/docset.yml
@@ -4,6 +4,9 @@ max_toc_depth: 2
 features:
   primary-nav: true
 
+# API Explorer (staging only). This block is consumed by docs-builder when the
+# assembler-api-explorer feature flag is enabled (staging today). Production and
+# other environments ignore these declarations until the rollout completes.
 api:
   # CloudFront remote specs — mirror https://d29hkgsdo66d1n.cloudfront.net/index.json.
   # No local spec files: each key fetches remotely on serve/build. Paths: /api/<key>/

--- a/docset.yml
+++ b/docset.yml
@@ -4,6 +4,36 @@ max_toc_depth: 2
 features:
   primary-nav: true
 
+api:
+  # CloudFront remote specs — mirror https://d29hkgsdo66d1n.cloudfront.net/index.json.
+  # No local spec files: each key fetches remotely on serve/build. Paths: /api/<key>/
+  elasticsearch:
+    - spec: elasticsearch.json
+      product: elasticsearch
+      repository: elastic/elasticsearch-specification
+  elasticsearch-serverless:
+    - spec: elasticsearch-serverless.json
+      product: serverless-elasticsearch
+      repository: elastic/elasticsearch-specification
+  kibana:
+    - spec: kibana.yaml
+      product: kibana
+      repository: elastic/kibana
+      children:
+        - file: kibana-api-overview.md
+  kibana-serverless:
+    - spec: kibana-serverless.yaml
+      product: kibana
+      repository: elastic/kibana
+  cloud-connect:
+    - spec: cloud-connect.yml
+      product: ess
+      repository: elastic/cloud-connected-api
+  cloud-serverless:
+    - spec: elastic-cloud-serverless.yml
+      product: cloud-serverless
+      repository: elastic/serverless-api-specification
+
 cta:
   monitor-kubernetes:
     button:


### PR DESCRIPTION
## Why

Assembler API Explorer generation now discovers `api:` blocks from assembled docsets instead of docs-builder. The narrative docset must own the site-wide API declarations so staging builds can render `/docs/api/` after the docs-builder change lands.

## What

Adds the six remote `api:` keys to `docset.yml` and moves the Kibana spaces child page to `api/kibana/kibana-api-overview.md`. Explicit `repository:` values are kept so specs resolve from their owner repos even though the declaring checkout is docs-content.

## Notes

Land this PR before or together with [elastic/docs-builder#3819](https://github.com/elastic/docs-builder/pull/3819).

Made with [Cursor](https://cursor.com)