### PR TITLE
Fix applies_to nesting for query rules UI page

### DIFF
--- a/solutions/elasticsearch-solution-project/query-rules-ui.md
+++ b/solutions/elasticsearch-solution-project/query-rules-ui.md
@@ -1,7 +1,7 @@
 ---
 applies_to:
   stack: ga 9.1
-  serverless: 
+  serverless:
     elasticsearch: ga
 products:
  - id: elasticsearch

--- a/solutions/elasticsearch-solution-project/query-rules-ui.md
+++ b/solutions/elasticsearch-solution-project/query-rules-ui.md
@@ -1,8 +1,8 @@
 ---
 applies_to:
   stack: ga 9.1
-  serverless: ga
-  elasticsearch:
+  serverless: 
+    elasticsearch: ga
 products:
  - id: elasticsearch
 ---


### PR DESCRIPTION
## Summary
Nests `elasticsearch` under `serverless` in the query rules UI frontmatter. It was a top-level sibling of `stack` and `serverless` instead of a serverless project subkey. Introduced in #4251.

## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes  
- [ ] No  

2. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used: cursor claude 4.6 opus

Made with [Cursor](https://cursor.com)