### PR TITLE
ci: validate changelog only when changelog files change

### DIFF
--- a/.github/workflows/changelog-validate.yml
+++ b/.github/workflows/changelog-validate.yml
@@ -2,7 +2,9 @@ name: changelog-validate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/changelog/**'
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

- Removes `edited`, `labeled`, and `unlabeled` from the `pull_request` trigger types — these re-ran validation when nothing in the changelog changed.
- Adds a `paths` filter scoped to `docs/changelog/**` so the workflow only fires when a changelog file is actually added or modified.
- Keeps `opened`, `synchronize`, and `reopened` as the only trigger types.

## Test plan

- [ ] Open a PR that touches `docs/changelog/` — workflow should trigger.
- [ ] Open a PR with no changelog files — workflow should not appear in checks.
- [ ] Add a label to a PR with a changelog file — workflow should not re-trigger.