### PR TITLE
Adapt docs-triage to the codex engine behind the OpenRouter proxy

### DIFF
--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -8,16 +8,37 @@ permissions:
   actions: write
   contents: read
   discussions: write
+  id-token: write
   issues: write
   pull-requests: write
   copilot-requests: write
 
 jobs:
-  run:
+  exchange:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.comment.body, '/triage')
-    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v1
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    outputs:
+      token: ${{ steps.get.outputs.token }}
+    steps:
+      - id: get
+        env:
+          PROXY_URL: https://ke4jawr4344mwdive254dtcp6a0woaza.lambda-url.eu-west-1.on.aws
+        run: |
+          set -euo pipefail
+          oidc=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=openrouter-proxy" | jq -r .value)
+          token=$(curl -sSf -X POST -H "Authorization: Bearer $oidc" "$PROXY_URL/token" | jq -r .token)
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+  run:
+    needs: exchange
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.comment.body, '/triage')
+    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
     with:
       additional-instructions: |
         ## Team Ownership Mapping
@@ -36,4 +57,8 @@ jobs:
         **Shared ownership**: Some paths have shared ownership (e.g., `/explore-analyze/machine-learning/` is shared by Developer and Experience). Pick the team whose keywords best match the issue content.
         **Internal projects**: If the issue seems related to an internal documentation project, initiative, or content strategy effort, apply `Team:Projects`.
         **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
-    secrets: inherit
+    secrets:
+      CODEX_API_KEY: ${{ needs.exchange.outputs.token }}
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
+      GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}

--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -38,7 +38,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.comment.body, '/triage')
-    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@main
+    uses: elastic/docs-actions/.github/workflows/gh-aw-issue-triage.lock.yml@v1
     with:
       additional-instructions: |
         ## Team Ownership Mapping


### PR DESCRIPTION
docs-actions#291 switched the shared triage workflows from the copilot engine to codex, routed through the Elastic Docs OpenRouter proxy:

- A new `exchange` job trades the workflow's GitHub OIDC token for a short-lived proxy token (this repo is already on the proxy's allow-list). That's why `id-token: write` appears in permissions.
- The token is passed explicitly as `CODEX_API_KEY`. Explicit `secrets:` replaces `secrets: inherit` because job outputs can't ride `inherit` — the three optional gh-aw secrets are passed through by name so nothing that worked before stops working.

Validated end to end in docs-actions-sandbox: real `issue_comment`/`issues` triggers, green runs, labels and comments applied (elastic/docs-actions-sandbox#57–60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)