### PR TITLE
docs: Add the space selector to the Kibana global header table

### DIFF
--- a/explore-analyze/find-and-organize/kibana-interface.md
+++ b/explore-analyze/find-and-organize/kibana-interface.md
@@ -31,14 +31,13 @@ The global header holds the following elements.
 | Element | What it does |
 |---|---|
 | {icon}`logo_elastic` logo | Opens the home page of your current space. |
-| Deployment/Project name and space information | Lets you navigate to other deployments or projects, and open any spaces you have access to.  |
+| Deployment/Project name and space information | Lets you navigate to other deployments or projects. |
+| Space selector | Switch between the spaces your roles allow. Where you find it depends on your deployment type and version. Refer to [Select and switch Kibana spaces](/deploy-manage/choose-and-switch-spaces.md) for the steps. |
 | {icon}`cross_project_search` {{cps-cap}} scope selector | {applies_to}`stack: unavailable` {applies_to}`serverless: preview` Sets which linked projects your searches include. It appears only when other projects are linked to yours. Refer to [{{cps-cap}} scope selector](/explore-analyze/cross-project-search/cross-project-search-manage-scope.md#cps-in-kibana). |
 | Global search field | Searches for apps and for the objects you created. Refer to [Find apps and objects](/explore-analyze/find-and-organize/find-apps-and-objects.md). |
 | {icon}`question` **Help menu** | Opens links to the documentation, to support, and to the connection details of your project or deployment. |
 | AI assistant or agent | Opens the AI assistant or agent of your solution. Its label depends on which one your project or deployment offers. |
 | Your avatar | Opens the user menu, where you can change your appearance and language preferences, customize your navigation menu, and log out. |
-
-Where you find the space selector depends on your deployment type and version. Refer to [Select and switch Kibana spaces](/deploy-manage/choose-and-switch-spaces.md) for the steps.
 
 ## Navigation menu
 


### PR DESCRIPTION
## Summary

Follow-up to #7418 from [Mike's review comment](https://github.com/elastic/docs-content/pull/7418#discussion_r3917556935):

- Adds a **Space selector** row to the global header table on [The Kibana interface](https://www.elastic.co/docs/explore-analyze/find-and-organize/kibana-interface).
- Moves the switch-spaces how-to link into that row so the control is listed with the other header elements.
- Keeps deployment/project navigation on its own row, so the two controls are not combined in one cell.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: Cursor Grok 4.6

Made with [Cursor](https://cursor.com)