### PR TITLE
Remove technical preview note for managed integrations

### DIFF
--- a/manage-data/ingest/managed-integrations/managed-integrations.md
+++ b/manage-data/ingest/managed-integrations/managed-integrations.md
@@ -22,11 +22,6 @@ type: overview
 
 To enable an {{managed-integration}} in {{kib}}, refer to [Enable an {{managed-integration}}](/manage-data/ingest/managed-integrations/enable-managed-integration.md).
 
-:::{important}
-:applies_to: stack: preview 9.0-9.4
-In these versions, {{managed-integrations}} are in technical preview. The design and code are less mature than GA features, and Elastic provides them as-is with no warranties. The support SLA for GA features doesn't apply. There are no additional costs for {{managed-integrations}} during technical preview.
-:::
-
 ## Key benefits [managed-integrations-benefits]
 
 {{managed-integrations}} remove the operational overhead of running your own collectors:

--- a/manage-data/ingest/managed-integrations/managed-integrations.md
+++ b/manage-data/ingest/managed-integrations/managed-integrations.md
@@ -24,7 +24,7 @@ To enable an {{managed-integration}} in {{kib}}, refer to [Enable an {{managed-i
 
 :::{important}
 :applies_to: stack: preview 9.0-9.4
-{{managed-integrations}} are a technical preview feature. The design and code are less mature than GA features, and Elastic provides them as-is with no warranties. The support SLA for GA features doesn't apply. There are no additional costs for {{managed-integrations}} during technical preview.
+In these versions, {{managed-integrations}} are in technical preview. The design and code are less mature than GA features, and Elastic provides them as-is with no warranties. The support SLA for GA features doesn't apply. There are no additional costs for {{managed-integrations}} during technical preview.
 :::
 
 ## Key benefits [managed-integrations-benefits]


### PR DESCRIPTION
## Summary

Remove the tech preview note on the [Elastic Managed integrations](https://www.elastic.co/docs/manage-data/ingest/managed-integrations/managed-integrations) page as Managed integrations are now GA.

The page-level `applies_to` already specifies in which version managed integrations were in technical preview.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No