### PR TITLE
[CPS GA] billing wording

### DIFF
--- a/deploy-manage/_snippets/cps-billing.md
+++ b/deploy-manage/_snippets/cps-billing.md
@@ -8,5 +8,5 @@ Usage is metered and charged based on the following factors:
 For current rates, refer to the [Elastic Cloud Pricing](https://cloud.elastic.co/cloud-pricing-table) page. You can also create a [Serverless estimate](https://cloud.elastic.co/pricing/serverless).
 
 :::{note}
-Billing begins on September 1, 2026. Until then, there are no separate {{cps}} charges.
+Billing begins on September 16, 2026. Until then, there are no separate {{cps}} charges.
 :::

--- a/deploy-manage/_snippets/cps-billing.md
+++ b/deploy-manage/_snippets/cps-billing.md
@@ -1,10 +1,12 @@
-During technical preview, there are no separate {{cps}} charges.
-
-When {{cps-init}} becomes generally available, charges are billed to the origin project. 
+{{cps-cap}} charges are billed to the origin project.
 
 Usage is metered and charged based on the following factors:
 
 * **Retained data volume:** The volume of data retained in your linked projects each month. The rate varies by the type of each linked project, such as Observability, Security, or {{es}}. For Observability linked projects, the rate also depends on the type of retained data.
 * **{{cps-init}} queries:** Cross-project search queries incur a separate data egress charge for data transferred as a result of those queries. This appears as a separate line item on your bill.
 
-From August 1, 2026, the [Elastic Cloud Pricing](https://cloud.elastic.co/cloud-pricing-table) page shows detailed pricing for various {{cps}} scenarios.
+For current rates, refer to the [Elastic Cloud Pricing](https://cloud.elastic.co/cloud-pricing-table) page. You can also create a [Serverless estimate](https://cloud.elastic.co/pricing/serverless).
+
+:::{note}
+Billing begins on September 1, 2026. Until then, there are no separate {{cps}} charges.
+:::


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary

[HOLD FOR GA]

- Updates CPS billing copy for GA: switch to present-tense, direct to the pricing table and Serverless estimator
- Adds billing start date
- Fixes https://github.com/elastic/docs-content-internal/issues/1262

Lifecycle/`applies_to` flip stays in https://github.com/elastic/docs-content-internal/issues/1592

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: grok 4.5 :(

