### PR TITLE
Document the Fleet enrollment token expiration field

### DIFF
--- a/reference/fleet/fleet-enrollment-tokens.md
+++ b/reference/fleet/fleet-enrollment-tokens.md
@@ -50,8 +50,12 @@ To create an enrollment token:
 
     The token name you specify must be unique to avoid conflict with any existing API keys.
 
-4. Click **Create enrollment token**.
-5. In the list of tokens, click the **Show token** icon {icon}`eye` to display the token secret.
+4. {applies_to}`stack: ga 9.3+` (Optional) In the **Expiration** field, enter a duration such as `30d`, `24h`, or `90m` to set how long the token is valid. Leave the field empty to create a token that never expires.
+
+    Use a positive whole number followed by `d` (days), `h` (hours), `m` (minutes), or `s` (seconds). After a token expires, you can no longer use it to enroll new agents. Agents that are already enrolled continue to function.
+
+5. Click **Create enrollment token**.
+6. In the list of tokens, click the **Show token** icon {icon}`eye` to display the token secret.
 
 All {{agents}} enrolled with this token use the selected policy unless you assign or enroll them in a different policy.
 


### PR DESCRIPTION
## Summary

This PR adds a new step in [Fleet enrollment tokens](https://www.elastic.co/docs/reference/fleet/fleet-enrollment-tokens) > [Create enrollment tokens](https://www.elastic.co/docs/reference/fleet/fleet-enrollment-tokens#create-fleet-enrollment-tokens) that describes the optional **Expiration** field.

The **Expiration** field existed before but was not exposed in the UI until https://github.com/elastic/kibana/pull/281324 (backported to 9.3).

Resolves https://github.com/elastic/docs-content/issues/7630

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Made with Cursor


