### PR TITLE
Fix header in Kafka output documentation to singular "topic"

### DIFF
--- a/reference/fleet/kafka-output.md
+++ b/reference/fleet/kafka-output.md
@@ -179,7 +179,7 @@ This sample configuration forwards events to the output when there are enough ev
     **Default:** `10s`
 
 
-## Topics settings [output-kafka-topics-settings]
+## Topic settings [output-kafka-topics-settings]
 
 Use these options to set the Kafka topic for each {{agent}} event.
 


### PR DESCRIPTION
## Summary

This PR fixes the header in the Kafka output documentation to singular “topic".

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No