### PR TITLE
Fix broken example in TSDS quickstart

### DIFF
--- a/manage-data/data-store/data-streams/quickstart-tsds.md
+++ b/manage-data/data-store/data-streams/quickstart-tsds.md
@@ -210,9 +210,9 @@ If you get an error about timestamp values, check the error response for the val
 Now that your data stream has some documents, you can use the ES|QL [`_query` endpoint]({{es-apis}}operation/operation-esql-query) to query the data. This sample aggregation shows the maximum of average temperature per sensor for each location, in hourly buckets.
 
 ```console
-POST _query
+POST _query?format=txt
 {
-  query: "TS quickstart-weather | STATS max(avg_over_time(temperature) BY location, TBUCKET(1h)"
+  "query": "TS quickstart-weather | STATS max(avg_over_time(temperature)) BY location, TBUCKET(1h)"
 }
 ```
 


### PR DESCRIPTION
## Summary

The ES|QL query in https://www.elastic.co/docs/manage-data/data-store/data-streams/quickstart-tsds fails with the following error:

```yaml
{
  "error": {
    "root_cause": [
      {
        "type": "parsing_exception",
        "reason": "line 1:62: no viable alternative at input 'max(avg_over_time(temperature) BY'"
      }
    ],
    "type": "parsing_exception",
    "reason": "line 1:62: no viable alternative at input 'max(avg_over_time(temperature) BY'",
    "caused_by": {
      "type": "no_viable_alt_exception",
      "reason": null
    }
  },
  "status": 400
}
```

This PR fixes the example by adding missing quotes and brackets. I've also added `format=txt` so the output is in the format shown.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

