### PR TITLE
docs: show ES|QL time shift in visualizations (#4033)

### DIFF
--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -309,6 +309,7 @@ FROM kibana_sample_data_logs
 | WHERE timestamp > NOW() - 15minutes
 ```
 
+To compare the current window with an earlier window of the same duration (a time shift), refer to [Compare current versus previous period with time shift](/explore-analyze/visualize/esorql.md#esql-viz-time-shift).
 
 ### Timezone handling [esql-kibana-timezone]
 ```{applies_to}

--- a/explore-analyze/query-filter/languages/esql-kibana.md
+++ b/explore-analyze/query-filter/languages/esql-kibana.md
@@ -309,7 +309,7 @@ FROM kibana_sample_data_logs
 | WHERE timestamp > NOW() - 15minutes
 ```
 
-To compare the current window with an earlier window of the same duration (a time shift), refer to [Compare current versus previous period with time shift](/explore-analyze/visualize/esorql.md#esql-viz-time-shift).
+To apply a time shift in an {{esql}} visualization, refer to [Compare current versus previous period with time shift](/explore-analyze/visualize/esorql.md#esql-viz-time-shift).
 
 ### Timezone handling [esql-kibana-timezone]
 ```{applies_to}

--- a/explore-analyze/visualize/_snippets/esql-time-shift.md
+++ b/explore-analyze/visualize/_snippets/esql-time-shift.md
@@ -1,0 +1,45 @@
+Point-and-click visualizations use a **Time shift** to compare the current window with an earlier window of the same duration. In an {{esql}} query, compute both windows in one [`STATS`](elasticsearch://reference/query-languages/esql/commands/stats-by.md) command. Use a per-aggregation `WHERE` filter for each window.
+
+The dashboard [time filter](/explore-analyze/query-filter/filtering.md) always applies to {{esql}} visualizations. Set it so both windows fall inside the selected range. Point-and-click **Time shift** fetches the offset range even when that range sits outside the time filter.
+
+This example uses the {{kib}} [sample web logs](/manage-data/ingest/sample-data.md) data. It compares the last 7 days with the 7 days before that, per host.
+
+To follow the example, [add the **Sample web logs** data](/manage-data/ingest/sample-data.md). Sample data timestamps are relative to when you installed the data set. If you installed it recently, set the time filter to **Last 15 days** so both 7-day windows have data.
+
+To create the visualization:
+
+1. Open a dashboard and add a new {{esql}} visualization:
+
+    * {applies_to}`serverless:` {applies_to}`stack: ga 9.2+` Select **Add** in the application menu, then select **Visualization (query)** or **New panel** → **{{esql}}** under **Visualizations**, depending on your {{kib}} version.
+    * {applies_to}`stack: ga 9.0-9.1` Select **Add panel** in the application menu, then select **{{esql}}**.
+
+2. Enter the following query:
+
+    ```esql
+    FROM kibana_sample_data_logs
+    | EVAL current_start = ?_tend - 7 days, prior_start = ?_tend - 14 days <1>
+    | STATS
+        current_count = COUNT(*) WHERE @timestamp >= current_start, <2>
+        prior_count = COUNT(*) WHERE @timestamp >= prior_start AND @timestamp < current_start
+      BY host.keyword
+    | EVAL pct_diff = CASE( <3>
+        prior_count > 0,
+        ROUND(100.0 * TO_DOUBLE(current_count - prior_count) / prior_count, 1),
+        null
+      )
+    | SORT ABS(pct_diff) DESC
+    ```
+
+    1. Bound both windows from the end of the time filter. `?_tend` stays in sync with the dashboard time filter.
+    2. Count events in each window in a single pass. Refer to [`STATS` with `WHERE`](elasticsearch://reference/query-languages/esql/commands/stats-by.md).
+    3. Compute the percent change. `CASE` returns `null` when the earlier window has no events.
+
+3. Run the query. A visualization appears with one row per host. If {{kib}} suggests a different visualization type, select **Table** from the visualization type dropdown.
+
+4. Select **Apply and close** to save the visualization to your dashboard.
+
+You now have current and prior counts, plus a percent difference, for each host. To use your own data, change the `FROM` source and the `BY` grouping field.
+
+To compare a different duration or offset, change the two `EVAL` time spans. For the last hour versus the same hour a week ago, set `current_start` to `?_tend - 1 hour` and `prior_start` to `?_tend - 7 days - 1 hour`. Keep the time filter wide enough to include both windows.
+
+For the point-and-click **Time shift** control, refer to [Compare differences over time](/explore-analyze/visualize/lens.md#compare-data-with-time-offsets).

--- a/explore-analyze/visualize/_snippets/esql-time-shift.md
+++ b/explore-analyze/visualize/_snippets/esql-time-shift.md
@@ -1,10 +1,6 @@
-Point-and-click visualizations use a **Time shift** to compare the current window with an earlier window of the same duration. In an {{esql}} query, compute both windows in one [`STATS`](elasticsearch://reference/query-languages/esql/commands/stats-by.md) command. Use a per-aggregation `WHERE` filter for each window.
+To compare the current period with a previous period of the same duration, compute both windows in one [`STATS`](elasticsearch://reference/query-languages/esql/commands/stats-by.md) command. Use a per-aggregation `WHERE` filter for each window.
 
-The dashboard [time filter](/explore-analyze/query-filter/filtering.md) always applies to {{esql}} visualizations. Set it so both windows fall inside the selected range. Point-and-click **Time shift** fetches the offset range even when that range sits outside the time filter.
-
-This example uses the {{kib}} [sample web logs](/manage-data/ingest/sample-data.md) data. It compares the last 7 days with the 7 days before that, per host.
-
-To follow the example, [add the **Sample web logs** data](/manage-data/ingest/sample-data.md). Sample data timestamps are relative to when you installed the data set. If you installed it recently, set the time filter to **Last 15 days** so both 7-day windows have data.
+This example uses the {{kib}} [sample web logs](/manage-data/ingest/sample-data.md). It compares the last 7 days with the 7 days before that, per host. Add that data set if you don't have it yet. Sample data timestamps are relative to when you installed the data set.
 
 To create the visualization:
 
@@ -13,18 +9,20 @@ To create the visualization:
     * {applies_to}`serverless:` {applies_to}`stack: ga 9.2+` Select **Add** in the application menu, then select **Visualization (query)** or **New panel** → **{{esql}}** under **Visualizations**, depending on your {{kib}} version.
     * {applies_to}`stack: ga 9.0-9.1` Select **Add panel** in the application menu, then select **{{esql}}**.
 
-2. Enter the following query:
+2. Set the [time filter](/explore-analyze/query-filter/filtering.md) to the last 15 days so both 7-day windows have data.
+
+3. Enter the following query:
 
     ```esql
     FROM kibana_sample_data_logs
-    | EVAL current_start = ?_tend - 7 days, prior_start = ?_tend - 14 days <1>
+    | EVAL current_start = ?_tend - 7 days, previous_start = ?_tend - 14 days <1>
     | STATS
-        current_count = COUNT(*) WHERE @timestamp >= current_start, <2>
-        prior_count = COUNT(*) WHERE @timestamp >= prior_start AND @timestamp < current_start
+        current_count = COUNT(*) WHERE @timestamp >= current_start AND @timestamp <= ?_tend, <2>
+        previous_count = COUNT(*) WHERE @timestamp >= previous_start AND @timestamp < current_start
       BY host.keyword
     | EVAL pct_diff = CASE( <3>
-        prior_count > 0,
-        ROUND(100.0 * TO_DOUBLE(current_count - prior_count) / prior_count, 1),
+        previous_count > 0,
+        ROUND(100.0 * TO_DOUBLE(current_count - previous_count) / previous_count, 1),
         null
       )
     | SORT ABS(pct_diff) DESC
@@ -32,14 +30,14 @@ To create the visualization:
 
     1. Bound both windows from the end of the time filter. `?_tend` stays in sync with the dashboard time filter.
     2. Count events in each window in a single pass. Refer to [`STATS` with `WHERE`](elasticsearch://reference/query-languages/esql/commands/stats-by.md).
-    3. Compute the percent change. `CASE` returns `null` when the earlier window has no events.
+    3. Compute the percent change. `CASE` returns `null` when the previous window has no events.
 
-3. Run the query. A visualization appears with one row per host. If {{kib}} suggests a different visualization type, select **Table** from the visualization type dropdown.
+4. Run the query. A visualization appears with one row per host. If {{kib}} suggests a different visualization type, select **Table** from the visualization type dropdown.
 
-4. Select **Apply and close** to save the visualization to your dashboard.
+5. Select **Apply and close** to save the visualization to your dashboard.
 
-You now have current and prior counts, plus a percent difference, for each host. To use your own data, change the `FROM` source and the `BY` grouping field.
+To use your own data, change the `FROM` source and the `BY` grouping field. If your time field isn't `@timestamp`, replace `@timestamp` in the `STATS` filters. To apply the dashboard time filter to a custom time field, add a `WHERE` clause with `?_tstart` and `?_tend`. Refer to [Filter by time](/explore-analyze/query-filter/languages/esql-kibana.md#esql-kibana-time-filter).
 
-To compare a different duration or offset, change the two `EVAL` time spans. For the last hour versus the same hour a week ago, set `current_start` to `?_tend - 1 hour` and `prior_start` to `?_tend - 7 days - 1 hour`. Keep the time filter wide enough to include both windows.
+To compare a different duration or offset, change the two `EVAL` time spans. For the last hour versus the same hour a week ago, set `current_start` to `?_tend - 1 hour` and `previous_start` to `?_tend - 7 days - 1 hour`. Set the time filter to cover both windows.
 
-For the point-and-click **Time shift** control, refer to [Compare differences over time](/explore-analyze/visualize/lens.md#compare-data-with-time-offsets).
+To set **Time shift** in the point-and-click editor, refer to [Compare differences over time](/explore-analyze/visualize/lens.md#compare-data-with-time-offsets).

--- a/explore-analyze/visualize/esorql.md
+++ b/explore-analyze/visualize/esorql.md
@@ -135,6 +135,11 @@ An {{esql}} query returns a table. When you use the result to build a visualizat
 
 The chart type determines the combination of columns you need. Open a page from the [visualization types](lens.md#lens-visualization-types) list to find an {{esql}} query pattern and learn how to assign its result columns to the chart dimensions.
 
+## Compare current versus previous period with time shift [esql-viz-time-shift]
+
+:::{include} _snippets/esql-time-shift.md
+:::
+
 ## Add drilldowns to an {{esql}} visualization [esql-viz-drilldowns]
 ```{applies_to}
 stack: ga 9.4

--- a/explore-analyze/visualize/lens.md
+++ b/explore-analyze/visualize/lens.md
@@ -264,6 +264,8 @@ These are examples of common formulas:
 
 Compare your real-time data to the results that are offset by a time increment. For example, you can compare the real-time percentage of a user CPU time spent to the results offset by one hour.
 
+To apply a time shift in an {{esql}} visualization, refer to [Compare current versus previous period with time shift](esorql.md#esql-viz-time-shift).
+
 1. In the layer pane, click the field you want to offset.
 2. Click **Advanced**.
 3. In the **Time shift** field, enter the time offset increment.


### PR DESCRIPTION
## Summary

This PR addresses #4033 with the following changes:

- **`explore-analyze/visualize/_snippets/esql-time-shift.md`**: Worked ES|QL query that compares two equal time windows with per-aggregation `STATS` `WHERE`, using the Kibana **Time shift** term. The current window is bounded with `?_tend` so the counts do not depend on an implicit request filter.
- **`explore-analyze/visualize/esorql.md`**: Includes that example after the chart-type query patterns, where readers build ES|QL visualizations.
- **`explore-analyze/query-filter/languages/esql-kibana.md`**: Points from **Filter by time** to the visualization example.
- **`explore-analyze/visualize/lens.md`**: Points from **Compare differences over time** to the ES|QL equivalent.

The example leads with the query task. It does not claim that the dashboard time filter always applies to ES|QL visualizations. Kibana applies that range to `@timestamp` when the field exists. A custom time field needs `?_tstart` and `?_tend` in the query. Readers set the time filter to cover both windows, then split the span in `STATS`.

## Resolves

Closes #4033

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool(s) and model(s) used: Cursor Grok 4.6

---

> **AI-generated draft** — created with Cursor Grok 4.6.
> Review all generated content for factual accuracy before merging.