### PR TITLE
Remove admin and dev projects from add-to-board automation

### DIFF
--- a/.github/workflows/add-to-board.yml
+++ b/.github/workflows/add-to-board.yml
@@ -29,8 +29,6 @@ jobs:
           "Team:Ingest":      "1034",
           "Team:Experience":  "1034",
           "Team:SKI":         "1034",
-          "Team:Admin":       "1927",
-          "Team:Developer":   "726",
           "Team:DocsEng":     "1625",
           "Team:Platform":    "1232",
           "Team:Projects":    "1415",


### PR DESCRIPTION

## Summary
The core docs team uses [project-based workflows](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically) to add items to our board from this repo, so this automation is not needed. It is also adding items to retired boards currently. Removed our projects, in case the others are still needed

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

