### PR TITLE
[Security] 9.5.2 release notes

### DIFF
--- a/release-notes/elastic-security/index.md
+++ b/release-notes/elastic-security/index.md
@@ -27,6 +27,31 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % *
 
+## 9.5.2 [elastic-security-9.5.2-release-notes]
+
+### Features and enhancements [elastic-security-9.5.2-features-enhancements]
+
+* Adds **Destination IP** as a built-in **Group alerts by** option on the alerts table, and includes aggregatable IP fields in the **Custom field** picker [#284769]({{kib-pull}}284769).
+* Improves {{elastic-defend}} logs for a down output connection, including the remaining backoff time.
+
+### Fixes [elastic-security-9.5.2-fixes]
+
+* Fixes an issue where duplicated prebuilt Osquery packs ignored the pack-level schedule and ran queries on a stale hourly interval copied from the original pack [#283635]({{kib-pull}}283635).
+* Fixes the **Created at** column on the Osquery **History** page so scheduled queries show the planned execution time instead of when agents last responded [#283609]({{kib-pull}}283609).
+* Fixes an issue where the OpenAI **Other** connector incorrectly re-enabled **Enable PKI Authentication** after saving with the toggle turned off [#282843]({{kib-pull}}282843).
+* Fixes an issue where new {{elastic-defend}} policies on Platinum licenses enabled **Device Control** by default, even though that feature requires an Enterprise license. Affected policies blocked USB storage and later policy saves failed [#282133]({{kib-pull}}282133).
+* Fixes an issue where entity store tasks kept running after their {{kib}} space was deleted [#281514]({{kib-pull}}281514).
+* Improves the bulk edit toast shown when detection rules are skipped, so it points you to the bulk update dialog for rules that use {{data-sources}} [#280928]({{kib-pull}}280928).
+* Fixes an issue where Automatic Migration rules with a **Partially translated** status did not update to **Translated** after you used **Update missing index pattern** [#278431]({{kib-pull}}278431).
+* Fixes an issue where generating threat hunting leads failed when the number of candidate entities was very large [#275970]({{kib-pull}}275970).
+* Fixes an {{agent}} upgrade failure caused by a failed {{elastic-defend}} `verify` command. Affected endpoints logged `Unable to start endpoint to check version: exit status 2, try install` every 30 seconds.
+* Improves `memory-dump` response actions in {{elastic-defend}} on Windows. Live kernel dumps can include user-space memory when the {{elastic-endpoint}} driver is loaded. Raw memory dumps and live kernel dumps handle cancellation, service shutdown, timeouts, and unavailable-driver cases more reliably.
+* Fixes {{elastic-defend}} on Linux to report DNS event sources as unsupported on kprobe-based kernels.
+* Updates a `curl` dependency in {{elastic-defend}} to resolve [CVE-2024-8096](https://github.com/advisories/GHSA-gv3v-x3f3-7fxm).
+* Updates an OpenSSL dependency in {{elastic-defend}} to resolve multiple CVEs, including [CVE-2026-34182](https://github.com/advisories/GHSA-f9v2-4w9p-2cwc) and [CVE-2025-66199](https://github.com/advisories/GHSA-5888-36j9-c92p).
+* Updates a `zlib` dependency in {{elastic-defend}} to resolve [CVE-2026-27171](https://github.com/advisories/GHSA-h858-mf2m-8jf4).
+
+
 ## 9.5.1 [elastic-security-9.5.1-release-notes]
 
 ### Features and enhancements [elastic-security-9.5.1-features-enhancements]
@@ -37,7 +62,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ### Fixes [elastic-security-9.5.1-fixes]
 
 * Fixes an issue that allowed index Knowledge Base entries to be created as globally readable without the privilege to manage global entries by sending an empty `users` list [#283195]({{kib-pull}}283195).
-* Fixes an issue where the OpenAI **Other** connector incorrectly re-enabled **Enable PKI Authentication** after saving with the toggle turned off [#282843]({{kib-pull}}282843).
 * Fixes an overlap between the tools header and the close icon in the alert details flyout [#282790]({{kib-pull}}282790).
 * Restores the **Source event** link in the **Highlighted fields** section of the new alert details flyout [#282318]({{kib-pull}}282318).
 * Fixes an issue where the **Source event** link in an alert's **Highlighted fields** section failed to open the document when it lived in a hidden restored or partial index [#282272]({{kib-pull}}282272).

--- a/release-notes/elastic-security/index.md
+++ b/release-notes/elastic-security/index.md
@@ -45,6 +45,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 * Fixes an issue where Automatic Migration rules with a **Partially translated** status did not update to **Translated** after you used **Update missing index pattern** [#278431]({{kib-pull}}278431).
 * Fixes an issue where generating threat hunting leads failed when the number of candidate entities was very large [#275970]({{kib-pull}}275970).
 * Fixes an {{agent}} upgrade failure caused by a failed {{elastic-defend}} `verify` command. Affected endpoints logged `Unable to start endpoint to check version: exit status 2, try install` every 30 seconds.
+* Fixes alert suppression creating duplicate alerts instead of updating existing ones when the alert source data uses a nested field structure [#282192]({{kib-pull}}282192).
 * Improves `memory-dump` response actions in {{elastic-defend}} on Windows. Live kernel dumps can include user-space memory when the {{elastic-endpoint}} driver is loaded. Raw memory dumps and live kernel dumps handle cancellation, service shutdown, timeouts, and unavailable-driver cases more reliably.
 * Fixes {{elastic-defend}} on Linux to report DNS event sources as unsupported on kprobe-based kernels.
 * Updates a `curl` dependency in {{elastic-defend}} to resolve [CVE-2024-8096](https://github.com/advisories/GHSA-gv3v-x3f3-7fxm).


### PR DESCRIPTION
Resolves #7974: adds the 9.5.2 Security and Endpoint release notes.


Made with [Cursor](https://cursor.com)