### PR TITLE
Mark Agent Builder OAuth as generally available

### DIFF
--- a/explore-analyze/ai-features/agent-builder/mcp-server-api-keys.md
+++ b/explore-analyze/ai-features/agent-builder/mcp-server-api-keys.md
@@ -20,7 +20,7 @@ products:
 The [{{agent-builder}} MCP server](mcp-server.md) supports API key authentication for MCP clients. For example, you can let a scheduled script or automated service query your data through {{agent-builder}} tools without a person signing in.
 
 :::{tip}
-:applies_to: serverless: preview
+:applies_to: serverless: ga
 In {{serverless-short}} projects, MCP clients can also authenticate using OAuth 2.1 through an [application connection](/deploy-manage/app-connections/oauth-clients.md). To compare authentication options, refer to [MCP server authentication](mcp-server.md#mcp-server-authentication).
 :::
 

--- a/explore-analyze/ai-features/agent-builder/permissions.md
+++ b/explore-analyze/ai-features/agent-builder/permissions.md
@@ -44,7 +44,7 @@ Grants access to:
 - View tools
 - View skills {applies_to}`stack: ga 9.4+`
 - Access conversations
-- Manage OAuth MCP clients for the [{{agent-builder}} MCP server](mcp-server.md) {applies_to}`serverless: preview`
+- Manage OAuth MCP clients for the [{{agent-builder}} MCP server](mcp-server.md) {applies_to}`serverless: ga`
 
 Instead of `All`, you can pair `Read` with individual sub-features for more granular control over what users can manage:
 
@@ -161,7 +161,7 @@ For granular access, pair `feature_agentBuilder.read` with only the sub-feature 
 :::
 
 :::{admonition} Permissions for MCP clients
-:applies_to: {"serverless": "preview"}
+:applies_to: {"serverless": "ga"}
 
 Roles also determine what an MCP client can do when it connects to the {{agent-builder}} MCP server through OAuth. The MCP client inherits the permissions of the user who authorizes the connection. To learn more, refer to [OAuth for MCP clients](/deploy-manage/app-connections/oauth-clients.md).
 :::


### PR DESCRIPTION
## Summary

- Mark OAuth MCP client permissions as generally available on Serverless.
- Align the API key authentication page with the canonical OAuth and MCP server pages.

Closes elastic/docs-content-internal#1611

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool and model used: OpenAI Codex (GPT-5) for lifecycle-tag updates and consistency checks.

## Validation

- `git diff --check`
- Vale on both changed files (four pre-existing warnings outside the changed lines)
