### PR TITLE
Refactor self-managed shard allocation awareness page to clarify deployment type options and highlight ECK better

### DIFF
--- a/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
+++ b/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
@@ -13,10 +13,21 @@ products:
 
 You can use custom node attributes as *awareness attributes* to enable {{es}} to take your physical hardware configuration into account when allocating shards. If {{es}} knows which nodes are on the same physical server, in the same rack, or in the same zone, it can distribute the primary shard and its replica shards to minimize the risk of losing all shard copies in the event of a failure.
 
-:::{tip}
-:applies_to: {ece: ga, ess: ga}
-For {{ece}} and {{ech}} deployments, you can't set custom node attributes, so shard allocation awareness is not available. These platforms handle availability zone awareness automatically through their deployment configuration.
-:::
+## Deployment type considerations [deployment-considerations]
+
+How you configure shard allocation awareness depends on your deployment type:
+
+**Self-managed**: Follow the steps on this page to configure node attributes and awareness settings on each node.
+
+**{{ece}} and {{ech}}**: For {{ece}} and {{ech}} deployments, you can't set custom node attributes, so shard allocation awareness is not available. These platforms handle availability zone awareness automatically through their deployment configuration.
+
+**{{eck}}**: You can use the information on this page to configure your own node attributes in each NodeSet and awareness settings at the {{es}} cluster level. {{eck}} also provides advanced functionality and examples that combine Kubernetes pod scheduling with Elasticsearch shard allocation awareness:
+
+- Starting with ECK 3.4, you can use the [`zoneAwareness` field](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) on NodeSets to automatically configure zone-based shard allocation awareness. This is the recommended approach.
+- For earlier versions, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness-manual) for an example of manual zone awareness configuration.
+
+
+## Enabling shard allocation awareness [enabling-awareness]
 
 When shard allocation awareness is enabled with the `cluster.routing.allocation.awareness.attributes` setting, shards are only allocated to nodes that have values set for the specified awareness attributes. If you use multiple awareness attributes, {{es}} considers each attribute separately when allocating shards.
 
@@ -24,13 +35,9 @@ When shard allocation awareness is enabled with the `cluster.routing.allocation.
 The number of attribute values determines how many shard copies are allocated in each location. If the number of nodes in each location is unbalanced and there are a lot of replicas, replica shards might be left unassigned.
 ::::
 
-
 ::::{tip}
 Learn more about [designing resilient clusters](../../production-guidance/availability-and-resilience/resilience-in-larger-clusters.md).
 ::::
-
-
-## Enabling shard allocation awareness [enabling-awareness]
 
 To enable shard allocation awareness:
 
@@ -44,7 +51,7 @@ To enable shard allocation awareness:
         node.attr.rack_id: rack_one
         ```
 
