### PR TITLE
Add Inference to ECH billing dimensions

### DIFF
--- a/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
+++ b/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
@@ -17,6 +17,7 @@ products:
 2. [Data Transfer](#data-transfer)
 3. [Storage](#storage)
 4. [Synthetics](#synthetics)
+5. [Inference](#inference)
 
 Read on for detail about each of these billing dimensions.
 
@@ -109,4 +110,11 @@ Note that reducing either the snapshot frequency or retention period limits the 
 ## Synthetics [synthetics] 
 
 Synthetic Monitoring browser tests are charged per test run (metered in 60 second increments). Lightweight tests are charged per location per month (per deployment) for up to 1k simultaneous test run capacity (~2.6 billion tests per month). Tests executed from private locations do not incur an execution charge. All test result data is stored in your deployment and billed for under existing dimensions.
+
+
+## Inference [inference]
+
+[Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) is billed based on tokens used with models on EIS. Token charges appear separately from [deployment capacity](#ram-hours), which covers ML nodes running in your deployment.
+
+To learn how token-based pricing works and how to find Inference usage in the {{ecloud}} Console, refer to [EIS pricing](/explore-analyze/elastic-inference/eis.md#pricing).
 

--- a/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
+++ b/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
@@ -114,5 +114,5 @@ Synthetic Monitoring browser tests are charged per test run (metered in 60 secon
 
 ## Inference [inference]
 
-[Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) is billed separately from [deployment capacity](#ram-hours), which covers ML nodes running in your deployment. For the token-based pricing model and how to find Inference usage in the {{ecloud}} Console, refer to [EIS pricing](/explore-analyze/elastic-inference/eis.md#pricing).
+[Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) is billed separately from [deployment capacity](#ram-hours), which includes ML nodes running in your deployment. For the token-based pricing model and how to find {{infer}} usage in the {{ecloud}} Console, refer to [EIS pricing](/explore-analyze/elastic-inference/eis.md#pricing).
 

--- a/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
+++ b/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md
@@ -114,7 +114,5 @@ Synthetic Monitoring browser tests are charged per test run (metered in 60 secon
 
 ## Inference [inference]
 
-[Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) is billed based on tokens used with models on EIS. Token charges appear separately from [deployment capacity](#ram-hours), which covers ML nodes running in your deployment.
-
-To learn how token-based pricing works and how to find Inference usage in the {{ecloud}} Console, refer to [EIS pricing](/explore-analyze/elastic-inference/eis.md#pricing).
+[Elastic {{infer-cap}} Service (EIS)](/explore-analyze/elastic-inference/eis.md) is billed separately from [deployment capacity](#ram-hours), which covers ML nodes running in your deployment. For the token-based pricing model and how to find Inference usage in the {{ecloud}} Console, refer to [EIS pricing](/explore-analyze/elastic-inference/eis.md#pricing).
 

--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -217,8 +217,6 @@ You can now use `semantic_text` with the new ELSER endpoint on EIS. To learn how
 
 ## Pricing [pricing]
 
-For how Inference fits among {{ech}} billing dimensions, refer to [Cloud Hosted deployment billing dimensions](/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md#inference).
-
 All models on EIS incur a charge per million tokens. Certain LLM providers charge different prices depending on the prompt size. The pricing details are available on our [Pricing page](https://cloud.elastic.co/cloud-pricing-table?productType=serverless).
 
 This pricing model differs from the existing [Machine Learning Nodes](https://www.elastic.co/docs/explore-analyze/machine-learning/data-frame-analytics/ml-trained-models), which is billed through VCUs consumed.

--- a/explore-analyze/elastic-inference/eis.md
+++ b/explore-analyze/elastic-inference/eis.md
@@ -217,6 +217,8 @@ You can now use `semantic_text` with the new ELSER endpoint on EIS. To learn how
 
 ## Pricing [pricing]
 
+For how Inference fits among {{ech}} billing dimensions, refer to [Cloud Hosted deployment billing dimensions](/deploy-manage/cloud-organization/billing/cloud-hosted-deployment-billing-dimensions.md#inference).
+
 All models on EIS incur a charge per million tokens. Certain LLM providers charge different prices depending on the prompt size. The pricing details are available on our [Pricing page](https://cloud.elastic.co/cloud-pricing-table?productType=serverless).
 
 This pricing model differs from the existing [Machine Learning Nodes](https://www.elastic.co/docs/explore-analyze/machine-learning/data-frame-analytics/ml-trained-models), which is billed through VCUs consumed.


### PR DESCRIPTION
## Summary
- Adds Inference as a fifth billing dimension on the ECH hosted billing dimensions page, with a short section that distinguishes EIS token charges from ML nodes in deployment capacity and points to EIS pricing for detail.
- Closes https://github.com/elastic/docs-content/issues/7609

followup issue for inconsistency between serverless project types for EIS: https://github.com/elastic/docs-content/issues/7939

Made with [Cursor](https://cursor.com)