### PR TITLE
Remove 9.5.0 from ECE download docs and note ECH known issue

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images.md
@@ -76,11 +76,6 @@ Enterprise Search is not available in versions 9.0+.
 | docker.elastic.co/cloud-release/kibana-cloud:9.5.1 | ECE 4.0.0 |
 | docker.elastic.co/cloud-release/elastic-agent-cloud:9.5.1 | ECE 4.0.0 |
 |  |  |
-| [{{es}}, {{kib}}, and APM stack pack: 9.5.0](https://download.elastic.co/cloud-enterprise/versions/9.5.0.zip) | ECE 4.0.0 |
-| docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.5.0 | ECE 4.0.0 |
-| docker.elastic.co/cloud-release/kibana-cloud:9.5.0 | ECE 4.0.0 |
-| docker.elastic.co/cloud-release/elastic-agent-cloud:9.5.0 | ECE 4.0.0 |
-|  |  |
 | [{{es}}, {{kib}}, and APM stack pack: 9.4.5](https://download.elastic.co/cloud-enterprise/versions/9.4.5.zip) | ECE 4.0.0 |
 | docker.elastic.co/cloud-release/elasticsearch-cloud-ess:9.4.5 | ECE 4.0.0 |
 | docker.elastic.co/cloud-release/kibana-cloud:9.4.5 | ECE 4.0.0 |

--- a/deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions.md
+++ b/deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions.md
@@ -53,7 +53,6 @@ Following is the full list of available packs containing {{stack}} versions. Not
 | Stack pack download link | Minimum required ECE version |
 | --- | --- |
 | [{{es}}, {{kib}}, and APM stack pack: 9.5.1](https://download.elastic.co/cloud-enterprise/versions/9.5.1.zip) | ECE 4.0.0 | Kibana requires 2GB instance
-| [{{es}}, {{kib}}, and APM stack pack: 9.5.0](https://download.elastic.co/cloud-enterprise/versions/9.5.0.zip) | ECE 4.0.0 | Kibana requires 2GB instance
 | [{{es}}, {{kib}}, and APM stack pack: 9.4.5](https://download.elastic.co/cloud-enterprise/versions/9.4.5.zip) | ECE 4.0.0 | Kibana requires 2GB instance
 | [{{es}}, {{kib}}, and APM stack pack: 9.4.4](https://download.elastic.co/cloud-enterprise/versions/9.4.4.zip) | ECE 4.0.0 | Kibana requires 2GB instance
 | [{{es}}, {{kib}}, and APM stack pack: 9.4.3](https://download.elastic.co/cloud-enterprise/versions/9.4.3.zip) | ECE 4.0.0 | Kibana requires 2GB instance

--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -39,11 +39,11 @@ To learn more about the features that are supported by {{ecloud}}, check [{{eclo
 
 ## Stack versions [ec-stack-versions]
 
+* Due to a known issue, {{es}} 9.5.0 may return incorrect results from searches that exclude values using a `must_not` clause, where the excluded field has doc values enabled but is not indexed for search. Version 9.5.0 is unavailable for new deployments and upgrades. Review [this KB article](https://support.elastic.co/knowledge/00f3a35b) for more guidance on the known issue.
+
 * Due to a known issue with the {{stack}}, certain upgrade paths to and from version 8.17 are currently blocked or disabled. Review [this KB article](https://support.elastic.co/knowledge/7c3ad709) for more guidance on the known issue. Additionally, review [this KB article](https://support.elastic.co/knowledge/e87d76a5) for detailed information regarding the specific versions affected. 
 
 * Due to a known issue with the {{stack}}, the upgrade path from 9.1.10 to 9.2.4 is unavailable. Refer to [Elasticsearch known issues](elasticsearch://release-notes/known-issues.md#elasticsearch-9.2.4-known-issues) for more information on the underlying issue.
-
-* Due to a known issue, {{es}} 9.5.0 may return incorrect results from searches that exclude values using a `must_not` clause, where the excluded field has doc values enabled but is not indexed for search. Version 9.5.0 is unavailable for new deployments and upgrades. Review [this KB article](https://support.elastic.co/knowledge/00f3a35b) for more guidance on the known issue.
 
 
 ## Security [ec-restrictions-security]

--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -39,7 +39,7 @@ To learn more about the features that are supported by {{ecloud}}, check [{{eclo
 
 ## Stack versions [ec-stack-versions]
 
-* Due to a known issue, {{es}} 9.5.0 may return incorrect results from searches that exclude values using a `must_not` clause, where the excluded field has doc values enabled but is not indexed for search. Version 9.5.0 is unavailable for new deployments and upgrades. Review [this KB article](https://support.elastic.co/knowledge/00f3a35b) for more guidance on the known issue.
+* Due to a known issue, {{es}} 9.5.0 can return incorrect results from searches that exclude values using a `must_not` clause, where the excluded field has doc values enabled but is not indexed for search. Version 9.5.0 is unavailable for new deployments and upgrades. Review [this KB article](https://support.elastic.co/knowledge/00f3a35b) for more guidance on the known issue.
 
 * Due to a known issue with the {{stack}}, certain upgrade paths to and from version 8.17 are currently blocked or disabled. Review [this KB article](https://support.elastic.co/knowledge/7c3ad709) for more guidance on the known issue. Additionally, review [this KB article](https://support.elastic.co/knowledge/e87d76a5) for detailed information regarding the specific versions affected. 
 

--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -43,6 +43,8 @@ To learn more about the features that are supported by {{ecloud}}, check [{{eclo
 
 * Due to a known issue with the {{stack}}, the upgrade path from 9.1.10 to 9.2.4 is unavailable. Refer to [Elasticsearch known issues](elasticsearch://release-notes/known-issues.md#elasticsearch-9.2.4-known-issues) for more information on the underlying issue.
 
+* Due to a known issue with the {{stack}}, version 9.5.0 is unavailable for new deployments and upgrades. Refer to [Elasticsearch known issues](elasticsearch://release-notes/known-issues.md#elasticsearch-9.5.0-known-issues) for more information on the underlying issue.
+
 
 ## Security [ec-restrictions-security]
 

--- a/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
+++ b/deploy-manage/deploy/elastic-cloud/restrictions-known-problems.md
@@ -43,7 +43,7 @@ To learn more about the features that are supported by {{ecloud}}, check [{{eclo
 
 * Due to a known issue with the {{stack}}, the upgrade path from 9.1.10 to 9.2.4 is unavailable. Refer to [Elasticsearch known issues](elasticsearch://release-notes/known-issues.md#elasticsearch-9.2.4-known-issues) for more information on the underlying issue.
 
-* Due to a known issue with the {{stack}}, version 9.5.0 is unavailable for new deployments and upgrades. Refer to [Elasticsearch known issues](elasticsearch://release-notes/known-issues.md#elasticsearch-9.5.0-known-issues) for more information on the underlying issue.
+* Due to a known issue, {{es}} 9.5.0 may return incorrect results from searches that exclude values using a `must_not` clause, where the excluded field has doc values enabled but is not indexed for search. Version 9.5.0 is unavailable for new deployments and upgrades. Review [this KB article](https://support.elastic.co/knowledge/00f3a35b) for more guidance on the known issue.
 
 
 ## Security [ec-restrictions-security]


### PR DESCRIPTION
## Summary
- Remove the 9.5.0 stack pack (and Docker images) from the ECE full download lists. Recent-version tables already point at 9.5.1.
- Add a Stack versions known-issue on the ECH restrictions page: 9.5.0 can return incorrect `must_not` results and is unavailable for new deployments and upgrades. Points at [KB 00f3a35b](https://support.elastic.co/knowledge/00f3a35b).

Related to [#incident-3460-elasticsearch-9-5-0-contains-a-query-correctness-defect](https://elastic.slack.com/archives/C0BNYAPGTS4)
Rel: https://github.com/elastic/cloud-assets/pull/2242

## Test plan
- [ ] [Install ECE offline](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/ece-install-offline-images): full list has 9.5.1 and not 9.5.0.
- [ ] [Manage Elastic Stack versions](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/manage-elastic-stack-versions): full list has 9.5.1 and not 9.5.0.
- [ ] [Restrictions and known problems](https://www.elastic.co/docs/deploy-manage/deploy/elastic-cloud/restrictions-known-problems#ec-stack-versions): 9.5.0 bullet links to https://support.elastic.co/knowledge/00f3a35b.

<small>*(AI-authored via Cursor 🤖)*</small>