### PR TITLE
Fix docs-triage startup failure: drop undeclared COPILOT_GITHUB_TOKEN secret

### DIFF
--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -59,6 +59,5 @@ jobs:
         **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
     secrets:
       CODEX_API_KEY: ${{ needs.exchange.outputs.token }}
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
       GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}


### PR DESCRIPTION
Follow-up to #8037: the caller passes `COPILOT_GITHUB_TOKEN`, but the reusable triage workflow doesn't declare that secret — GitHub rejects the workflow at startup ("Invalid secret, COPILOT_GITHUB_TOKEN is not defined in the referenced workflow", as seen in docs-content-internal run 32387809795 before the same fix landed there).

The secret was never needed: Copilot threat detection authenticates natively with `github.token` through the `copilot-requests: write` permission. Removing the line restores validation; the remaining pass-throughs (`GH_AW_GITHUB_TOKEN`, `GH_AW_GITHUB_MCP_SERVER_TOKEN`) are declared and stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)