### PR TITLE
Sync agent-skill references to elastic/agent-skills v0.6.0

### DIFF
--- a/deploy-manage/api-keys/elastic-cloud-api-keys.md
+++ b/deploy-manage/api-keys/elastic-cloud-api-keys.md
@@ -33,7 +33,7 @@ An {{ecloud}} API key belongs to the organization and is not tied to the user wh
 You can have multiple API keys for different purposes, and you can revoke them when you no longer need them. Each organization can have up to 500 active API keys.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/access-management
+:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/onboarding
 :::
 
 ## Required permissions

--- a/deploy-manage/api-keys/elasticsearch-api-keys.md
+++ b/deploy-manage/api-keys/elasticsearch-api-keys.md
@@ -27,11 +27,6 @@ To manage API keys in {{kib}}, go to the **API keys** management page in the nav
 
 ![API Keys UI](/deploy-manage/images/kibana-api-keys.png "")
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/elasticsearch/elasticsearch-authn
-:::
-
-
 ## Security privileges [api-keys-security-privileges]
 
 * To use API keys in {{kib}}, you must have the `manage_security`, `manage_api_key`, or the `manage_own_api_key` cluster privileges.

--- a/deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
+++ b/deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md
@@ -20,7 +20,7 @@ On this page, you can find examples of how to create and manage serverless proje
 To try the examples in this section, start by [setting up an API key](#general-manage-project-with-api-set-up-api-key).
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/manage-project
+:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/provisioning
 :::
 
 ## API resources
@@ -51,10 +51,6 @@ To create and manage projects with the {{serverless-full}} API, you must authent
    ```
 
 ## Create an {{serverless-full}} project [general-manage-project-with-api-create-a-serverless-elasticsearch-project]
-
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/create-project
-:::
 
 ```bash
 curl -H "Authorization: ApiKey $API_KEY" \

--- a/deploy-manage/manage-connectors.md
+++ b/deploy-manage/manage-connectors.md
@@ -22,10 +22,6 @@ You can find the **{{connectors-ui}}** management page in the navigation menu or
 {{connectors-ui}} are not the same as [application connections](/deploy-manage/app-connections.md) or [search connectors](elasticsearch://reference/search-connectors/index.md). Application connections manage OAuth client registration and external access to {{serverless-short}} projects. Search connectors sync data from third-party sources into {{es}}.
 :::
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-connectors
-:::
-
 ## Required permissions [_required_permissions_2]
 
 Access to connectors is granted based on your privileges to alerting-enabled features. For more information, go to [Security](../explore-analyze/alerting/alerts/alerting-setup.md#alerting-security).

--- a/deploy-manage/security/logging-configuration/configuring-audit-logs.md
+++ b/deploy-manage/security/logging-configuration/configuring-audit-logs.md
@@ -21,10 +21,6 @@ When auditing security events, a single client request might generate multiple a
 
 ### {{es}} auditing configuration
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/elasticsearch/elasticsearch-audit
-:::
-
 {{es}} configuration options include:
 
   * [{{es}} audited events settings](elasticsearch://reference/elasticsearch/configuration-reference/auding-settings.md#event-audit-settings): Use include and exclude filters to control the types of events that get logged.
@@ -42,10 +38,6 @@ For a complete description of event details and format, refer to the following r
   * [{{es}} log entry output format](./logfile-audit-output.md#audit-log-entry-format)
 
 ### {{kib}} auditing configuration
-
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-audit
-:::
 
 To control the logs that are outputted by {{kib}}, you can use [{{kib}} ignore filters](kibana://reference/configuration-reference/security-settings.md#audit-logging-ignore-filters). These are a list of filters that determine which events should be excluded from the audit log.
 

--- a/deploy-manage/security/network-security-api.md
+++ b/deploy-manage/security/network-security-api.md
@@ -21,7 +21,7 @@ sub:
 This example demonstrates how to use the {{ecloud}} RESTful API, {{ece}} RESTful API, or {{serverless-full}} RESTful API to manage different types of network security policies and rules. 
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/network-security
+:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/provisioning
 :::
 
 We cover the following examples:

--- a/deploy-manage/users-roles/cloud-organization/manage-users.md
+++ b/deploy-manage/users-roles/cloud-organization/manage-users.md
@@ -23,7 +23,7 @@ Alternatively, [configure {{ecloud}} SAML SSO](../../../deploy-manage/users-role
 An {{ecloud}} account can belong to multiple organizations. However, the user's roles and the resources that they have access to are controlled at the organization level.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/access-management
+:url: https://github.com/elastic/agent-skills/tree/main/skills/cloud/onboarding
 :::
 
 :::{tip}

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/native.md
@@ -29,10 +29,6 @@ You can also manage and authenticate users natively at the following levels:
 * For an [{{ecloud}} organization](/deploy-manage/users-roles/cloud-organization/manage-users.md).
 :::
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/elasticsearch/elasticsearch-authz
-:::
-
 ## Configure a native realm [native-realm-configuration]
 
 The native realm is available and enabled by default. You can disable it explicitly with the following setting.

--- a/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md
+++ b/deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md
@@ -12,10 +12,6 @@ products:
 
 After a user is [authenticated](user-authentication.md), {{stack}} needs to determine whether the user behind an incoming request is allowed to execute the request. The primary method of authorization in a cluster is [role-based access control](#roles) (RBAC), although {{stack}} also supports [Attribute-based access control](#attributes) (ABAC).
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/elasticsearch/elasticsearch-authz
-:::
-
 :::{tip}
 If you use {{ece}} or {{ech}}, then you can also implement RBAC at the level of your [{{ece}} orchestrator](/deploy-manage/users-roles/cloud-enterprise-orchestrator.md) or [{{ecloud}} organization](/deploy-manage/users-roles/cloud-organization.md).
 

--- a/explore-analyze/ai-features/agent-builder/custom-agents.md
+++ b/explore-analyze/ai-features/agent-builder/custom-agents.md
@@ -23,7 +23,7 @@ Built-in agents are immutable and cannot be edited. To customize agent behavior,
 Custom agents are space-aware: they are only available in the [{{kib}} space](/deploy-manage/manage-spaces.md) where they were created. In contrast, built-in agents are available across all spaces.
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/agent-builder
+:url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-agent-builder
 :::
 
 ## Create a custom agent

--- a/explore-analyze/visualize/custom-visualizations-with-vega.md
+++ b/explore-analyze/visualize/custom-visualizations-with-vega.md
@@ -26,10 +26,6 @@ Add a **Vega** panel on a dashboard to use these grammars with {{kib}} filters, 
 You can also ask [{{agent-builder}}](/explore-analyze/ai-features/agent-builder/agent-builder-dashboards-and-visualizations.md) to generate Vega-Lite visualizations from natural language when it creates or updates a dashboard through chat.
 :::
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/kibana/kibana-vega
-:::
-
 :::{image} /explore-analyze/images/kibana-vega.png
 :alt: Vega UI
 :screenshot:

--- a/solutions/observability/apm/service-overview.md
+++ b/solutions/observability/apm/service-overview.md
@@ -15,10 +15,6 @@ products:
 
 Selecting a non-mobile [**service**](/solutions/observability/apm/services.md) brings you to the **Service overview**. The **Service overview** contains a wide variety of charts and tables that provide high-level visibility into how a service is performing across your infrastructure:
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/service-health
-:::
-
 * Service details like service version, runtime version, framework, and APM agent name and version
 * Container and orchestration information
 * Cloud provider, machine type, service name, region, and availability zone

--- a/solutions/observability/incident-management/create-an-slo.md
+++ b/solutions/observability/incident-management/create-an-slo.md
@@ -34,7 +34,7 @@ From here, complete the following steps:
 3. [Describe your SLO](/solutions/observability/incident-management/create-an-slo.md#slo-describe).
 
 :::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/manage-slos
+:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/service-reliability
 :::
 
 ::::{note}

--- a/solutions/observability/logs/filter-aggregate-logs.md
+++ b/solutions/observability/logs/filter-aggregate-logs.md
@@ -19,11 +19,6 @@ This guide shows you how to:
 * [Filter logs](/solutions/observability/logs/filter-aggregate-logs.md#logs-filter): Narrow down your log data by applying specific criteria.
 * [Aggregate logs](/solutions/observability/logs/filter-aggregate-logs.md#logs-aggregate): Analyze and summarize data to find patterns and gain insight.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/observability/logs-search
-:::
-
-
 ## Before you get started [logs-filter-and-aggregate-prereq]
 
 ::::{note}

--- a/troubleshoot/elasticsearch/security.md
+++ b/troubleshoot/elasticsearch/security.md
@@ -10,10 +10,6 @@ products:
 
 Use the information in this section to troubleshoot common problems and find answers for frequently asked questions.
 
-:::{agent-skill}
-:url: https://github.com/elastic/agent-skills/tree/main/skills/elasticsearch/elasticsearch-security-troubleshooting
-:::
-
 * [](security/security-trb-settings.md)
 * [](security/security-trb-roles.md)
 * [](security/security-trb-extraargs.md)


### PR DESCRIPTION
## Summary

The [elastic/agent-skills](https://github.com/elastic/agent-skills) `v0.6.0` release (2026-09-04) reorganized the skill catalog. Several `{agent-skill}` callouts in this repo pointed at skills that were renamed, consolidated, or removed, resulting in broken 404 links (surfaced by the audit logging page in Slack).

This PR retargets or removes those callouts so every remaining `{agent-skill}` URL resolves to a folder present in the current `main` tree.

Closes elastic/docs-content#8230.

## Changes

**Rename**
- `explore-analyze/ai-features/agent-builder/custom-agents.md`: `kibana/agent-builder` -> `kibana/kibana-agent-builder`

**Retarget to consolidated skill**
- `deploy-manage/api-keys/elastic-cloud-api-keys.md`, `deploy-manage/users-roles/cloud-organization/manage-users.md`: `cloud/access-management` -> `cloud/onboarding`
- `deploy-manage/security/network-security-api.md`: `cloud/network-security` -> `cloud/provisioning`
- `deploy-manage/deploy/elastic-cloud/manage-serverless-projects-using-api.md`: `cloud/manage-project` -> `cloud/provisioning`; removed the duplicate `cloud/create-project` callout
- `solutions/observability/incident-management/create-an-slo.md`: `observability/manage-slos` -> `observability/service-reliability`

**Remove (no public successor)**
- `deploy-manage/security/logging-configuration/configuring-audit-logs.md`: `elasticsearch-audit` and `kibana-audit` (the flagged page)
- `deploy-manage/manage-connectors.md`: `kibana-connectors`
- `explore-analyze/visualize/custom-visualizations-with-vega.md`: `kibana-vega`
- `deploy-manage/api-keys/elasticsearch-api-keys.md`: `elasticsearch-authn`
- `deploy-manage/users-roles/cluster-or-deployment-auth/native.md`, `deploy-manage/users-roles/cluster-or-deployment-auth/user-roles.md`: `elasticsearch-authz`
- `troubleshoot/elasticsearch/security.md`: `elasticsearch-security-troubleshooting`
- `solutions/observability/logs/filter-aggregate-logs.md`: `logs-search`
- `solutions/observability/apm/service-overview.md`: `service-health` (per #8230, retargeting to `sre-triage` is out of scope: UI tour vs incident triage)

## Notes

- The Remove and Retarget lists match issue #8230 exactly.
- EDOT (`edot-*`) callouts also moved to `observability-onboarding`, but those pages live in the `elastic-otel-*` product repos and are tracked separately in #8230 (out of scope here).

Made with [Cursor](https://cursor.com)