### PR TITLE
Clarify that enabling space awareness in Fleet has no supported rollback

### DIFF
--- a/deploy-manage/manage-spaces-fleet.md
+++ b/deploy-manage/manage-spaces-fleet.md
@@ -26,7 +26,9 @@ To use space awareness with {{fleet}}:
 
 ## Enable space awareness in Fleet [spaces-fleet-enable]
 
-You must enable space awareness for deployments upgraded to 9.1.0 or later. Space awareness requires a one-time migration that copies your existing {{fleet}} data into a new, space-aware model. Previous data is preserved in snapshots in case you need to roll back.
+You must enable space awareness for deployments upgraded to 9.1.0 or later. Space awareness requires a one-time, irreversible migration. Fleet reads the legacy agent and package policy saved objects, then creates new space-aware versions with the same IDs and attributes. There is no supported rollback path for this migration.
+
+If your deployment uses [reusable integration policies](/reference/fleet/agent-policy.md#add-integration), agent policies that use them cannot be moved to a different space after migration.
 
 To enable space awareness in upgraded deployments:
 


### PR DESCRIPTION
<!--
Thank you for contributing to the Elastic Docs! 🎉
Use this template to help us efficiently review your contribution.
-->

## Summary
<!--
Describe what your PR changes or improves.  
If your PR fixes an issue, link it here. If your PR does not fix an issue, describe the reason you are making the change. 
-->

https://www.elastic.co/docs/deploy-manage/manage-spaces-fleet contains instructions on how to enable Fleet space awareness for deployments that were created before 9.1.0. The sentence
> Previous data is preserved in snapshots in case you need to roll back.

is misleading for two reasons:
1. The migration path does not create ES snapshots
2. Rollback is not officially supported

How it works is Fleet copies non space-aware space objects with legacy type (e.g. `ingest-agent-policies`) into the new space-aware equivalents (e.g. `fleet-agent-policies`), but legacy SO are not synced from that point onwards, making rollback both difficult and risky.

This PR fixes the wording.

## Generative AI disclosure
<!--
To help us ensure compliance with the Elastic open source and documentation guidelines, please answer the following:
-->
1. Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [ ] Yes  
- [x] No  
<!--
4. If you answered "Yes" to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).

Tool(s) and model(s) used:
-->

