### PR TITLE
Document PrivateLink endpoint

### DIFF
--- a/deploy-manage/security/_snippets/private-connection-fleet.md
+++ b/deploy-manage/security/_snippets/private-connection-fleet.md
@@ -1,9 +1,9 @@
-If you are using {{service-name}} together with Fleet, and enrolling the Elastic Agent with a private connection URL, you need to configure Fleet Server to use and propagate the {{service-name}} URL by updating the **Fleet Server hosts** field in the **Fleet settings** section of {{kib}}. Otherwise, Elastic Agent will reset to use a default address instead of the {{service-name}} URL. 
+In {{ech}} deployments, if you are using {{service-name}} together with {{fleet}}, and enrolling the {{agent}} with a private connection URL, you need to configure {{fleet-server}} to use and propagate the {{service-name}} URL by updating the **Fleet server hosts** field in the **Fleet settings** section of {{kib}}. Otherwise, {{agent}} will reset to use a default address instead of the {{service-name}} URL. 
 
 The URL needs to follow this pattern: 
 
 ```text
-https://{{fleet_component_ID_or_deployment_alias}}.fleet.{{private_hosted_zone_domain_name}}:443`
+https://{{fleet_component_ID_or_deployment_alias}}.fleet.{{private_hosted_zone_domain_name}}:443
 ```
 
 Similarly, the {{es}} host needs to be updated to propagate the private connection URL. The {{es}} URL needs to follow this pattern: 

--- a/deploy-manage/security/_snippets/private-connection-fleet.md
+++ b/deploy-manage/security/_snippets/private-connection-fleet.md
@@ -1,4 +1,4 @@
-In {{ech}} deployments, if you are using {{service-name}} together with {{fleet}}, and enrolling the {{agent}} with a private connection URL, you need to configure {{fleet-server}} to use and propagate the {{service-name}} URL by updating the **Fleet server hosts** field in the **Fleet settings** section of {{kib}}. Otherwise, {{agent}} will reset to use a default address instead of the {{service-name}} URL. 
+If you are using {{service-name}} together with {{fleet}}, and enrolling the {{agent}} with a private connection URL, you need to configure {{fleet-server}} to use and propagate the {{service-name}} URL by updating the **Fleet server hosts** field in the **Fleet settings** section of {{kib}}. Otherwise, {{agent}} will reset to use a default address instead of the {{service-name}} URL. 
 
 The URL needs to follow this pattern: 
 

--- a/deploy-manage/security/private-connectivity-aws.md
+++ b/deploy-manage/security/private-connectivity-aws.md
@@ -522,8 +522,47 @@ To access the deployment or project:
 
 ### AWS PrivateLink and Fleet
 
+:::::{applies-switch}
+
+::::{applies-item} ech: ga
 :::{include} _snippets/private-connection-fleet.md
 :::
+::::
+
+::::{applies-item} serverless: ga
+When a private connection is set up for your project, {{fleet}} adds two entries that can route {{agent}} traffic over AWS PrivateLink:
+
+* A {{fleet-server}} host named **Private Fleet Server**, listed in the **Fleet server hosts** section.
+* An {{es}} output named **Private Elasticsearch Output**, listed in the **Outputs** section.
+
+Both entries appear on the **Fleet** → **Settings** page with an **AWS PrivateLink** badge, and they point to the private endpoints of your project. Elastic manages their names and URLs, so you can't change them. Neither entry is used until you select it, either as the default for all agent policies or in an individual policy.
+
+To send data from all agent policies over the private connection:
+
+1. Go to **Fleet** → **Settings**.
+2. In the **Fleet server hosts** section, select **Edit** for **Private Fleet Server**, then select **Make this Fleet server the default one**.
+3. In the **Outputs** section, select **Edit** for **Private Elasticsearch Output**, then select **Make this output the default for agent integrations**. To also send agent monitoring data over the private connection, select **Make this output the default for agent monitoring**.
+4. Save your changes.
+
+To send data from a single agent policy over the private connection, and leave the remaining policies on the public endpoints:
+
+1. Go to **Fleet** → **Agent policies**, then select the policy you want to change.
+2. On the **Settings** tab, set **Fleet Server** to **Private Fleet Server**.
+3. Set **Output for integrations** and, optionally, **Output for agent monitoring** to **Private Elasticsearch Output**.
+4. Save your changes.
+
+A selection made in an agent policy takes precedence over the defaults on the **Settings** page.
+
+If the private connection is later removed from your project, {{fleet}} makes the public {{fleet-server}} host and output the default again, and deletes the private entries. Agent policies that used a private entry switch back to the default, so {{agents}} aren't left pointing at an unreachable URL.
+
+:::{admonition} Limitations
+* You can't change the performance tuning preset on **Private Elasticsearch Output**. It uses the default **Balanced** preset.
+* You can't create another {{es}} output that points to the private endpoint. Only the output that {{fleet}} adds can use that URL.
+* {{managed-integrations}} don't use the private endpoints. Elastic runs their collectors and writes the data to your project over Elastic's internal network. For more information, refer to [Security and data residency](/manage-data/ingest/managed-integrations/managed-integrations.md#managed-integrations-data-security).
+:::
+::::
+
+:::::
 
 ## Setting up a cross-region PrivateLink connection [ec-aws-inter-region-private-link]
 

--- a/reference/fleet/agent-policy.md
+++ b/reference/fleet/agent-policy.md
@@ -295,6 +295,8 @@ If your [Elastic subscription level](https://www.elastic.co/subscriptions) suppo
 2. Click **Agent policies**. Click the name of the policy you want to change, then click **Settings**.
 3. Set **Output for integrations** and (optionally) **Output for agent monitoring** to use a different output, for example, {{ls}}. You might need to scroll down to see these options.
 
+    {applies_to}`serverless: ga` If an AWS PrivateLink connection is set up for your project, you can select **Private Elasticsearch Output** to send this policy's data over your private endpoint while other policies keep using the default. Refer to [AWS PrivateLink and {{fleet}}](/deploy-manage/security/private-connectivity-aws.md#aws-privatelink-and-fleet).
+
     Unable to select a different output? Confirm that your [Elastic subscription level](https://www.elastic.co/subscriptions) supports **per policy output assignment** in {{fleet}}.
 
     :::{image} images/agent-output-settings.png

--- a/reference/fleet/fleet-agent-serverless-restrictions.md
+++ b/reference/fleet/fleet-agent-serverless-restrictions.md
@@ -23,6 +23,8 @@ If you are using {{agent}} with [{{serverless-full}}](/deploy-manage/deploy/elas
 
 On {{serverless-short}}, you can configure new {{es}} outputs to use a proxy, with the restriction that the output URL is fixed. Any new {{es}} outputs must use the default {{es}} host URL.
 
+If an AWS PrivateLink connection is set up for your project, {{fleet}} also provides an output that points to your private endpoint, which you can use instead. Refer to [AWS PrivateLink and {{fleet}}](/deploy-manage/security/private-connectivity-aws.md#aws-privatelink-and-fleet).
+
 ### Upgrade
 
 {{agents}} are not automatically upgraded with the upgrade of the {{serverless-short}} project. You can upgrade standalone or {{fleet}}-managed {{agent}}s at your convenience.
@@ -45,3 +47,4 @@ Note the following restrictions with using [{{fleet-server}}](/reference/fleet/f
 
 * On-premises {{fleet-server}} is not currently available for use in a {{serverless-short}} environment. We recommend using the hosted {{fleet-server}} that is included and configured automatically in {{serverless-short}} {{observability}} and Security projects.
 * On {{serverless-short}}, you can configure {{fleet-server}} to use a proxy, with the restriction that the {{fleet-server}} host URL is fixed. Any new {{fleet-server}} hosts must use the default {{fleet-server}} host URL. Refer to [Using a proxy server with {{agent}} and {{fleet}}](/reference/fleet/fleet-agent-proxy-support.md) for more information.
+* If an AWS PrivateLink connection is set up for your project, {{fleet}} also provides a {{fleet-server}} host that points to your private endpoint, which you can use instead of the default. Refer to [AWS PrivateLink and {{fleet}}](/deploy-manage/security/private-connectivity-aws.md#aws-privatelink-and-fleet).

--- a/reference/fleet/fleet-settings.md
+++ b/reference/fleet/fleet-settings.md
@@ -32,7 +32,9 @@ Not sure if {{fleet-server}} is running? Refer to [What is {{fleet-server}}?](/r
 
 On self-managed clusters, you must specify one or more URLs.
 
-On {{ecloud}}, this field is populated automatically. If you are using Azure Private Link, GCP Private Service Connect, or AWS PrivateLink and enrolling the {{agent}} with a private link URL, ensure that this setting is configured. Otherwise, {{agent}} will reset to use a default address instead of the private link URL.
+On {{ecloud}}, this field is populated automatically. On {{ech}} deployments, if you are using Azure Private Link, GCP Private Service Connect, or AWS PrivateLink and enrolling the {{agent}} with a private link URL, ensure that this setting is configured. Otherwise, {{agent}} will reset to use a default address instead of the private link URL.
+
+{applies_to}`serverless: ga` If an AWS PrivateLink connection is set up for your project, {{fleet}} adds a **Private Fleet Server** host that points to your private endpoint. Select it to send agent traffic over the private connection. Refer to [AWS PrivateLink and {{fleet}}](/deploy-manage/security/private-connectivity-aws.md#aws-privatelink-and-fleet).
 
 ::::{note}
 If a URL is specified without a port, {{kib}} sets the port to `80` (http) or `443` (https).
@@ -67,13 +69,12 @@ When a {{fleet-server}} is added or removed from the list, all agent policies ar
 
 Add or edit output settings to specify where {{agent}}s send data. {{agent}}s use the default output if you don’t select an output in the agent policy.
 
-::::{tip}
-If your [Elastic subscription level](https://www.elastic.co/subscriptions) supports **per integration output assignment**, you can configure {{agent}} to [send data to different outputs for different integration policies](/reference/fleet/integration-level-outputs.md).
-::::
+The {{ecloud}} internal output is locked, so you can't edit it. It handles internal routing to reduce external network charges when you use the {{ecloud}} agent policy, and it provides visibility for troubleshooting on {{ece}}.
 
+{applies_to}`serverless: ga` If an AWS PrivateLink connection is set up for your project, {{fleet}} adds a **Private Elasticsearch Output** that points to your private endpoint. Refer to [AWS PrivateLink and {{fleet}}](/deploy-manage/security/private-connectivity-aws.md#aws-privatelink-and-fleet).
 
 ::::{note}
-The {{ecloud}} internal output is locked and cannot be edited. This output is used for internal routing to reduce external network charges when using the {{ecloud}} agent policy. It also provides visibility for troubleshooting on {{ece}}.
+If your [Elastic subscription level](https://www.elastic.co/subscriptions) supports **per integration output assignment**, you can configure {{agent}} to [send data to different outputs for different integration policies](/reference/fleet/integration-level-outputs.md).
 ::::
 
 


### PR DESCRIPTION
## Summary

This PR documents the AWS PrivateLink Fleet Server host and Elasticsearch output that Fleet provisions automatically in Serverless projects when a project has AWS PrivateLink enabled (ref: [elastic/kibana#275601](https://github.com/elastic/kibana/pull/275601)).

Closes elastic/docs-content#7167

### Review follow-ups

- Restored the serverless path for other private connectivity services (Azure Private Link today) on **Fleet Server hosts**. AWS still auto-provisions **Private Fleet Server**. Other services still require configuring the private URL. GCP Private Service Connect stays on the Elastic Cloud Hosted sentence only; it is not documented as available for serverless yet.
- Removed the stale performance-tuning limitation. The preset, Advanced YAML configuration, and Write to logs streams settings are now editable on the private output, matching the default serverless output ([elastic/kibana#289759](https://github.com/elastic/kibana/pull/289759)). Names and URLs stay locked.
- Tightened the fallback wording when a private connection is removed.

### Documented limitations

- You can't create a second Elasticsearch output at the private URL. This was possible through the API by accident and is now blocked by [elastic/kibana#287316](https://github.com/elastic/kibana/pull/287316); per @criamico it should not be presented as a workaround.
- Elastic Managed integrations don't use the private endpoints.

### Verification

All UI labels, entry names, editable fields, and the removal behavior are verified against `elastic/kibana` at `main`:

- Names and provisioning: `server/services/preconfiguration/fleet_server_host.ts`, `preconfiguration/outputs.ts`
- Badge label, derived from the URL: `settings/components/fleet_server_hosts_table/index.tsx`, `outputs_table/index.tsx`
- Editable fields: `SERVERLESS_MANAGED_OUTPUT_ALLOW_EDIT` in `preconfiguration/outputs.ts`, `use_fleet_server_host_form.tsx`
- Per-policy field labels: `agent_policy/components/agent_policy_advanced_fields/index.tsx`
- Fallback on removal, including agent policies reverting to the default: `cleanPreconfiguredFleetServerHosts`, `cleanPreconfiguredOutputs`, `removeFleetServerHostFromAll`

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

2. Tool(s) and model(s) used: Cursor with Claude Opus 5.