### PR TITLE
Update troubleshooting-upgrades.md

### DIFF
--- a/troubleshoot/elasticsearch/troubleshooting-upgrades.md
+++ b/troubleshoot/elasticsearch/troubleshooting-upgrades.md
@@ -192,7 +192,7 @@ You might see [shard allocation issues](/troubleshoot/elasticsearch/diagnose-una
 
 * Node upgrades didn't follow the [recommended upgrade order](/deploy-manage/upgrade/deployment-or-cluster/elasticsearch.md#upgrade-order)
 * One of the [edge cases](#troubleshooting-upgrades-theory) described earlier occurs
-* An insufficient number of eligible nodes have been upgraded to allocate replicas.
+* An insufficient number of eligible nodes has been upgraded to allocate replicas
 
 Beyond the [common allocation issues](/troubleshoot/elasticsearch/cluster-allocation-api-examples.md), these errors appear only during rolling upgrades:
 
@@ -205,7 +205,7 @@ Beyond the [common allocation issues](/troubleshoot/elasticsearch/cluster-alloca
 
 	* `cannot allocate replica shard to a node with version [X.X.X] since this is older than the primary version [Y.Y.Y]`
 
-Primary shards assigned to a node running the later version cannot have their replicas assigned to nodes with the older version. If replica shard allocations are blocked due to insufficient eligible nodes on later version, continue upgrading your nodes to resolve the preceding errors.
+Primary shards on a later-version node cannot allocate replicas onto earlier-version nodes. This is expected during a rolling upgrade. Continue upgrading nodes until enough later-version nodes exist to allocate the replicas.
 
 ### Post-upgrade issues [troubleshooting-upgrades-errors-post]
 

--- a/troubleshoot/elasticsearch/troubleshooting-upgrades.md
+++ b/troubleshoot/elasticsearch/troubleshooting-upgrades.md
@@ -192,6 +192,7 @@ You might see [shard allocation issues](/troubleshoot/elasticsearch/diagnose-una
 
 * Node upgrades didn't follow the [recommended upgrade order](/deploy-manage/upgrade/deployment-or-cluster/elasticsearch.md#upgrade-order)
 * One of the [edge cases](#troubleshooting-upgrades-theory) described earlier occurs
+* An insufficient number of eligible nodes have been upgraded to allocate replicas.
 
 Beyond the [common allocation issues](/troubleshoot/elasticsearch/cluster-allocation-api-examples.md), these errors appear only during rolling upgrades:
 
@@ -204,7 +205,7 @@ Beyond the [common allocation issues](/troubleshoot/elasticsearch/cluster-alloca
 
 	* `cannot allocate replica shard to a node with version [X.X.X] since this is older than the primary version [Y.Y.Y]`
 
-If you encounter any of these, continue upgrading your nodes. The data allocates as more nodes reach the later version.
+Primary shards assigned to a node running the later version cannot have their replicas assigned to nodes with the older version. If replica shard allocations are blocked due to insufficient eligible nodes on later version, continue upgrading your nodes to resolve the preceding errors.
 
 ### Post-upgrade issues [troubleshooting-upgrades-errors-post]
 


### PR DESCRIPTION

## Summary
👋 Adding back in a variation of an earlier sentence that got moved to main upgrade doc (https://github.com/elastic/docs-content/pull/6396, https://github.com/elastic/docs-content/pull/5848).

> During a rolling upgrade, primary shards assigned to a node running the new version cannot have their replicas assigned to a node with the old version. The new version might have a different data format that is not understood by the old version.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [X] No  