### PR TITLE
docset: add catalog categories for API catalog chips

### DIFF
--- a/docset.yml
+++ b/docset.yml
@@ -14,28 +14,51 @@ api:
     - spec: elasticsearch.json
       product: elasticsearch
       repository: elastic/elasticsearch-specification
+      catalog:
+        categories:
+          - self
+          - ece
+          - ess
   elasticsearch-serverless:
     - spec: elasticsearch-serverless.json
       product: serverless-elasticsearch
       repository: elastic/elasticsearch-specification
+      catalog:
+        categories:
+          - serverless
   kibana:
     - spec: kibana.yaml
       product: kibana
       repository: elastic/kibana
       children:
         - file: kibana-api-overview.md
+      catalog:
+        categories:
+          - self
+          - ece
+          - ess
   kibana-serverless:
     - spec: kibana-serverless.yaml
       product: kibana
       repository: elastic/kibana
+      catalog:
+        categories:
+          - serverless
   cloud-connect:
     - spec: cloud-connect.yml
       product: ess
       repository: elastic/cloud-connected-api
+      catalog:
+        categories:
+          - self
+          - ece
   cloud-serverless:
     - spec: elastic-cloud-serverless.yml
       product: cloud-serverless
       repository: elastic/serverless-api-specification
+      catalog:
+        categories:
+          - serverless
 
 cta:
   monitor-kubernetes:


### PR DESCRIPTION
## Why

- The assembled API catalog at `/docs/api/` needs explicit `catalog.categories` so readers can filter APIs by deployment.
- This is a follow-up to [elastic/docs-builder#4057](https://github.com/elastic/docs-builder/pull/4057), which adds the category chips. That PR is still open.

## What

- Add `catalog.categories` to the existing `api:` entries in `docset.yml`.
- These labels are discovery chips only. They are not versioned `applies_to` claims. Accepted keys: `self`, `ece`, `ess` (`ech` is an alias), and `serverless`.
- Without categories, the catalog still lists APIs but shows no filter bar.

## Notes

- **Risk:** `catalog:` is new in docs-builder #4057. Current docs-builder `main` ignores unknown `api:` keys, so merging this first should not fail assembler or staging builds. The chips will not appear until #4057 ships.
- Logstash is out of scope here. When it is declared, use `[self, ece, ess]` (Logstash appears in ECE and ECH).
- Other Bump-only APIs (cloud, cloud-enterprise, cloud-billing, observability intake) stay out until they have `api:` entries.


Made with [Cursor](https://cursor.com)