### PR TITLE
Add links to new clock sync page

### DIFF
--- a/deploy-manage/tools/snapshot-and-restore/create-snapshots.md
+++ b/deploy-manage/tools/snapshot-and-restore/create-snapshots.md
@@ -148,6 +148,7 @@ PUT _slm/policy/nightly-snapshots
 5. If `true`, the policy’s snapshots include the cluster state. This also includes all feature states by default. To only include specific feature states, see [Back up a specific feature state](#back-up-specific-feature-state).
 6. Optional retention rules. This configuration keeps snapshots for 30 days, retaining at least 5 and no more than 50 snapshots regardless of age. See [{{slm-init}} retention](#slm-retention-task) and [Snapshot retention limits](#snapshot-retention-limits).
 
+{{slm-init}} uses the system clock to determine when to take snapshots. To ensure it takes snapshots when expected, [keep the clocks on all nodes synchronized](/deploy-manage/deploy/self-managed/system-config-clocks.md).
 
 
 ### Manually run an {{slm-init}} policy [manually-run-slm-policy]
@@ -165,7 +166,7 @@ The snapshot process runs in the background. To monitor its progress, see [Monit
 
 ### {{slm-init}} retention [slm-retention-task]
 
-{{slm-init}} snapshot retention is a cluster-level task that runs separately from a policy’s snapshot schedule. To control when the {{slm-init}} retention task runs, configure the [`slm.retention_schedule`](elasticsearch://reference/elasticsearch/configuration-reference/snapshot-restore-settings.md#slm-retention-schedule) cluster setting.
+{{slm-init}} snapshot retention is a cluster-level task that runs separately from a policy’s snapshot schedule. Retention ages are measured using the system clock, so [keep node clocks synchronized](/deploy-manage/deploy/self-managed/system-config-clocks.md) to avoid deleting snapshots too early or too late. To control when the {{slm-init}} retention task runs, configure the [`slm.retention_schedule`](elasticsearch://reference/elasticsearch/configuration-reference/snapshot-restore-settings.md#slm-retention-schedule) cluster setting.
 
 ```console
 PUT _cluster/settings

--- a/explore-analyze/alerting/watcher/trigger-schedule.md
+++ b/explore-analyze/alerting/watcher/trigger-schedule.md
@@ -12,10 +12,10 @@ products:
 
 Schedule [triggers](trigger.md) define when the watch execution should start based on date and time. All times are in UTC time unless a timezone is explicitly specified in the schedule.
 
-{{watcher}} uses the system clock to determine the current time. To ensure schedules are triggered when expected, you should synchronize the clocks of all nodes in the cluster using a time service such as [NTP](http://www.ntp.org/).
+{{watcher}} uses the system clock to determine the current time. To ensure schedules are triggered when expected, [keep the clocks on all nodes synchronized](/deploy-manage/deploy/self-managed/system-config-clocks.md).
 
 ::::{note}
-{{watcher}} can’t correct for manual adjustments to the system clock. Be aware when making such changes that watch execution may be affected with watches being skipped or repeated if the adjustment covers their target execution time. This applies to changes made via NTP as well.
+{{watcher}} does not correct for discontinuities in the system clock, in which the clock time jumps forwards or backwards. Discontinuities happen when setting the clock manually, and sometimes when using a time synchronization service if the node's clock is allowed to drift too far out of synchronization. Watches can trigger at unexpected times, or be skipped or repeated, if the system clock experiences a discontinuity.
 ::::
 
 When specifying a timezone for a watch, keep in mind the effect daylight savings time transitions may have on the schedule, especially if the watch is scheduled to run during the transition. Here’s how {{watcher}} handles watches scheduled during discontinuities:


### PR DESCRIPTION
Follow-up to #7912 to link back to the new clock sync page from a few
relevant places elsewhere in the docs.