### PR TITLE
Fix Kibana advanced-settings redirect path

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -123,11 +123,11 @@ redirects:
   'solutions/observability/apps/integrate-with-machine-learning.md': 'solutions/observability/apm/machine-learning.md'
   'solutions/observability/apps/apm-agent-explorer.md': 'solutions/observability/apm/apm-agent-explorer.md'
   'solutions/observability/apps/applications-ui-settings.md':
-    to: 'kibana://docs/reference/advanced-settings.md'
+    to: 'kibana://reference/advanced-settings.md'
     anchors:
       '': 'observability-advanced-settings'
   'solutions/observability/apm/applications-ui-settings.md':
-    to: 'kibana://docs/reference/advanced-settings.md'
+    to: 'kibana://reference/advanced-settings.md'
     anchors:
       '': 'observability-advanced-settings'
   'solutions/observability/apps/act-on-data.md': 'solutions/observability/apm/act-on-data.md'


### PR DESCRIPTION
## Why

- Assemble `--strict` fails on two redirects that target `kibana://docs/reference/advanced-settings.md`
- Kibana link keys are relative to the docs folder, so the published key is `reference/advanced-settings.md`
- This breaks assembler-preview on unrelated docs-builder PRs, including https://github.com/elastic/docs-builder/pull/3946

## What

- Change both `applications-ui-settings.md` redirect targets to `kibana://reference/advanced-settings.md`
- Keep the `observability-advanced-settings` anchor remap

## Notes

- The extra `docs/` prefix landed in #7986
- The `observability-advanced-settings` anchor is valid in the Kibana `main` link index
- After this merges to `main`, re-run assembler-preview on docs-builder PR 3946

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool(s) and model(s) used: Cursor Grok 4.6


Made with [Cursor](https://cursor.com)