-    * Using the `-E` command line argument when you start a node:
+    * By using the `-E` command-line argument when you start a node:
 
         ```sh
         ./bin/elasticsearch -Enode.attr.rack_id=rack_one
@@ -52,31 +59,28 @@ To enable shard allocation awareness:
 
     :::{tip}
     :applies_to: eck:
-    For {{eck}} deployments, set custom node attributes in the `config` section of your {{es}} resource manifest instead of `elasticsearch.yml`. Starting with ECK 3.4.0, you can use the [`zoneAwareness` field](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) on NodeSets to automatically configure zone-based shard allocation awareness. For manual configuration or earlier versions, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness-manual).
+    For {{eck}} deployments, set the node attributes in the `config` section of each NodeSet.
     :::
 
-2. Tell {{es}} to take one or more awareness attributes into account when allocating shards by setting `cluster.routing.allocation.awareness.attributes` in **every** master-eligible node’s [`elasticsearch.yml`](/deploy-manage/stack-settings.md) config file.
-
-    ```yaml
-    cluster.routing.allocation.awareness.attributes: rack_id <1>
-    ```
-
-    1. Specify multiple attributes as a comma-separated list.
-
-
-    You can also use the [cluster-update-settings]({{es-apis}}operation/operation-cluster-put-settings) API to set or update a cluster’s awareness attributes:
+2. Tell {{es}} to take one or more awareness attributes into account when allocating shards by setting `cluster.routing.allocation.awareness.attributes`. Use the [cluster update settings API]({{es-apis}}operation/operation-cluster-put-settings):
 
     ```console
     PUT /_cluster/settings
     {
       "persistent" : {
-        "cluster.routing.allocation.awareness.attributes" : "rack_id"
+        "cluster.routing.allocation.awareness.attributes" : "rack_id" <1>
       }
     }
     ```
 
+    1. Specify multiple attributes as a comma-separated list.
 
-With this example configuration, if you start two nodes with `node.attr.rack_id` set to `rack_one` and create an index with 5 primary shards and 1 replica of each primary, all primaries and replicas are allocated across the two node.
+    :::{tip}
+    :applies_to: eck:
+    When configuring awareness manually, you are responsible for keeping the {{k8s}} node scheduling and the {{es}} node attributes consistent. Using [ECK zone awareness](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) (ECK 3.4+) handles both layers automatically and is the recommended approach. For complete examples of both approaches, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-tsc-zone).
+    :::
+
+With this example configuration, if you start two nodes with `node.attr.rack_id` set to `rack_one` and create an index with 5 primary shards and 1 replica of each primary, all primaries and replicas are allocated across the two nodes. Because both nodes share the same rack, awareness cannot separate shard copies across racks yet. That separation happens when you add nodes in a second rack.
 
 :::{image} /deploy-manage/images/elasticsearch-reference-shard-allocation-awareness-one-rack.png
 :alt: All primaries and replicas are allocated across two nodes in the same rack
@@ -97,7 +101,7 @@ If `rack_two` fails and takes down both its nodes, by default {{es}} allocates t
 
 By default, if one location fails, {{es}} spreads its shards across the remaining locations. This might be undesirable if the cluster does not have sufficient resources to host all its shards when one location is missing.
 
-To prevent the remaining locations from being overloaded in the event of a whole-location failure, specify the attribute values that should exist with the `cluster.routing.allocation.awareness.force.*` settings. This will mean that {{es}} will prefer to leave some replicas unassigned in the event of a whole-location failure instead of overloading the nodes in the remaining locations.
+To prevent the remaining locations from being overloaded in the event of a whole-location failure, specify the attribute values that should exist with the `cluster.routing.allocation.awareness.force.*` settings. This means that {{es}} prefers to leave some replicas unassigned in the event of a whole-location failure instead of overloading the nodes in the remaining locations.
 
 For example, if you have an awareness attribute called `zone` and configure nodes in `zone1` and `zone2`, you can use forced awareness to make {{es}} leave half of your shard copies unassigned if only one zone is available:
 
@@ -109,6 +113,6 @@ cluster.routing.allocation.awareness.force.zone.values: zone1,zone2 <1>
 1. Specify all possible `zone` attribute values.
 
 
-With this example configuration, if you have two nodes with `node.attr.zone` set to `zone1` and an index with `number_of_replicas` set to `1`, {{es}} allocates all the primary shards but none of the replicas. It will assign the replica shards once nodes with a different value for `node.attr.zone` join the cluster. In contrast, if you do not configure forced awareness, {{es}} will allocate all primaries and replicas to the two nodes even though they are in the same zone.
+With this example configuration, if you have two nodes with `node.attr.zone` set to `zone1` and an index with `number_of_replicas` set to `1`, {{es}} allocates all the primary shards but none of the replicas. It assigns the replica shards once nodes with a different value for `node.attr.zone` join the cluster. In contrast, if you do not configure forced awareness, {{es}} allocates all primaries and replicas to the two nodes even though they are in the same zone.
 
 

--- a/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
+++ b/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
@@ -77,7 +77,7 @@ To enable shard allocation awareness:
 
     :::{tip}
     :applies_to: eck:
-    When configuring awareness manually, you are responsible for keeping the {{k8s}} node scheduling and the {{es}} node attributes consistent. Using [ECK zone awareness](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) (ECK 3.4+) handles both layers automatically and is the recommended approach. For complete examples of both approaches, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-tsc-zone).
+    When configuring awareness manually, you are responsible for keeping the {{k8s}} node scheduling and the {{es}} node attributes consistent. Using [ECK zone awareness](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) (ECK 3.4+) handles both layers automatically and is the recommended approach. For complete examples of both approaches, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-availability-zone-awareness).
     :::
 
 With this example configuration, if you start two nodes with `node.attr.rack_id` set to `rack_one` and create an index with 5 primary shards and 1 replica of each primary, all primaries and replicas are allocated across the two nodes. Because both nodes share the same rack, awareness cannot separate shard copies across racks yet. That separation happens when you add nodes in a second rack.

--- a/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
+++ b/deploy-manage/distributed-architecture/shard-allocation-relocation-recovery/shard-allocation-awareness.md
@@ -77,7 +77,7 @@ To enable shard allocation awareness:
 
     :::{tip}
     :applies_to: eck:
-    When configuring awareness manually, you are responsible for keeping the {{k8s}} node scheduling and the {{es}} node attributes consistent. Using [ECK zone awareness](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) (ECK 3.4+) handles both layers automatically and is the recommended approach. For complete examples of both approaches, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-availability-zone-awareness).
+    When configuring awareness manually, you are responsible for keeping the {{k8s}} node scheduling and the {{es}} node attributes consistent. Using [ECK zone awareness](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-zone-awareness) handles both layers automatically and is the recommended approach. For complete examples of both approaches, refer to [Advanced {{es}} node scheduling](/deploy-manage/deploy/cloud-on-k8s/advanced-elasticsearch-node-scheduling.md#k8s-availability-zone-awareness).
     :::
 
 With this example configuration, if you start two nodes with `node.attr.rack_id` set to `rack_one` and create an index with 5 primary shards and 1 replica of each primary, all primaries and replicas are allocated across the two nodes. Because both nodes share the same rack, awareness cannot separate shard copies across racks yet. That separation happens when you add nodes in a second rack.


### PR DESCRIPTION
## Summary

- Adds a **Deployment type considerations** section at the top of the shard allocation awareness page, clearly presenting how the feature applies to each deployment type: self-managed, ECE/ECH (automatic, not configurable), and ECK (manual NodeSet config or the recommended `zoneAwareness` field for ECK 3.4+).
- Removes the ECE/ECH tip and the overloaded ECK tip from inside step 1, replacing them with structured, navigation-friendly content.
- Adds focused ECK-specific tips in steps 1 and 2 to guide users toward the right approach for ECK.
- Updates step 2 to lead with the cluster settings API (correct for dynamic settings) instead of `elasticsearch.yml` (outdated approach / not recommended for dynamic cluster settings anymore).
- Minor style fixes: typo (`two node` → `two nodes`), future tense → present tense, parallel list structure, `command-line` hyphenation.

Closes #6250

## Test plan

- [ ] Preview build renders the new section and ECK-scoped tips correctly
- [ ] Links to `advanced-elasticsearch-node-scheduling.md` anchors resolve correctly
- [ ] Vale passes on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)