### PR TITLE
Rename triage secret to ANTHROPIC_API_KEY for the claude engine

### DIFF
--- a/.github/workflows/docs-ai-menu.yml
+++ b/.github/workflows/docs-ai-menu.yml
@@ -196,7 +196,7 @@ jobs:
         **Internal projects**: If the issue seems related to an internal documentation project, initiative, or content strategy effort, apply `Team:Projects`.
         **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
     secrets:
-      CODEX_API_KEY: ${{ needs.exchange.outputs.token }}
+      ANTHROPIC_API_KEY: ${{ needs.exchange.outputs.token }}
       GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
       GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 

--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -58,6 +58,6 @@ jobs:
         **Internal projects**: If the issue seems related to an internal documentation project, initiative, or content strategy effort, apply `Team:Projects`.
         **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
     secrets:
-      CODEX_API_KEY: ${{ needs.exchange.outputs.token }}
+      ANTHROPIC_API_KEY: ${{ needs.exchange.outputs.token }}
       GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
       GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}


### PR DESCRIPTION
The v1 triage workflows moved to the claude engine (docs-actions#302) and now declare `ANTHROPIC_API_KEY` instead of `CODEX_API_KEY`; passing the old name fails workflow validation at startup ("Invalid secret, CODEX_API_KEY is not defined in the referenced workflow"). Same exchange job, same short-lived proxy token — only the secret name changes, in both `docs-triage.yml` and `docs-ai-menu.yml`. docs-content-internal and docs-eng-team received the same rename directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)