### PR TITLE
[Observability] Remove Docker Compose from Network Topology docs

### DIFF
--- a/solutions/observability/infra-and-hosts/network-topology.md
+++ b/solutions/observability/infra-and-hosts/network-topology.md
@@ -32,7 +32,7 @@ The Network Topology plugin includes:
 * **A reference {{ls}} pipeline** that walks the IF-MIB (interface counters and status), IP-MIB (ARP tables and IP address assignments), BRIDGE-MIB (MAC address forwarding tables), BGP4-MIB (BGP peer sessions), and OSPF-MIB (OSPF neighbor adjacencies) on each target device at a configurable poll interval. The pipeline handles poll timeouts, missing OID branches on devices that don't support a given MIB, and batching across large device inventories.
 * **A `snmp-device-enrichment` ingest pipeline** that parses each device's `sysDescr` string to assign a normalized `host.type` (router, switch, firewall, access point, server) and `observer.vendor`. The pipeline recognizes common vendors out of the box (Cisco, Juniper, Arista, Fortinet, Palo Alto, HPE, Aruba) and is extensible for less common hardware.
 * **An interactive topology graph** in {{kib}}'s Observability navigation that builds an adjacency graph from ARP, MAC table, BGP, and OSPF relationships and renders it as a force-directed layout you can zoom, pan, and rearrange. Clicking a device opens a flyout with its interface table, ARP neighbors, BGP peers, and OSPF adjacencies.
-* **A sample data generator** and Docker Compose dev environment, so you can evaluate the plugin with a realistic multi-site network before connecting to live infrastructure.
+* **A sample data generator**, so you can evaluate the plugin with a realistic multi-site network before connecting to live infrastructure. For local development, use {{kib}}'s shared {{es}} workflow; see the [plugin README](https://github.com/elastic/kibana-network-topology-plugin).
 
 ## How it works [network-topology-how-it-works]
 

--- a/solutions/observability/infra-and-hosts/network-topology/monitor-network-devices.md
+++ b/solutions/observability/infra-and-hosts/network-topology/monitor-network-devices.md
@@ -33,7 +33,7 @@ You need:
 * {{ls}} installed and able to reach your network devices.
 
 :::{tip}
-If you don't have SNMP-enabled devices to point at yet, you can evaluate the plugin against simulated data using the sample data generator and Docker Compose dev environment included in the [Network Topology plugin repository](https://github.com/elastic/kibana-network-topology-plugin).
+If you don't have SNMP-enabled devices to point at yet, you can evaluate the plugin against simulated data using the sample data generator in the [Network Topology plugin repository](https://github.com/elastic/kibana-network-topology-plugin). The plugin is not a standalone app and does not require a dedicated {{es}} cluster — use your existing self-managed stack, or follow the plugin README's Development Quick Start.
 :::
 
 ## Step 1: Install the plugin [network-topology-install-plugin]


### PR DESCRIPTION
## Summary

Removes outdated Docker Compose references from the Network Topology docs.

The Network Topology plugin no longer ships a plugin-owned Docker Compose dev environment (removed in [elastic/kibana-network-topology-plugin#20](https://github.com/elastic/kibana-network-topology-plugin/pull/20)). The published docs still described that setup on:

- [Network Topology overview](https://www.elastic.co/docs/solutions/observability/infra-and-hosts/network-topology#network-topology-features)
- [Tutorial: Monitor your network devices](https://www.elastic.co/docs/solutions/observability/infra-and-hosts/network-topology/monitor-network-devices)

This PR updates those pages to:

- Keep the sample data generator as the way to evaluate the plugin without live SNMP devices
- Point local development at Kibana’s shared Elasticsearch workflow / the [plugin README](https://github.com/elastic/kibana-network-topology-plugin) Development Quick Start
- Clarify that the plugin is not a standalone app and does not require a dedicated Elasticsearch cluster

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor (Cursor Grok 4.5)