### PR TITLE
Clarify that the FedRAMP table lists differences, not all features

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/fedramp.md
+++ b/deploy-manage/deploy/elastic-cloud/fedramp.md
@@ -17,14 +17,14 @@ All FedRAMP deployments are hosted on AWS GovCloud (U.S.).
 
 Learn about the Elastic FedRAMP offerings:
 
- - [Comparison of available features](#ec-fedramp-comparison)
+ - [Differences from {{ech}}](#ec-fedramp-comparison)
  - [Get started with FedRAMP](#ec-fedramp-get-started)
  - [Limitations](#ec-fedramp-limitations)
  - [FedRAMP FAQ](#ec-fedramp-faq)
 
-## Comparison of available features [ec-fedramp-comparison]
+## Differences from {{ech}} [ec-fedramp-comparison]
 
-This table provides a comparison of features and capabilities included in {{ech}} and all FedRAMP authorized Cloud offerings.
+Most {{ech}} features are also available in FedRAMP authorized Cloud offerings. This table lists only the features and offering details that differ for {{fedramp-mod}} or {{fedramp-high}}.
 
 | Feature | {{ech}} | {{fedramp-mod}} | {{fedramp-high}} |
 |--------------|-----------|--------|-----------|
@@ -38,7 +38,6 @@ This table provides a comparison of features and capabilities included in {{ech}
 | [Bring Your Own Key (BYOK)](/deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md) | Yes | No | No |
 | [Support policy](https://www.elastic.co/support/welcome) | Global coverage | Global coverage or optional U.S. persons on U.S. soil support available | U.S. persons on U.S. soil support |
 | [{{kib}} connectors](kibana://reference/connectors-kibana.md) | All connector types | Email, Index, Webhook, Gen-AI, Bedrock, Gemini, Inference, Slack, Slack-API, PagerDuty | Email, Index, Webhook, Gen-AI, Bedrock, Gemini, Inference, Slack, Slack-API, PagerDuty |
-| [Cross-cluster search](/explore-analyze/cross-cluster-search.md) and [cross-cluster replication](/deploy-manage/tools/cross-cluster-replication.md) | Yes | Yes | Yes |
 | [Private connectivity](/deploy-manage/security/private-connectivity.md) | Yes | Yes | No |
 | [AutoOps](/deploy-manage/monitor/autoops.md) | Yes | No | No |
 | [Synthetic monitoring](/solutions/observability/synthetics/index.md) | Yes | No | No |


### PR DESCRIPTION
Summary:

- Clarifies that the FedRAMP comparison table is a list of differences from Elastic Cloud Hosted, not a complete feature catalog
- Removes the CCS/CCR row because it does not differ across offerings
- Follow-up to #7988

used grok 4.6