### PR TITLE
Lower the Serverless email sending quota to 150 per 15 minutes

### DIFF
--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -110,9 +110,11 @@ serverless: unavailable
 
 ### Email service limits
 
-The following quotas apply to both {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
+The following quotas apply to {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service. Only the sending quota differs between the two:
 
-* Email sending quota: 500 emails per 15 minute period.
+* Email sending quota:
+    * {applies_to}`serverless: ga` 150 emails per 15 minute period.
+    * {applies_to}`ess: ga` 500 emails per 15 minute period.
 * Maximum number of recipients per message: 30 recipients per email (To, CC, and BCC all count as recipients).
 * Maximum message size (including attachments): 10 MB per message (after Base64 encoding).
 * The email-sender can't be customized (Any custom `From:` header will be removed).

--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -114,7 +114,7 @@ The following quotas apply to {{ech}} deployments and {{serverless-full}} projec
 
 * Email sending quota:
     * {applies_to}`serverless: ga` 150 emails per 15 minute period.
-    * {applies_to}`ess: ga` 500 emails per 15 minute period.
+    * {applies_to}`ech: ga` 500 emails per 15 minute period.
 * Maximum number of recipients per message: 30 recipients per email (To, CC, and BCC all count as recipients).
 * Maximum message size (including attachments): 10 MB per message (after Base64 encoding).
 * The email-sender can't be customized (Any custom `From:` header will be removed).

--- a/deploy-manage/deploy/elastic-cloud/tools-apis.md
+++ b/deploy-manage/deploy/elastic-cloud/tools-apis.md
@@ -110,7 +110,7 @@ serverless: unavailable
 
 ### Email service limits
 
-The following quotas apply to {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service. Only the sending quota differs between the two:
+The following quotas apply to {{ech}} deployments and {{serverless-full}} projects when using the Elastic email service:
 
 * Email sending quota:
     * {applies_to}`serverless: ga` 150 emails per 15 minute period.


### PR DESCRIPTION
## Summary

The email sending quota for {{serverless-full}} projects is being lowered to 150 emails per 15 minute period. {{ech}} is unaffected and stays at 500.

The sending quota is no longer the same across deployment types, so that bullet is split into a Serverless entry and a Hosted entry with `applies_to` badges. The page is already scoped to both `ess: ga` and `serverless: ga` in its frontmatter, so both badges are in scope.

The other three limits on this list, recipients per message, message size, and the fixed sender address, are unchanged and still apply to both.

Created with Cursor using Claude Opus 5
