### PR TITLE
Clarify expectations around clock sync

### DIFF
--- a/deploy-manage/deploy/self-managed/important-system-configuration.md
+++ b/deploy-manage/deploy/self-managed/important-system-configuration.md
@@ -22,6 +22,7 @@ The following settings **must** be considered before going to production:
 * [](/deploy-manage/deploy/self-managed/file-descriptors.md): Raise open file handles to at least `65,535` (Linux and macOS only).
 * [](/deploy-manage/deploy/self-managed/executable-jna-tmpdir.md): Ensure JNA and native libraries can execute from a temp path that is not mounted `noexec` (Linux only).
 * [](/deploy-manage/deploy/self-managed/system-config-tcpretries.md): Lower `net.ipv4.tcp_retries2` so node and network failures are detected sooner than the Linux default (Linux only).
+* [](/deploy-manage/deploy/self-managed/system-config-clocks.md): Keep system clocks synchronized and free from large discontinuities.
 
 ::::{admonition} How these limits are enforced
 This page lists operating system limits you must set before {{es}} serves production traffic. {{es}} verifies many of these expectations through [bootstrap checks](/deploy-manage/deploy/self-managed/bootstrap-checks.md) at node startup. In production mode, a failed check stops the node from starting rather than only logging a warning.

--- a/deploy-manage/deploy/self-managed/system-config-clocks.md
+++ b/deploy-manage/deploy/self-managed/system-config-clocks.md
@@ -22,7 +22,7 @@ Keep the clocks on all nodes in the cluster synchronized with real time, and avo
 
 A properly-configured time synchronization service typically keeps clocks synchronized to within at most a few milliseconds. A few seconds of clock skew between nodes can cause some confusing effects, but {{es}} otherwise operates normally under these conditions. A skew or discontinuity of over ten seconds can cause unexpected or inefficient behavior.
 
-{{es}} does not rely on clock synchronization for any safety guarantees. For instance, if {{es}} acknowledges a write operation then this operation is guaranteed to be durable regardless of any clock skew or discontinuity.
+{{es}} does not rely on clock synchronization for any safety guarantees. For instance, if {{es}} acknowledges a write operation, then this operation is guaranteed to be durable regardless of any clock skew or discontinuity.
 
 ## Related pages
 

--- a/deploy-manage/deploy/self-managed/system-config-clocks.md
+++ b/deploy-manage/deploy/self-managed/system-config-clocks.md
@@ -18,11 +18,11 @@ products:
 * Timestamped log messages
 * Certain cache invalidation events
 
