### PR TITLE
Add remote cluster ports to Azure, AWS, and GCP private connectivity pages

### DIFF
--- a/deploy-manage/security/_snippets/private-url-struct.md
+++ b/deploy-manage/security/_snippets/private-url-struct.md
@@ -18,7 +18,5 @@ Use the following URL structure. Take the alias and product from your Elastic en
 
 
 :::{tip}
-{{ech}} supports ports 443 and 9243.
-
 You can also connect to the cluster using the {{es}} cluster ID, for example, https://6b111580caaa4a9e84b18ec7c600155e.{{example-phz-dn}}.
 :::

--- a/deploy-manage/security/private-connectivity-aws.md
+++ b/deploy-manage/security/private-connectivity-aws.md
@@ -202,7 +202,7 @@ This limitation does not apply to [cross-region PrivateLink connections](#ec-aws
     :screenshot:
     :::
 
-    The security group for the endpoint should, at minimum, allow for inbound connectivity from your instances' CIDR range on ports 443 and 9243. Security groups for the instances should allow for outbound connectivity to the endpoint on ports 443 and 9243.
+    The security group for the endpoint should, at minimum, allow for inbound connectivity from your instances' CIDR range on ports 443 and 9243. Security groups for the instances should allow for outbound connectivity to the endpoint on ports 443 and 9243. If you use this endpoint for remote cluster traffic, also allow port `9400` or `9443`, depending on the security model you configure.
 
     <!--need to verify this for serverless-->
 
@@ -249,6 +249,8 @@ After you create your VPC endpoint and DNS entries, check that you are able to r
 ::::{applies-item} ess: ga
 :::{include} _snippets/private-url-struct.md
 :::
+
+{{ech}} supports ports `443` and `9243` for Elasticsearch and Kibana traffic. Remote cluster traffic for cross-cluster search and cross-cluster replication uses port `9400` with the TLS certificate based security model, or `9443` with the API key based model. Refer to [Connection paths and private connectivity](/deploy-manage/remote-clusters.md#remote-clusters-connection-paths) for the supported combinations.
 ::::
 ::::{applies-item} serverless: ga
 :::{include} _snippets/private-url-struct-serverless.md
@@ -437,6 +439,8 @@ Use the alias you’ve set up as CNAME DNS record to access your resource.
 ::::{applies-item} ess: ga
 :::{include} _snippets/private-url-struct.md
 :::
+
+{{ech}} supports ports `443` and `9243` for Elasticsearch and Kibana traffic. Remote cluster traffic for cross-cluster search and cross-cluster replication uses port `9400` with the TLS certificate based security model, or `9443` with the API key based model. Refer to [Connection paths and private connectivity](/deploy-manage/remote-clusters.md#remote-clusters-connection-paths) for the supported combinations.
 ::::
 ::::{applies-item} serverless: ga
 :::{include} _snippets/private-url-struct-serverless.md

--- a/deploy-manage/security/private-connectivity-azure.md
+++ b/deploy-manage/security/private-connectivity-azure.md
@@ -267,6 +267,8 @@ After you create your private connection, you can check that you're able to reac
 ::::{applies-item} ess: ga
 :::{include} _snippets/private-url-struct.md
 :::
+
+{{ech}} supports ports `443` and `9243`.
 ::::
 ::::{applies-item} serverless: ga
 :::{include} _snippets/private-url-struct-serverless.md
@@ -443,6 +445,8 @@ Use the alias you've set up as an A record to access your resource.
 ::::{applies-item} ess: ga
 :::{include} _snippets/private-url-struct.md
 :::
+
+{{ech}} supports ports `443` and `9243`.
 ::::
 ::::{applies-item} serverless: ga
 :::{include} _snippets/private-url-struct-serverless.md

--- a/deploy-manage/security/private-connectivity-gcp.md
+++ b/deploy-manage/security/private-connectivity-gcp.md
@@ -256,6 +256,8 @@ Use the alias you’ve set up as CNAME A record to access your deployment.
 :::{include} _snippets/private-url-struct.md
 :::
 
+{{ech}} supports ports `443` and `9243` for Elasticsearch and Kibana traffic. Remote cluster traffic for cross-cluster search and cross-cluster replication uses port `9400` with the TLS certificate based security model, or `9443` with the API key based model. Refer to [Connection paths and private connectivity](/deploy-manage/remote-clusters.md#remote-clusters-connection-paths) for the supported combinations.
+
 To access the deployment:
 
 1. If needed, find the endpoint of an application in your deployment:


### PR DESCRIPTION
## Summary

- Extracts the port information from the shared `private-url-struct.md` snippet so each private connectivity page can specify its own supported ports.
- Adds remote cluster ports (9400 for TLS certificate model, 9443 for API key model) to the AWS and Azure pages. Adds just 9400 for GCP and adds limitation for 9443
- Adds a sentence to the AWS security group guidance so readers don't build rules that silently drop remote cluster traffic.

Serverless notes unchanged.

Partial fix for https://github.com/elastic/docs-content/issues/8185