### PR TITLE
docs: document the Managed policy filter in ILM policy selectors (#7637)

### DIFF
--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -17,7 +17,9 @@ Follow these steps to configure or remove data stream lifecycle settings for an 
 - [Remove the lifecycle for a data stream](#delete-lifecycle)
 - [Manage data retention on the Streams page](#data-retention-streams)
 
-These steps configure data stream lifecycle settings directly. {applies_to}`stack: ga 9.5+` You can also select an existing {{ilm-init}} policy from the same **Edit data lifecycle** flyout. For the full set of {{ilm-init}} configuration options, refer to the [{{ilm-init}} documentation](/manage-data/lifecycle/index-lifecycle-management.md). For a comparison between the two, refer to [](/manage-data/lifecycle.md).
+These steps configure data stream lifecycle settings directly. For the full set of {{ilm-init}} configuration options, refer to the [{{ilm-init}} documentation](/manage-data/lifecycle/index-lifecycle-management.md). For a comparison between the two, refer to [](/manage-data/lifecycle.md).
+
+{applies_to}`stack: ga 9.5+` You can also select an existing {{ilm-init}} policy from the same **Edit data lifecycle** flyout used in the steps below.
 
 ## Set a data stream's lifecycle [set-lifecycle]
 

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -19,7 +19,6 @@ Follow these steps to configure or remove data stream lifecycle settings for an 
 
 These steps configure data stream lifecycle settings directly. For the full set of {{ilm-init}} configuration options, refer to the [{{ilm-init}} documentation](/manage-data/lifecycle/index-lifecycle-management.md). For a comparison between the two, refer to [](/manage-data/lifecycle.md).
 
-
 ## Set a data stream's lifecycle [set-lifecycle]
 
 To add or modify the retention period of your data stream you can use the **{{index-manage-app}}** tools in {{kib}} or the {{es}} [lifecycle API]({{es-apis}}operation/operation-indices-put-data-lifecycle).

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -17,15 +17,15 @@ Follow these steps to configure or remove data stream lifecycle settings for an 
 - [Remove the lifecycle for a data stream](#delete-lifecycle)
 - [Manage data retention on the Streams page](#data-retention-streams)
 
-These steps are for data stream lifecycle only. For the steps to configure {{ilm}}, refer to the [{{ilm-init}} documentation](/manage-data/lifecycle/index-lifecycle-management.md). For a comparison between the two, refer to [](/manage-data/lifecycle.md).
+These steps configure data stream lifecycle settings directly. {applies_to}`stack: ga 9.5+` You can also select an existing {{ilm-init}} policy from the same **Edit data lifecycle** flyout. For the full set of {{ilm-init}} configuration options, refer to the [{{ilm-init}} documentation](/manage-data/lifecycle/index-lifecycle-management.md). For a comparison between the two, refer to [](/manage-data/lifecycle.md).
 
 ## Set a data stream's lifecycle [set-lifecycle]
 
 To add or modify the retention period of your data stream you can use the **{{index-manage-app}}** tools in {{kib}} or the {{es}} [lifecycle API]({{es-apis}}operation/operation-indices-put-data-lifecycle).
 
-:::::{tab-set}
+::::::{tab-set}
 :group: kibana-api
-:::{tab-item} {{kib}}
+:::::{tab-item} {{kib}}
 :sync: kibana
 
 To change the data retention settings for a data stream:
@@ -34,15 +34,39 @@ To change the data retention settings for a data stream:
 1. Open the **Data Streams** tab.
 1. Use the search tool to find the data stream you're looking for.
 1. Select the data stream to view its details.
-1. In the data stream details pane, select **Manage > Edit data retention** to adjust the settings. You can do any of the following:
+1. In the data stream details pane:
+
+    ::::{applies-switch}
+
+    :::{applies-item} stack: ga 9.5+
+
+    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select one of the following lifecycle methods:
+
+    - **Data stream lifecycle**: Select how long to retain your data, in days, hours, minutes, or seconds, or select **Keep data indefinitely** so your data stream is still managed but the data is never deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
+    - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
+
+        Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+
+    Select **Apply** to save your changes.
+
+    :::
+
+    :::{applies-item} stack: ga 9.0-9.4
+
+    Select **Manage** → **Edit data retention** to adjust the settings. You can do any of the following:
 
     - Select how long to retain your data, in days, hours, minutes, or seconds.
-    - Choose to **Keep data indefinitely**, so that your data will not be deleted. Your data stream is still managed but the data will never be deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
+    - Select **Keep data indefinitely**, so that your data will not be deleted. Your data stream is still managed but the data will never be deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
     - Disable **Enable data retention** to turn off data stream lifecycle management for your data stream.
 
     If the data stream is already managed by [{{ilm-init}}](/manage-data/lifecycle/index-lifecycle-management.md), to edit the data retention settings you must edit the associated {{ilm-init}} policy.
-:::
-:::{tab-item} API
+
+    :::
+
+    ::::
+
+:::::
+:::::{tab-item} API
 :sync: api
 
 To change the data retention settings for a data stream:
@@ -66,8 +90,8 @@ To change the data retention settings for a data stream:
     ```
 
     1. The retention period of this data stream is set to 30 days. This means that {{es}} is allowed to delete data that is older than 30 days at its own discretion.
-:::
 :::::
+::::::
 
 The changes in the lifecycle are applied on all backing indices of the data stream.
 

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -62,7 +62,7 @@ To change the data retention settings for a data stream:
         - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
 
             :::{tip}
-            Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+            Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Select the **Managed** filter next to the search field to reveal them.
             :::
 
     1. Select **Apply** to save your changes.

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -40,6 +40,16 @@ To change the data retention settings for a data stream:
 
     ::::{applies-switch}
 
+    :::{applies-item} serverless: ga
+
+    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select how long to retain your data, in days, hours, minutes, or seconds, or select **Keep data indefinitely** so your data stream is still managed but the data is never deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
+
+    {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
+
+    Select **Apply** to save your changes.
+
+    :::
+
     :::{applies-item} stack: ga 9.5+
 
     Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select one of the following lifecycle methods:
@@ -48,16 +58,6 @@ To change the data retention settings for a data stream:
     - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
 
         Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
-
-    Select **Apply** to save your changes.
-
-    :::
-
-    :::{applies-item} serverless: ga
-
-    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select how long to retain your data, in days, hours, minutes, or seconds, or select **Keep data indefinitely** so your data stream is still managed but the data is never deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
-
-    {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
 
     Select **Apply** to save your changes.
 

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -24,9 +24,9 @@ These steps configure data stream lifecycle settings directly. For the full set 
 
 To add or modify the retention period of your data stream you can use the **{{index-manage-app}}** tools in {{kib}} or the {{es}} [lifecycle API]({{es-apis}}operation/operation-indices-put-data-lifecycle).
 
-::::::{tab-set}
+:::::::{tab-set}
 :group: kibana-api
-:::::{tab-item} {{kib}}
+::::::{tab-item} {{kib}}
 :sync: kibana
 
 To change the data retention settings for a data stream:
@@ -37,23 +37,27 @@ To change the data retention settings for a data stream:
 1. Select the data stream to view its details.
 1. In the data stream details pane:
 
-    ::::{applies-switch}
+    :::::{applies-switch}
 
-    :::{applies-item} serverless: ga
+    ::::{applies-item} serverless: ga
 
     1. Select {icon}`gear` **Actions** → **Edit data lifecycle**.
-    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and configure retention in the **Data phases** panel. The data stream keeps this configuration even if the index template's lifecycle settings change later, until you turn **Inherit lifecycle from index template** back on.
+    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and configure retention in the **Data phases** panel.
     1. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age. Leave **Delete phase** off to keep your data indefinitely.
     1. Select **Apply** to save your changes.
 
     {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
 
+    :::{tip}
+    Turning off **Inherit lifecycle from index template** sets an explicit lifecycle configuration on the data stream. Selecting **Apply** updates the data stream's existing backing indices right away, not just new ones, and the setting continues to apply to backing indices created later, for example by rollover, until you turn **Inherit lifecycle from index template** back on. This only affects the **Successful data** tab. The **Failed data** tab has its own, separate inheritance setting.
     :::
 
-    :::{applies-item} stack: ga 9.5+
+    ::::
+
+    ::::{applies-item} stack: ga 9.5+
 
     1. Select {icon}`gear` **Actions** → **Edit data lifecycle**.
-    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and select one of the following lifecycle methods. The data stream keeps whichever method you choose even if the index template's lifecycle settings change later, until you turn **Inherit lifecycle from index template** back on.
+    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and select one of the following lifecycle methods:
 
         - **Data stream lifecycle**: Configure retention in the **Data phases** panel. The **Hot phase** is always on. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave it off to keep your data indefinitely. With an Enterprise license and a default snapshot repository configured, you can also turn on **Frozen phase** to move data to a searchable snapshot before it's deleted.
         - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
@@ -62,7 +66,11 @@ To change the data retention settings for a data stream:
 
     1. Select **Apply** to save your changes.
 
+    :::{tip}
+    Turning off **Inherit lifecycle from index template** sets an explicit lifecycle configuration on the data stream. Selecting **Apply** updates the data stream's existing backing indices right away, not just new ones, and the setting continues to apply to backing indices created later, for example by rollover, until you turn **Inherit lifecycle from index template** back on. This only affects the **Successful data** tab. The **Failed data** tab has its own, separate inheritance setting.
     :::
+
+    ::::
 
     :::{applies-item} stack: ga 9.0-9.4
 
@@ -76,10 +84,10 @@ To change the data retention settings for a data stream:
 
     :::
 
-    ::::
+    :::::
 
-:::::
-:::::{tab-item} API
+::::::
+::::::{tab-item} API
 :sync: api
 
 To change the data retention settings for a data stream:
@@ -103,8 +111,8 @@ To change the data retention settings for a data stream:
     ```
 
     1. The retention period of this data stream is set to 30 days. This means that {{es}} is allowed to delete data that is older than 30 days at its own discretion.
-:::::
 ::::::
+:::::::
 
 The changes in the lifecycle are applied on all backing indices of the data stream.
 

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -53,6 +53,16 @@ To change the data retention settings for a data stream:
 
     :::
 
+    :::{applies-item} serverless: ga
+
+    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select how long to retain your data, in days, hours, minutes, or seconds, or select **Keep data indefinitely** so your data stream is still managed but the data is never deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
+
+    {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
+
+    Select **Apply** to save your changes.
+
+    :::
+
     :::{applies-item} stack: ga 9.0-9.4
 
     Select **Manage** → **Edit data retention** to adjust the settings. You can do any of the following:

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -41,11 +41,9 @@ To change the data retention settings for a data stream:
     ::::{applies-item} serverless: ga
 
     1. Select {icon}`gear` **Actions** → **Edit data lifecycle**.
-    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and configure retention in the **Data phases** panel.
+    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off and configure retention in the **Data phases** panel.
     1. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age. Leave **Delete phase** off to keep your data indefinitely.
     1. Select **Apply** to save your changes.
-
-    {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
 
     :::{tip}
     Turning off **Inherit lifecycle from index template** sets an explicit lifecycle configuration on the data stream. Selecting **Apply** updates the data stream's existing backing indices right away, not just new ones, and the setting continues to apply to backing indices created later, for example by rollover, until you turn **Inherit lifecycle from index template** back on. This only affects the **Successful data** tab. The **Failed data** tab has its own, separate inheritance setting.
@@ -56,7 +54,7 @@ To change the data retention settings for a data stream:
     ::::{applies-item} stack: ga 9.5+
 
     1. Select {icon}`gear` **Actions** → **Edit data lifecycle**.
-    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and select one of the following lifecycle methods:
+    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off and select one of the following lifecycle methods:
 
         - **Data stream lifecycle**: Configure retention in the **Data phases** panel. The **Hot phase** is always on. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave it off to keep your data indefinitely. With an Enterprise license and a default snapshot repository configured, you can also turn on **Frozen phase** to move data to a searchable snapshot before it's deleted.
         - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -19,7 +19,6 @@ Follow these steps to configure or remove data stream lifecycle settings for an 
 
 These steps configure data stream lifecycle settings directly. For the full set of {{ilm-init}} configuration options, refer to the [{{ilm-init}} documentation](/manage-data/lifecycle/index-lifecycle-management.md). For a comparison between the two, refer to [](/manage-data/lifecycle.md).
 
-{applies_to}`stack: ga 9.5+` You can also select an existing {{ilm-init}} policy from the same **Edit data lifecycle** flyout used in the steps below.
 
 ## Set a data stream's lifecycle [set-lifecycle]
 

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -42,7 +42,7 @@ To change the data retention settings for a data stream:
 
     :::{applies-item} serverless: ga
 
-    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select how long to retain your data, in days, hours, minutes, or seconds, or select **Keep data indefinitely** so your data stream is still managed but the data is never deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
+    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and use the **Data phases** panel to configure retention. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave **Delete phase** off to keep your data indefinitely.
 
     {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
 
@@ -54,7 +54,7 @@ To change the data retention settings for a data stream:
 
     Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select one of the following lifecycle methods:
 
-    - **Data stream lifecycle**: Select how long to retain your data, in days, hours, minutes, or seconds, or select **Keep data indefinitely** so your data stream is still managed but the data is never deleted. Managing a time series data stream such as for logs or metrics enables {{es}} to better store your data even if you do not use a retention period.
+    - **Data stream lifecycle**: Configure retention using the **Data phases** panel. The **Hot phase** is always on. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave **Delete phase** off to keep your data indefinitely. With an Enterprise license and a default snapshot repository configured, you can also turn on **Frozen phase** to move data to a searchable snapshot before it's deleted.
     - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
 
         Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -61,7 +61,9 @@ To change the data retention settings for a data stream:
         - **Data stream lifecycle**: Configure retention in the **Data phases** panel. The **Hot phase** is always on. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave it off to keep your data indefinitely. With an Enterprise license and a default snapshot repository configured, you can also turn on **Frozen phase** to move data to a searchable snapshot before it's deleted.
         - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
 
-            Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+            :::{tip}
+            Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+            :::
 
     1. Select **Apply** to save your changes.
 

--- a/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
+++ b/manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md
@@ -42,24 +42,26 @@ To change the data retention settings for a data stream:
 
     :::{applies-item} serverless: ga
 
-    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and use the **Data phases** panel to configure retention. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave **Delete phase** off to keep your data indefinitely.
+    1. Select {icon}`gear` **Actions** → **Edit data lifecycle**.
+    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and configure retention in the **Data phases** panel. The data stream keeps this configuration even if the index template's lifecycle settings change later, until you turn **Inherit lifecycle from index template** back on.
+    1. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age. Leave **Delete phase** off to keep your data indefinitely.
+    1. Select **Apply** to save your changes.
 
     {{ilm-init}} policies aren't available in {{serverless-short}}, so the **{{ilm-init}} policy** method isn't offered here.
-
-    Select **Apply** to save your changes.
 
     :::
 
     :::{applies-item} stack: ga 9.5+
 
-    Select {icon}`gear` **Actions** → **Edit data lifecycle**. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn off **Inherit lifecycle from index template**, if enabled, and select one of the following lifecycle methods:
+    1. Select {icon}`gear` **Actions** → **Edit data lifecycle**.
+    1. To use the lifecycle settings from the data stream's index template, turn on **Inherit lifecycle from index template**. Otherwise, turn it off, if enabled, and select one of the following lifecycle methods. The data stream keeps whichever method you choose even if the index template's lifecycle settings change later, until you turn **Inherit lifecycle from index template** back on.
 
-    - **Data stream lifecycle**: Configure retention using the **Data phases** panel. The **Hot phase** is always on. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave **Delete phase** off to keep your data indefinitely. With an Enterprise license and a default snapshot repository configured, you can also turn on **Frozen phase** to move data to a searchable snapshot before it's deleted.
-    - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
+        - **Data stream lifecycle**: Configure retention in the **Data phases** panel. The **Hot phase** is always on. Turn on **Delete phase** and set **Delete after** to a duration, in days, hours, minutes, or seconds, to delete data once it reaches that age, or leave it off to keep your data indefinitely. With an Enterprise license and a default snapshot repository configured, you can also turn on **Frozen phase** to move data to a searchable snapshot before it's deleted.
+        - **{{ilm-init}} policy**: Select an existing {{ilm-init}} policy from the list.
 
-        Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+            Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A data stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
 
-    Select **Apply** to save your changes.
+    1. Select **Apply** to save your changes.
 
     :::
 

--- a/solutions/observability/streams/configure-retention.md
+++ b/solutions/observability/streams/configure-retention.md
@@ -131,9 +131,9 @@ Select an existing {{ilm-init}} policy to automate how data moves through phases
 
 To follow an existing policy:
 
-::::{applies-switch}
+:::::{applies-switch}
 
-:::{applies-item} { "stack": "ga 9.5+" }
+::::{applies-item} { "stack": "ga 9.5+" }
 
 1. Select {icon}`controls` **Edit lifecycle method**.
 1. Turn off **Inherit from index template** or **parent stream**, if enabled.
@@ -145,7 +145,7 @@ To follow an existing policy:
 
 After selecting a policy, you can [configure data lifecycle phases](#streams-configure-data-lifecycle-phases) directly from the **Data lifecycle** tab.
 
-:::
+::::
 
 :::{applies-item} { "stack": "ga 9.1-9.4" }
 
@@ -157,7 +157,7 @@ After selecting a policy, you can [configure data lifecycle phases](#streams-con
 
 :::
 
-::::
+:::::
 
 If the policy you need doesn't exist, refer to [Configure a lifecycle policy](../../../manage-data/lifecycle/index-lifecycle-management/configure-lifecycle-policy.md) to create one.
 

--- a/solutions/observability/streams/configure-retention.md
+++ b/solutions/observability/streams/configure-retention.md
@@ -139,6 +139,8 @@ To follow an existing policy:
 1. Turn off **Inherit from index template** or **parent stream**, if enabled.
 1. Select **{{ilm-init}} policy**, then select a predefined policy from the list.
 
+    Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+
 After selecting a policy, you can [configure data lifecycle phases](#streams-configure-data-lifecycle-phases) directly from the **Data lifecycle** tab.
 
 :::

--- a/solutions/observability/streams/configure-retention.md
+++ b/solutions/observability/streams/configure-retention.md
@@ -139,7 +139,9 @@ To follow an existing policy:
 1. Turn off **Inherit from index template** or **parent stream**, if enabled.
 1. Select **{{ilm-init}} policy**, then select a predefined policy from the list.
 
-    Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Starting with {{stack}} version 9.5.1, select the **Managed** filter next to the search field to reveal them. Revealed managed policies show a **Managed** badge. A stream that already follows a managed policy keeps that policy visible in the selector regardless of the filter.
+    :::{tip}
+    Policies managed by Elastic are hidden from the list by default, even if you search for one by name. Select the **Managed** filter next to the search field to reveal them.
+    :::
 
 After selecting a policy, you can [configure data lifecycle phases](#streams-configure-data-lifecycle-phases) directly from the **Data lifecycle** tab.
 


### PR DESCRIPTION
## Summary

Some non core analytics leftover that was sitting in my to-do. This update is scoped to the existing docs and the specific change that was made to the product. It does not fill gaps. The gaps that were found (and there are probably more as these pages have changed a little over the last versions I think) were logged as separate issues.

This PR addresses #7637 with the following changes:

- **`solutions/observability/streams/configure-retention.md`**: In the "Follow an ILM policy" section (9.5+ tab), added a paragraph explaining that Elastic-managed ILM policies are hidden from the selector by default (even when searching by name), that the **Managed** filter next to the search field reveals them, that revealed policies show a **Managed** badge, and that a stream already following a managed policy stays visible regardless of the filter. Scoped `stack: ga 9.5.1` within the existing `stack: ga 9.5+` tab, since the filter itself ships in 9.5.1/9.6.0, not 9.5.0.
- **`manage-data/lifecycle/data-stream/tutorial-update-existing-data-stream.md`**: The "Set a data stream's lifecycle" section was stale — it only documented the pre-9.5 **Edit data retention** action (retention period or keep-indefinitely, no ILM option), and had no serverless coverage at all. Since Stack 9.5.0, that single-item action was replaced by **Edit data lifecycle**, which adds an **Inherit lifecycle from index template** checkbox and a choice between the **Data stream lifecycle** and **ILM policy** methods. Added a `stack: ga 9.5+` tab documenting the current flow (including the same Managed-filter behavior for the ILM policy method), a `serverless: ga` tab for the same flyout without the ILM method (ILM isn't available in serverless — verified in source), and preserved the `stack: ga 9.0-9.4` legacy flow. Also updated the page's intro sentence, which claimed these steps were "for data stream lifecycle only," since ILM policy selection is now available directly from the same flyout starting in 9.5.

## Resolves

Closes #7637

---

> **AI-generated draft** — created with Claude Sonnet 5.
> Review all generated content for factual accuracy before merging.