### PR TITLE
[CPS] Remove "new projects" only limitation

### DIFF
--- a/deploy-manage/_snippets/cps-limitations-core.md
+++ b/deploy-manage/_snippets/cps-limitations-core.md
@@ -1,6 +1,5 @@
 - **Maximum of 20 linked projects:** Each origin project can have up to 20 linked projects. A linked project can be associated with any number of origin projects.
 - **System indices:** Indices such as `.security` and `.fleet-*` are excluded from {{cps}} results by design.
-- **New projects only:** During technical preview, only newly created projects can function as origin projects.
 - **{{anomaly-detect-cap}} and transforms:** During technical preview, ML {{anomaly-jobs}} and transforms are not supported with {{cps-init}}. They continue to run on origin project data only.
 - **{{dfanalytics-jobs-cap}}:** {{dfanalytics-jobs}} are not supported with {{cps-init}}. They continue to run on origin project data only.
 - For {{esql}} limitations specific to {{cps-init}}, refer to [ES|QL with {{cps}}](elasticsearch://reference/query-languages/esql/esql-cross-serverless-projects.md#limitations).

--- a/deploy-manage/cross-project-search-config.md
+++ b/deploy-manage/cross-project-search-config.md
@@ -50,11 +50,6 @@ Before you configure {{cps}}, review these prerequisites and best practices:
 
 ### Projects available for linking [cps-compatibility]
 
-::::{important} - Origin project limitations
-
-During technical preview, only newly created projects can be origin projects for {{cps}}. Existing projects can be linked from an origin project, but they can't serve as origin projects themselves. To get started, create a new {{serverless-short}} project and link it to your existing projects.
-::::
-
 To be available for linking, projects must meet the following requirements:
 
 - The origin project and all linked projects must be in the same {{ecloud}} organization.


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
## Summary
- part of https://github.com/elastic/docs-content-internal/issues/1603
- Drops the preview-only restriction that only newly created projects could serve as origins projects

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [X] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: grok 4.6