-Keep the clocks on all nodes in the cluster synchronized with real time, and avoid large discontinuities in these clocks. Run a time synchronization service such as [NTP](http://www.ntp.org/) or Chrony on every host.
+Keep the clocks on all nodes in the cluster synchronized with real time, and avoid discontinuities in these clocks in which the clock time jumps forwards or backwards by a large amount. Run a time synchronization service such as [NTP](http://www.ntp.org/) or Chrony on every host.
 
-A properly-configured time synchronization service will typically keep clocks synchronized to within at most a few milliseconds. A few seconds of clock skew between nodes can cause some confusing effects, but {{es}} will otherwise operate normally in such an environment. A skew or discontinuity of over ten seconds can cause unexpected or inefficient behavior.
+A properly-configured time synchronization service typically keeps clocks synchronized to within at most a few milliseconds. A few seconds of clock skew between nodes can cause some confusing effects, but {{es}} otherwise operates normally under these conditions. A skew or discontinuity of over ten seconds can cause unexpected or inefficient behavior.
 
-{{es}} does not rely on clock synchronization for any safety guarantees. For instance, if {{es}} acknowledges a write operation then this operation is guaranteed to be durable regardless of any clock skew between nodes.
+{{es}} does not rely on clock synchronization for any safety guarantees. For instance, if {{es}} acknowledges a write operation then this operation is guaranteed to be durable regardless of any clock skew or discontinuity.
 
 ## Related pages
 

--- a/deploy-manage/deploy/self-managed/system-config-clocks.md
+++ b/deploy-manage/deploy/self-managed/system-config-clocks.md
@@ -20,7 +20,7 @@ products:
 
 Keep the clocks on all nodes in the cluster synchronized with real time, and avoid large discontinuities in these clocks. Run a time synchronization service such as [NTP](http://www.ntp.org/) or Chrony on every host.
 
-A properly-configured time synchronization service will typically keep clocks synchronized to within at most a few milliseconds. A few seconds of clock skew between nodes may cause some confusing effects, but {{es}} will otherwise operate normally in such an environment. A skew or discontinuity of over ten seconds may cause unexpected or inefficient behavior.
+A properly-configured time synchronization service will typically keep clocks synchronized to within at most a few milliseconds. A few seconds of clock skew between nodes can cause some confusing effects, but {{es}} will otherwise operate normally in such an environment. A skew or discontinuity of over ten seconds can cause unexpected or inefficient behavior.
 
 {{es}} does not rely on clock synchronization for any safety guarantees. For instance, if {{es}} acknowledges a write operation then this operation is guaranteed to be durable regardless of any clock skew between nodes.
 

--- a/deploy-manage/deploy/self-managed/system-config-clocks.md
+++ b/deploy-manage/deploy/self-managed/system-config-clocks.md
@@ -1,0 +1,30 @@
+---
+description: Keep system clocks synchronized and free from large discontinuities.
+applies_to:
+  deployment:
+    self:
+products:
+  - id: elasticsearch
+---
+
+# Synchronize system clocks [system-config-clocks]
+
+{{es}} relies on the system clock of each node for many time-dependent operations. This includes:
+
+* Timestamps recorded during ingest
+* Searches that use `now` (see [date math](elasticsearch://reference/elasticsearch/rest-apis/common-options.md#date-math))
+* Scheduled activities
+* Security features such as API key and token expiry, JWT and SAML time validation, and TLS certificate validity
+* Timestamped log messages
+* Certain cache invalidation events
+
+Keep the clocks on all nodes in the cluster synchronized with real time, and avoid large discontinuities in these clocks. Run a time synchronization service such as [NTP](http://www.ntp.org/) or Chrony on every host.
+
+A properly-configured time synchronization service will typically keep clocks synchronized to within at most a few milliseconds. A few seconds of clock skew between nodes may cause some confusing effects, but {{es}} will otherwise operate normally in such an environment. A skew or discontinuity of over ten seconds may cause unexpected or inefficient behavior.
+
+{{es}} does not rely on clock synchronization for any safety guarantees. For instance, if {{es}} acknowledges a write operation then this operation is guaranteed to be durable regardless of any clock skew between nodes.
+
+## Related pages
+
+* [Schedule trigger](/explore-analyze/alerting/watcher/trigger-schedule.md): How {{watcher}} uses the system clock for schedules
+* [{{kib}} task management](/deploy-manage/distributed-architecture/kibana-tasks-management.md): Clock synchronization for {{kib}} scheduled tasks

--- a/deploy-manage/toc.yml
+++ b/deploy-manage/toc.yml
@@ -301,6 +301,7 @@ toc:
                   - file: deploy/self-managed/max-number-of-threads.md
                   - file: deploy/self-managed/executable-jna-tmpdir.md
                   - file: deploy/self-managed/system-config-tcpretries.md
+                  - file: deploy/self-managed/system-config-clocks.md
                   - file: deploy/self-managed/bootstrap-checks.md
               - file: deploy/self-managed/install-elasticsearch-from-archive-on-linux-macos.md
               - file: deploy/self-managed/install-elasticsearch-with-zip-on-windows.md


### PR DESCRIPTION
Today we don't spell out anywhere the need for system clocks to be
reasonably well synchronized. This commit adds the missing guidance.

Closes elastic/elasticsearch#147398