### PR TITLE
docs: clarify inline applies_to placement for standalone paragraphs

### DIFF
--- a/contribute-docs/how-to/cumulative-docs/badge-placement.md
+++ b/contribute-docs/how-to/cumulative-docs/badge-placement.md
@@ -21,6 +21,7 @@ version and deployment type differences in your docs:
 
 * **Pages**: Provide signals that a page applies to the reader.
 * **Headings**: Provide signals about a section’s scope so a user can choose to read or skip it as needed.
+* **Paragraphs**: Call out a single sentence or short passage that's version- or deployment-specific when the rest of the surrounding content isn't.
 * **Lists**: Identify features in a list of features that are exclusive to a specific context, or that were introduced in a specific version or comparing differing requirements, limits, and other simple, mirrored facts.
 * **Definition lists**: Identify settings or options that are exclusive to a specific context, or that were introduced in a specific version.
 * **Tabs**: Provide two sets of procedures when one or more steps in a process differs between contexts. For differences per version or deployment type, you should use [`applies-switch`](https://elastic.github.io/docs-builder/syntax/applies-switch/) instead of a generic [`tab-set`](https://elastic.github.io/docs-builder/syntax/tabs/).
@@ -70,6 +71,26 @@ Do **not** use [inline annotations](https://elastic.github.io/docs-builder/synta
 :alt: Rendering error when using inline applies_to with headings
 ::::
 :::
+
+### Paragraphs [paragraphs]
+
+Use an inline annotation to lead a standalone paragraph when only part of a passage is version- or deployment-specific. Put the badge first in the paragraph, with a blank line separating it from the paragraph before it, so it's unambiguous that the badge scopes only the paragraph it leads.
+
+```markdown
+General statement that applies to every version.
+
+{applies_to}`stack: ga 9.5+` This paragraph only applies starting in Stack 9.5.
+```
+
+:::{warning}
+Do **not** place the annotation between two sentences of the same paragraph. With no blank line separating it from the preceding sentence, it's ambiguous whether the badge scopes the sentence before it, the sentence after it, or both.
+
+```markdown
+General statement. {applies_to}`stack: ga 9.5+` This sentence only applies starting in Stack 9.5.
+```
+:::
+
+If the version-specific content can't stand on its own as a separate paragraph, for example because it depends on the sentence before it, follow the guidelines for [lists](#ordered-and-unordered-lists) or use an [admonition](#admonitions) instead.
 
 ### Ordered and unordered lists [ordered-and-unordered-lists]
 

--- a/contribute-docs/how-to/cumulative-docs/badge-placement.md
+++ b/contribute-docs/how-to/cumulative-docs/badge-placement.md
@@ -74,7 +74,7 @@ Do **not** use [inline annotations](https://elastic.github.io/docs-builder/synta
 
 ### Paragraphs [paragraphs]
 
-Use an inline annotation to lead a standalone paragraph when only part of a passage is version- or deployment-specific. Put the badge first in the paragraph, with a blank line separating it from the paragraph before it, so it's unambiguous that the badge scopes only the paragraph it leads.
+Use an inline annotation to lead a standalone paragraph when only part of a passage is version- or deployment-specific. Separate the tagged paragraph from the rest of the content with a blank line, so it's unambiguous that the badge scopes only that paragraph.
 
 ```markdown
 General statement that applies to every version.
@@ -83,14 +83,14 @@ General statement that applies to every version.
 ```
 
 :::{warning}
-Do **not** place the annotation between two sentences of the same paragraph. With no blank line separating it from the preceding sentence, it's ambiguous whether the badge scopes the sentence before it, the sentence after it, or both.
+Do **not** place the annotation between two sentences of the same paragraph. Without a blank line splitting the sentences into separate paragraphs, it's ambiguous which sentence the badge scopes.
 
 ```markdown
 General statement. {applies_to}`stack: ga 9.5+` This sentence only applies starting in Stack 9.5.
 ```
 :::
 
-If the version-specific content can't stand on its own as a separate paragraph, for example because it depends on the sentence before it, follow the guidelines for [lists](#ordered-and-unordered-lists) or use an [admonition](#admonitions) instead.
+If the version-specific content can't stand on its own as a separate paragraph, for example because it's tightly coupled to the surrounding sentence, follow the guidelines for [lists](#ordered-and-unordered-lists) or use an [admonition](#admonitions) instead.
 
 ### Ordered and unordered lists [ordered-and-unordered-lists]
 


### PR DESCRIPTION
## Summary

- **`contribute-docs/how-to/cumulative-docs/badge-placement.md`**: Added a "Paragraphs" use case and section. The page previously covered pages, headings, lists, definition lists, tables, tabs, admonitions, dropdowns, code blocks, and images, but never addressed a standalone paragraph of prose. That gap let an inline `applies_to` tag get placed floating mid-paragraph between two sentences, which is ambiguous about whether it scopes the sentence before or after it. The new section gives a correct example (tag leads its own paragraph, blank line before it) and an incorrect one (tag floats mid-paragraph), matching the correct/incorrect pattern already used for headings and definition lists on this page.

This surfaced from a real mistake: an AI-assisted PR placed `{applies_to}` mid-paragraph, got corrected, then initially overcorrected by deleting the fact instead of just moving it to its own paragraph — because neither this page nor the derived `docs-applies-to-tagging` skill spelled out that a standalone tagged paragraph is a valid, different case from "floating mid-paragraph."

Vale passes clean on the changed file. The new MyST syntax (a `:::{warning}` admonition wrapping a fenced code block) mirrors the existing headings section's correct/incorrect pattern on this same page.

---

> **AI-generated draft** — created with Claude Sonnet 5.
> Review all generated content for factual accuracy before merging.