### PR TITLE
[Observability] Add 9.5.2 release notes

### DIFF
--- a/release-notes/elastic-observability/index.md
+++ b/release-notes/elastic-observability/index.md
@@ -26,7 +26,6 @@ To check for security updates, go to [Security announcements for the Elastic sta
 ### Fixes [elastic-observability-9.5.2-fixes]
 * Fixes the metric threshold rule form silently showing no conditions when the source configuration request is slow or fails, instead of showing a loading or error state [#280121]({{kib-pull}}280121).
 * Fixes the {{product.apm}} agent configuration tutorial page exposing the APM Server secret token to users without APM write permissions [#283942]({{kib-pull}}283942).
-* Fixes alert suppression creating duplicate alerts instead of updating existing ones when the alert source data uses a nested field structure [#282192]({{kib-pull}}282192).
 * Fixes an error loading maintenance window status on the Synthetics monitors overview for users with read-only access [#281894]({{kib-pull}}281894).
 
 ## 9.5.1 [elastic-observability-9.5.1-release-notes]

--- a/release-notes/elastic-observability/index.md
+++ b/release-notes/elastic-observability/index.md
@@ -21,6 +21,14 @@ To check for security updates, go to [Security announcements for the Elastic sta
 % ### Fixes [elastic-observability-next-fixes]
 % *
 
+## 9.5.2 [elastic-observability-9.5.2-release-notes]
+
+### Fixes [elastic-observability-9.5.2-fixes]
+* Fixes the metric threshold rule form silently showing no conditions when the source configuration request is slow or fails, instead of showing a loading or error state [#280121]({{kib-pull}}280121).
+* Fixes the {{product.apm}} agent configuration tutorial page exposing the APM Server secret token to users without APM write permissions [#283942]({{kib-pull}}283942).
+* Fixes alert suppression creating duplicate alerts instead of updating existing ones when the alert source data uses a nested field structure [#282192]({{kib-pull}}282192).
+* Fixes an error loading maintenance window status on the Synthetics monitors overview for users with read-only access [#281894]({{kib-pull}}281894).
+
 ## 9.5.1 [elastic-observability-9.5.1-release-notes]
 
 ### Features and enhancements [elastic-observability-9.5.1-features-enhancements]


### PR DESCRIPTION
## Summary
Adds the 9.5.2 Observability release notes. Related to https://github.com/elastic/docs-content/issues/7969 and https://github.com/elastic/dev/issues/3600.

Entries sourced from elastic/kibana PRs backported to `v9.5.2` and confirmed as Observability-relevant by checking the actual code paths changed:
- Fixes the metric threshold rule form silently showing no conditions when the source configuration request is slow or fails (elastic/kibana#280121)
- Fixes the APM app agent configuration tutorial page exposing the APM Server secret token to unauthorized users (elastic/kibana#283942)
- Fixes alert suppression creating duplicate alerts when alert source data uses a nested field structure, affecting custom/metric threshold rules (elastic/kibana#282192)
- Fixes an error loading maintenance window status on the Synthetics monitors overview for read-only users (elastic/kibana#281894)

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No