### PR TITLE
Mark BYOK for existing deployments as GA

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-byok.md
+++ b/deploy-manage/deploy/elastic-cloud/azure-native-isv-service-byok.md
@@ -1,7 +1,7 @@
 ---
 applies_to:
   deployment:
-    ess: preview
+    ess: ga
 products:
   - id: cloud-hosted
 navigation_title: Customer-managed encryption keys

--- a/deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md
+++ b/deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key.md
@@ -276,7 +276,7 @@ You can encrypt a deployment with your customer-managed key when you [create a n
             ```
 
             ::::{tip}
-            You can also create the deployment from a snapshot of a deployment that was initially not encrypted with a customer-managed key. You can use this as a workaround to encrypt existing data under new deployments using your key, until encrypting existing deployments with a customer-managed key is supported.
+            You can also create the deployment from a snapshot of a deployment that was initially not encrypted with a customer-managed key. To encrypt an existing deployment in place instead, refer to [Encrypt an existing deployment with your key](#ec_encrypt_an_existing_deployment_with_a_customer_managed_key).
             ::::
 
 
@@ -352,7 +352,7 @@ After you have created the service principal and granted it the necessary permis
             ```
 
             ::::{tip}
-            You can also create the deployment from a snapshot of a deployment that was initially not encrypted with a customer-managed key. You can use this as a workaround to encrypt existing data under new deployments using your key, until encrypting existing deployments with a customer-managed key is supported.
+            You can also create the deployment from a snapshot of a deployment that was initially not encrypted with a customer-managed key. To encrypt an existing deployment in place instead, refer to [Encrypt an existing deployment with your key](#ec_encrypt_an_existing_deployment_with_a_customer_managed_key).
             ::::
 
 
@@ -443,7 +443,7 @@ After you have granted the Elastic principals the necessary roles, you can finis
             ```
 
             ::::{tip}
-            You can also create the deployment from a snapshot of a deployment that was initially not encrypted with a customer-managed key. You can use this as a workaround to encrypt existing data under new deployments using your key, until encrypting existing deployments with a customer-managed key is supported.
+            You can also create the deployment from a snapshot of a deployment that was initially not encrypted with a customer-managed key. To encrypt an existing deployment in place instead, refer to [Encrypt an existing deployment with your key](#ec_encrypt_an_existing_deployment_with_a_customer_managed_key).
             ::::
 
 
@@ -453,10 +453,6 @@ The deployment is now created and encrypted using the specified key. Future snap
 :::::::
 
 ### Encrypt an existing deployment with your key [ec_encrypt_an_existing_deployment_with_a_customer_managed_key]
-```{applies_to}
-deployment:
-  ess: preview
-```
 
 1. Go to your deployment's **Security** page.
 2. Under **Encryption at rest**, select **Manage encryption key**.


### PR DESCRIPTION
## Summary

Encrypting an **existing** Elastic Cloud Hosted deployment with a customer-managed key (BYOK) is now generally available. This removes the tech preview labelling and the preview-era wording from [Use a customer-managed encryption key](https://www.elastic.co/docs/deploy-manage/security/encrypt-deployment-with-customer-managed-encryption-key).

Tracking issue: [elastic/roadmap#40](https://github.com/elastic/roadmap/issues/40)

## Changes

- Removed the section-level `applies_to: ess: preview` badge from **Encrypt an existing deployment with your key**. The section now inherits the page-level `ess: ga`, so no redundant GA badge is added.
- Reworded the three per-CSP tips (AWS, Azure, Google Cloud) that described creating a deployment from a snapshot as a *workaround* "until encrypting existing deployments with a customer-managed key is supported". That framing is obsolete now that the in-place flow is GA. The tips keep the snapshot-restore option and now cross-link to the existing-deployment section instead.

No other content changes. The remaining forward-looking statements on the page are about *changing or removing* a key, which is still unsupported, so they are left as-is.

## Test plan

- [ ] Confirm the **Encrypt an existing deployment with your key** section renders without a Preview badge
- [ ] Confirm the three reworded tips render and the anchor link `#ec_encrypt_an_existing_deployment_with_a_customer_managed_key` resolves

Made with [Cursor](https://cursor.com)