### PR TITLE
Update the Logstash output doc with guidance on using a single ES output

### DIFF
--- a/reference/fleet/logstash-output.md
+++ b/reference/fleet/logstash-output.md
@@ -83,6 +83,37 @@ output {
 
 For more information about configuring {{ls}}, refer to [Configuring {{ls}}](logstash://reference/creating-logstash-pipeline.md) and [{{agent}} input plugin](logstash-docs-md://lsr/plugins-inputs-elastic_agent.md).
 
+## Use a single {{es}} output [logstash-output-single-es-output]
+
+The preceding pipeline example branches on `[@metadata][_id]` so that integrations that set a document ID keep it, while integrations that don't still ingest correctly. That approach requires two nearly identical `elasticsearch` output blocks. Events are split across those outputs, so bulk request sizes can vary and ingestion throughput can drop.
+
+On {{ls}} 8.12.0 or later ({{es}} output plugin 11.21.0 or later), you can keep a single {{es}} output by copying any present `[@metadata][_id]` into `[@metadata][_ingest_document][id]`. The {{es}} output plugin reads that field when it builds each bulk request. The `mutate` `copy` is a no-op when `[@metadata][_id]` is absent, so you don't need the conditional.
+
+```yaml
+filter {
+  mutate {
+    copy => { "[@metadata][_id]" => "[@metadata][_ingest_document][id]" }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://localhost:9200"]
+    # cloud_id => "..."
+    api_key => "<api_key>"
+    data_stream => true
+    ssl_enabled => true
+    ssl_certificate_authorities => "<elasticsearch_ca_path>"
+    manage_template => false
+  }
+}
+```
+
+`[@metadata][_ingest_document][id]` is read internally by the {{es}} output plugin and is not part of that plugin's documented configuration surface. Keep two things in mind when you use it:
+
+* Don't also set `document_id` on the output. An explicit `document_id` overrides the metadata field.
+* If your pipeline also uses the [`elastic_integration` filter](logstash-docs-md://lsr/plugins-filters-elastic_integration.md), add the `mutate` after that filter. The filter replaces the whole `[@metadata][_ingest_document]` map, so an earlier `copy` is discarded.
+
 ## {{ls}} output configuration settings [_ls_output_configuration_settings]
 
 The `logstash` output supports the following settings, grouped by category. Many of these settings have sensible defaults that allow you to run {{agent}} with minimal configuration.


### PR DESCRIPTION
## Summary

This PR adds a **Use a single Elasticsearch output** section documenting an alternative to the dual-output example in the [Fleet Logstash output](https://www.elastic.co/docs/reference/fleet/logstash-output) doc.

Closes https://github.com/elastic/docs-content/issues/7854

### Verification

Used Claude to check against `logstash-plugins/logstash-output-elasticsearch` at `HEAD`:

- `data_stream_event_action_tuple` calls the same `common_event_params`, which reads `[@metadata][_ingest_document]`, so this works with `data_stream => true`.
- The behavior landed in Elasticsearch output plugin **11.21.0**; Logstash **8.12.0** is the first release that bundles it.
- `resolve_document_id` prefers an explicit `document_id`, so the two must not be combined. Documented as a caveat.
- The `elastic_integration` filter replaces the whole `[@metadata][_ingest_document]` map via `event.setField`, so the `mutate` must come after it. Also documented.

### Reviewer note

`[@metadata][_ingest_document][id]` is documented as an *output* of the `elastic_integration` filter, but the Elasticsearch output plugin's docs never mention that it *consumes* the field. Documenting it here makes an internal contract semi-public, so I'd like a Logstash maintainer (cc @robbavey, per the issue) to confirm this is acceptable before merge.

A follow-up PR will apply the same treatment to `docs/reference/filebeat/filebeat-deduplication.md` in `elastic/beats`, which carries the identical dual-output pattern.

## Generative AI disclosure

1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool(s) and model(s) used: Cursor (Claude Opus 5)
