### PR TITLE
Route triage workflows directly through OpenRouter

### DIFF
--- a/.github/workflows/docs-ai-menu.yml
+++ b/.github/workflows/docs-ai-menu.yml
@@ -145,29 +145,9 @@ jobs:
               statusOverrides,
             });
 
-  exchange:
-    name: Exchange OIDC token for proxy token
-    needs: [evaluate-trigger]
-    if: needs.evaluate-trigger.outputs.triage_triggered == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    outputs:
-      token: ${{ steps.get.outputs.token }}
-    steps:
-      - id: get
-        env:
-          PROXY_URL: https://ke4jawr4344mwdive254dtcp6a0woaza.lambda-url.eu-west-1.on.aws
-        run: |
-          set -euo pipefail
-          oidc=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=openrouter-proxy" | jq -r .value)
-          token=$(curl -sSf -X POST -H "Authorization: Bearer $oidc" "$PROXY_URL/token" | jq -r .token)
-          echo "token=$token" >> "$GITHUB_OUTPUT"
-
   run-docs-triage:
     name: Docs AI / triage
-    needs: [evaluate-trigger, exchange]
+    needs: [evaluate-trigger]
     if: needs.evaluate-trigger.outputs.triage_triggered == 'true'
     permissions:
       actions: read
@@ -196,7 +176,7 @@ jobs:
         **Internal projects**: If the issue seems related to an internal documentation project, initiative, or content strategy effort, apply `Team:Projects`.
         **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
     secrets:
-      ANTHROPIC_API_KEY: ${{ needs.exchange.outputs.token }}
+      ANTHROPIC_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
       GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}
 

--- a/.github/workflows/docs-triage.yml
+++ b/.github/workflows/docs-triage.yml
@@ -8,33 +8,12 @@ permissions:
   actions: write
   contents: read
   discussions: write
-  id-token: write
   issues: write
   pull-requests: write
   copilot-requests: write
 
 jobs:
-  exchange:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      startsWith(github.event.comment.body, '/triage')
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    outputs:
-      token: ${{ steps.get.outputs.token }}
-    steps:
-      - id: get
-        env:
-          PROXY_URL: https://ke4jawr4344mwdive254dtcp6a0woaza.lambda-url.eu-west-1.on.aws
-        run: |
-          set -euo pipefail
-          oidc=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=openrouter-proxy" | jq -r .value)
-          token=$(curl -sSf -X POST -H "Authorization: Bearer $oidc" "$PROXY_URL/token" | jq -r .token)
-          echo "token=$token" >> "$GITHUB_OUTPUT"
   run:
-    needs: exchange
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.comment.body, '/triage')
@@ -58,6 +37,6 @@ jobs:
         **Internal projects**: If the issue seems related to an internal documentation project, initiative, or content strategy effort, apply `Team:Projects`.
         **Fallback**: If you genuinely cannot determine the owning team, apply `cross-team` so the issue stays visible to all teams.
     secrets:
-      ANTHROPIC_API_KEY: ${{ needs.exchange.outputs.token }}
+      ANTHROPIC_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       GH_AW_GITHUB_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
       GH_AW_GITHUB_MCP_SERVER_TOKEN: ${{ secrets.GH_AW_GITHUB_MCP_SERVER_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the OIDC exchange jobs from the standalone and AI menu triage callers
- pass the repository-scoped `OPENROUTER_API_KEY` as the reusable workflow's `ANTHROPIC_API_KEY`
- drop the standalone caller's obsolete `id-token: write` permission

## Test plan
- [x] Parse both modified workflows as YAML
- [x] Validate the direct OpenRouter reusable workflow end-to-end in docs-actions-sandbox: https://github.com/elastic/docs-actions-sandbox/actions/runs/32747874840