### PR TITLE
Document ECE RHEL 10 host prep

### DIFF
--- a/deploy-manage/deploy/cloud-enterprise/configure-host-rhel.md
+++ b/deploy-manage/deploy/cloud-enterprise/configure-host-rhel.md
@@ -12,14 +12,16 @@ products:
 
 # Configure a RHEL host [ece-configure-hosts-rhel-centos]
 
-Red Hat Enterprise Linux 8 and 9, along with Rocky Linux 8 and 9, run {{ece}} (ECE) on Podman rather than Docker. Use these steps to install and configure Podman, and to apply the SELinux, XFS, and kernel tuning that ECE expects on RHEL-compatible distributions.
+Red Hat Enterprise Linux 8, 9, and 10, along with Rocky Linux 8 and 9, run {{ece}} (ECE) on Podman rather than Docker. Use these steps to install and configure Podman, and to apply the SELinux, XFS, and kernel tuning that ECE expects on RHEL-compatible distributions.
 
 * [Prerequisites](#ece-prerequisites-rhel8)
 * [Install Podman and configure the host](#ece-configure-hosts-rhel8-podman)
 
 ## Prerequisites [ece-prerequisites-rhel8]
 
-* Follow your internal guidelines to create a RHEL 8 (the version must be >= 8.5), RHEL 9, Rocky Linux 8, or Rocky Linux 9 server or VM in your environment.
+* Follow your internal guidelines to create a RHEL 8 (the version must be >= 8.5), RHEL 9, RHEL 10, Rocky Linux 8, or Rocky Linux 9 server or VM in your environment.
+
+    {applies_to}`ece: ga 4.2` RHEL 10 is supported with Podman 5 only. Do not install Podman 4 on RHEL 10, and do not follow the RHEL 9 CNI networking steps on RHEL 10.
 
 * Verify that required traffic is allowed. Check the [Networking prerequisites](ece-networking-prereq.md) for a list of ports that need to be open. The technical configuration depends on the underlying infrastructure. For example, for AWS, allowing traffic between hosts is implemented using security groups.
 
@@ -46,6 +48,7 @@ Red Hat Enterprise Linux 8 and 9, along with Rocky Linux 8 and 9, run {{ece}} (E
     sudo dnf -y install containernetworking-plugins
     ```
 
+    Do not install `containernetworking-plugins` on RHEL 10. That package is not available, and ECE on RHEL 10 uses Podman's default Netavark backend instead of CNI.
     ::::
 
 2. Remove Docker and previously installed Podman packages (if previously installed).
@@ -74,6 +77,11 @@ Red Hat Enterprise Linux 8 and 9, along with Rocky Linux 8 and 9, run {{ece}} (E
         ```
 
 4. Install Podman:
+
+    ::::{note}
+    :applies_to: ece: ga 4.2
+    RHEL 10 supports Podman 5 only. Use the Podman 5 steps in this section. Podman 4 is not a supported combination on RHEL 10.
+    ::::
 
     * For Podman 4:
 
@@ -122,20 +130,27 @@ Red Hat Enterprise Linux 8 and 9, along with Rocky Linux 8 and 9, run {{ece}} (E
             sudo dnf versionlock list
             ```
 
-5. For RHEL 9 and Rocky Linux 9 only: Switch the network stack from Netavark to CNI.
+5. Configure the Podman network backend. The required backend depends on the OS version:
 
-    1. If the `/etc/containers/containers.conf` file does not exist, copy the `/usr/share/containers/containers.conf` file to the `/etc/containers/` directory (for example, using `cp /usr/share/containers/containers.conf /etc/containers/`).
-    2. Open the `/etc/containers/containers.conf` file. Navigate to the **network** section and make sure that the **network_backend** setting is set to `cni`.
-    3. Reboot the system (`reboot`).
-    4. Check that the network stack has changed to `cni`: <br>
+    * For RHEL 9 and Rocky Linux 9 only: Switch the network stack from Netavark to CNI.
 
-        ```sh
-        cat /etc/containers/containers.conf
-        [...]
-        [network]
-        network_backend="cni"
-        [...]
-        ```
+        1. If the `/etc/containers/containers.conf` file does not exist, copy the `/usr/share/containers/containers.conf` file to the `/etc/containers/` directory (for example, using `cp /usr/share/containers/containers.conf /etc/containers/`).
+        2. Open the `/etc/containers/containers.conf` file. Navigate to the **network** section and make sure that the **network_backend** setting is set to `cni`.
+        3. Reboot the system (`reboot`).
+        4. Check that the network stack has changed to `cni`: <br>
+
+            ```sh
+            cat /etc/containers/containers.conf
+            [...]
+            [network]
+            network_backend="cni"
+            [...]
+            ```
+
+    * {applies_to}`ece: ga 4.2` For RHEL 10: Keep the default Netavark backend. Do not install `containernetworking-plugins` and do not set `network_backend=cni`.
+
+        1. If the `/etc/containers/containers.conf` file does not exist, copy the `/usr/share/containers/containers.conf` file to the `/etc/containers/` directory (for example, using `cp /usr/share/containers/containers.conf /etc/containers/`).
+        2. If the file contains a `network_backend` setting (for example a leftover `cni` pin), remove that line so Podman uses the RHEL 10 default (Netavark).
 
 6. If Podman requires a proxy in your infrastructure setup, modify the `/usr/share/containers/containers.conf` file and add the `HTTP_PROXY` and `HTTPS_PROXY` environment variables in the [engine] section. Note that multiple env variables in that configuration file exists — use the one in the [engine] section.
 
@@ -228,6 +243,8 @@ Red Hat Enterprise Linux 8 and 9, along with Rocky Linux 8 and 9, run {{ece}} (E
     ```
 
 16. As a sudoers user, add the following two lines to section `[storage]` in the file `/etc/containers/storage.conf`. Verify that those parameters are only defined once. Either remove or comment out potentially existing parameters.
+
+    If `/etc/containers/storage.conf` does not exist, copy it from `/usr/share/containers/storage.conf` first (for example, `sudo cp /usr/share/containers/storage.conf /etc/containers/storage.conf`). On RHEL 10, this file is typically not present in `/etc/containers/` until you copy it after installing Podman.
 
     ::::{note}
     Avoid customizing the host Docker path `/mnt/data/docker` when using SELinux. Otherwise the ECE installer script needs to be adjusted.
@@ -412,6 +429,8 @@ Red Hat Enterprise Linux 8 and 9, along with Rocky Linux 8 and 9, run {{ece}} (E
     2. Set the dual-stack network as the default for new containers. Open `/etc/containers/containers.conf` and, in the `[network]` section, set `default_network`. If the file or section does not exist yet, create it.
 
         On RHEL 9 and Rocky Linux 9, merge this setting with the existing `network_backend="cni"` configuration rather than creating a duplicate `[network]` section.
+
+        {applies_to}`ece: ga 4.2` On RHEL 10, do not add `network_backend`. Leave that setting unset so Podman continues to use Netavark.
 
         ```text
         [network]

--- a/deploy-manage/deploy/cloud-enterprise/configure-host-rhel.md
+++ b/deploy-manage/deploy/cloud-enterprise/configure-host-rhel.md
@@ -244,8 +244,6 @@ Red Hat Enterprise Linux 8, 9, and 10, along with Rocky Linux 8 and 9, run {{ece
 
 16. As a sudoers user, add the following two lines to section `[storage]` in the file `/etc/containers/storage.conf`. Verify that those parameters are only defined once. Either remove or comment out potentially existing parameters.
 
-    If `/etc/containers/storage.conf` does not exist, copy it from `/usr/share/containers/storage.conf` first (for example, `sudo cp /usr/share/containers/storage.conf /etc/containers/storage.conf`). On RHEL 10, this file is typically not present in `/etc/containers/` until you copy it after installing Podman.
-
     ::::{note}
     Avoid customizing the host Docker path `/mnt/data/docker` when using SELinux. Otherwise the ECE installer script needs to be adjusted.
     ::::

--- a/deploy-manage/deploy/cloud-enterprise/ece-ipv6-aws-setup.md
+++ b/deploy-manage/deploy/cloud-enterprise/ece-ipv6-aws-setup.md
@@ -82,7 +82,7 @@ Dual-stack ECE hosts are required for IPv6 egress. IPv6 ingress alone does not r
 To create a new environment using this tutorial, you need the following:
 
 - An {{aws}} account with permissions to create VPCs, subnets, EC2 instances, NLBs, ALBs, and ACM certificates.
-- A RHEL 8 or RHEL 9 AMI (official Red Hat AMI, not marketplace variants).
+- A RHEL 8, RHEL 9, or RHEL 10 AMI (official Red Hat AMI, not marketplace variants).
 - An instance type that meets the [ECE requirements](/deploy-manage/deploy/cloud-enterprise/ece-hardware-prereq.md), with at least 32 GB of RAM for single-node testing.
 
 ::::{note}
@@ -590,7 +590,7 @@ To support IPv6 egress in an existing IPv4 ECE environment, you must update both
 
 2. Reconfigure host network interfaces for dual-stack connectivity:
 
-    After assigning IPv6 addresses in {{aws}}, RHEL 8/9 might not automatically configure IPv6 on the active interface. Configure NetworkManager explicitly:
+    After assigning IPv6 addresses in {{aws}}, RHEL 8, 9, and 10 might not automatically configure IPv6 on the active interface. Configure NetworkManager explicitly:
 
     ```bash
     # List connections and identify the active one
@@ -624,7 +624,7 @@ To support IPv6 egress in an existing IPv4 ECE environment, you must update both
       ece-network
     ```
 
-    Then open `/etc/containers/containers.conf` and, in the `[network]` section, set `default_network`. If the file or section does not exist yet, create it. On RHEL 9 and Rocky Linux 9, merge this setting with the existing `network_backend="cni"` configuration rather than creating a duplicate `[network]` section:
+    Then open `/etc/containers/containers.conf` and, in the `[network]` section, set `default_network`. If the file or section does not exist yet, create it. On RHEL 9 and Rocky Linux 9, merge this setting with the existing `network_backend="cni"` configuration rather than creating a duplicate `[network]` section. {applies_to}`ece: ga 4.2` On RHEL 10, do not add `network_backend`. Leave that setting unset so Podman continues to use Netavark:
 
     ```text
     [network]

--- a/deploy-manage/deploy/cloud-enterprise/install.md
+++ b/deploy-manage/deploy/cloud-enterprise/install.md
@@ -47,7 +47,7 @@ After completing the prerequisites, proceed to configure your ECE hosts. This in
 ECE supports a [wide range of OS versions](https://www.elastic.co/support/matrix#elastic-cloud-enterprise). Below are some OS-specific instructions for preparing your hosts, though other versions follow a similar process. Choose the appropriate guide for your operating system and follow the instructions:
 
 * [Ubuntu 20.04 LTS (Focal Fossa) and Ubuntu 22.04 LTS (Jammy Jellyfish)](configure-host-ubuntu.md)
-* [Red Hat Enterprise Linux (RHEL) 8 and 9](configure-host-rhel.md)
+* [Red Hat Enterprise Linux (RHEL) 8, 9, and 10](configure-host-rhel.md)
 * [Rocky Linux 8 and 9](configure-host-rhel.md)
 * [SUSE Linux Enterprise Server (SLES) 12 SP5 and 15](configure-host-suse.md)
 

--- a/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
+++ b/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
@@ -35,7 +35,9 @@ Using Docker or Podman as container runtime is a configuration local to the host
 
 1. Make sure you are running a healthy x-node ECE environment ready to be upgraded. All nodes use the Docker container runtime.
 2. Upgrade to ECE 3.3.0+ following the [Upgrade your installation](../../upgrade/orchestrator/upgrade-cloud-enterprise.md) guideline. Skip this step if your existing ECE installation already runs ECE >= 3.3.0.
-3. Follow your internal guidelines to add an additional vanilla RHEL (Note that the version must be >= 8.5, but <9), or Rocky Linux 8 or 9 VM to your environment.
+3. Follow your internal guidelines to add an additional vanilla RHEL 8 (the version must be >= 8.5), RHEL 9, RHEL 10, or Rocky Linux 8 or 9 VM to your environment.
+
+    {applies_to}`ece: ga 4.2` RHEL 10 is supported with Podman 5 only. Do not install Podman 4 on RHEL 10, and do not follow the RHEL 9 CNI networking steps on RHEL 10.
 4. Verify that required traffic from the host added in step 3 is allowed to the primary ECE VM(s). Check the [Networking prerequisites](ece-networking-prereq.md) and [Google Cloud Platform (GCP)](/deploy-manage/deploy/cloud-enterprise/prepare-environment.md) guidelines for a list of ports that need to be open. The technical configuration highly depends on the underlying infrastructure.
 
     **Example** For AWS, allowing traffic between hosts is implemented using security groups.
@@ -76,6 +78,7 @@ Using Docker or Podman as container runtime is a configuration local to the host
     sudo dnf -y install containernetworking-plugins
     ```
 
+    Do not install `containernetworking-plugins` on RHEL 10. That package is not available, and ECE on RHEL 10 uses Podman's default Netavark backend instead of CNI.
     ::::
 
 2. Remove Docker and previously installed podman packages (if previously installed).
@@ -104,6 +107,11 @@ Using Docker or Podman as container runtime is a configuration local to the host
         ```
 
 4. Install Podman:
+
+    ::::{note}
+    :applies_to: ece: ga 4.2
+    RHEL 10 supports Podman 5 only. Use the Podman 5 steps in this section. Podman 4 is not a supported combination on RHEL 10.
+    ::::
 
     * For Podman 4
 
@@ -153,20 +161,27 @@ Using Docker or Podman as container runtime is a configuration local to the host
             sudo dnf versionlock list
             ```
 
-5. [This step is for RHEL 9 and Rocky Linux 9 only] Switch the network stack from Netavark to CNI:
+5. Configure the Podman network backend. The required backend depends on the OS version:
 
-    1. If the */etc/containers/containers.conf* file does not exist, copy the */usr/share/containers/containers.conf* file to the */etc/containers/* directory (for example, using `cp /usr/share/containers/containers.conf /etc/containers/`).
-    2. Open the */etc/containers/containers.conf* file. Navigate to the **network** section and make sure that the **network_backend** setting is set to `cni`.
-    3. Reboot the system (`reboot`).
-    4. Check that the network stack has changed to `cni`: <br>
+    * For RHEL 9 and Rocky Linux 9 only: Switch the network stack from Netavark to CNI.
 
-        ```sh
-        cat /etc/containers/containers.conf
-        [...]
-        [network]
-        network_backend="cni"
-        [...]
-        ```
+        1. If the `/etc/containers/containers.conf` file does not exist, copy the `/usr/share/containers/containers.conf` file to the `/etc/containers/` directory (for example, using `cp /usr/share/containers/containers.conf /etc/containers/`).
+        2. Open the `/etc/containers/containers.conf` file. Navigate to the **network** section and make sure that the **network_backend** setting is set to `cni`.
+        3. Reboot the system (`reboot`).
+        4. Check that the network stack has changed to `cni`: <br>
+
+            ```sh
+            cat /etc/containers/containers.conf
+            [...]
+            [network]
+            network_backend="cni"
+            [...]
+            ```
+
+    * {applies_to}`ece: ga 4.2` For RHEL 10: Keep the default Netavark backend. Do not install `containernetworking-plugins` and do not set `network_backend=cni`.
+
+        1. If the `/etc/containers/containers.conf` file does not exist, copy the `/usr/share/containers/containers.conf` file to the `/etc/containers/` directory (for example, using `cp /usr/share/containers/containers.conf /etc/containers/`).
+        2. If the file contains a `network_backend` setting (for example a leftover `cni` pin), remove that line so Podman uses the RHEL 10 default (Netavark).
 
 6. If podman requires a proxy in your infrastructure setup, modify the `/usr/share/containers/containers.conf` file and add the `HTTP_PROXY` and `HTTPS_PROXY` environment variables in the [engine] section. Note that multiple env variables in that configuration file exists — use the one in the [engine] section.
 
@@ -259,6 +274,8 @@ Using Docker or Podman as container runtime is a configuration local to the host
     ```
 
 16. As a sudoers user, add the following two lines to section `[storage]` in the file `/etc/containers/storage.conf`. Verify that those parameters are only defined once. Either remove or comment out potentially existing parameters.
+
+    If `/etc/containers/storage.conf` does not exist, copy it from `/usr/share/containers/storage.conf` first (for example, `sudo cp /usr/share/containers/storage.conf /etc/containers/storage.conf`). On RHEL 10, this file is typically not present in `/etc/containers/` until you copy it after installing Podman.
 
     ::::{note}
     Avoid customizing the host Docker path `/mnt/data/docker` when using SELinux. Otherwise the ECE installer script needs to be adjusted.

--- a/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
+++ b/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts.md
@@ -275,8 +275,6 @@ Using Docker or Podman as container runtime is a configuration local to the host
 
 16. As a sudoers user, add the following two lines to section `[storage]` in the file `/etc/containers/storage.conf`. Verify that those parameters are only defined once. Either remove or comment out potentially existing parameters.
 
-    If `/etc/containers/storage.conf` does not exist, copy it from `/usr/share/containers/storage.conf` first (for example, `sudo cp /usr/share/containers/storage.conf /etc/containers/storage.conf`). On RHEL 10, this file is typically not present in `/etc/containers/` until you copy it after installing Podman.
-
     ::::{note}
     Avoid customizing the host Docker path `/mnt/data/docker` when using SELinux. Otherwise the ECE installer script needs to be adjusted.
     ::::


### PR DESCRIPTION
## Summary

ECE 4.2 already supports RHEL 10 + Podman 5 on the [support matrix](https://www.elastic.co/support/matrix#elastic-cloud-enterprise), but the host-prep docs still listed only RHEL 8/9. Following the RHEL 9 steps on RHEL 10 fails: `containernetworking-plugins` is not available, and ECE keeps Podman's default Netavark backend instead of switching to CNI.

Updates:

- [Configure a RHEL host](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/configure-host-rhel): add RHEL 10; Podman 5 only; keep Netavark
- [Install ECE](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/install): include RHEL 10 in the OS list
- [Migrate ECE to Podman hosts](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/migrate-ece-to-podman-hosts): same host-prep differences (also drops the stale RHEL `<9` restriction)
- [Set up IPv6 for ECE on AWS](https://www.elastic.co/docs/deploy-manage/deploy/cloud-enterprise/ece-ipv6-aws-setup): RHEL 10 AMI and do not pin `network_backend=cni`

Host-prep differences are based on the ECE Ansible role RHEL 10 path (`tasks/base/RedHat-10`).


## Generative AI disclosure
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

Tool(s) and model(s) used: Cursor (Grok)

<small>*(AI-authored via Cursor 🤖)*</small>